### PR TITLE
feat: add aggregate signatures to transaction inputs and outputs

### DIFF
--- a/src/RFC-0201_TariScript.md
+++ b/src/RFC-0201_TariScript.md
@@ -406,9 +406,6 @@ Note that:
   metadata signature will be invalidated.
 - We provide the complete script on the output.
 
-_(See [Multi-party transaction output](#multi-party-transaction-output) for a discussion ot the multi-party version of a 
-transaction output.)_
-
 ### Transaction input changes
 
 The current definition of an input is
@@ -486,9 +483,6 @@ but obtained by executing the script with the provided input data. Because this 
 private key \\(k\_{Si}\\), it ensures that only the owner can provide the input data \\(\input_i\\) to the 
 TransactionInput. 
 
-_(See [Multi-party transaction input](#multi-party-transaction-input) for a discussion ot the multi-party version of a
-transaction output.)_
-
 ### Script Offset
 
 For every transaction an accompanying [script offset] \\( \so \\) needs to be provided. This is there to prove that every  
@@ -502,9 +496,6 @@ $$
 \end{aligned}
 \tag{16}
 $$
-
-_(See [Multi-party script offset](#multi-party-script-offset) for a discussion ot the multi-party version of the
-script offset.)_
 
 Verification of (16) will entail:
 

--- a/src/RFC-0201_TariScript.md
+++ b/src/RFC-0201_TariScript.md
@@ -266,13 +266,16 @@ $$
 
 The [metadata signature] is an aggregated Commitment Signature signed with a combination of the homomorphic 
 commitment private values \\( (v\_i \\, , \\, k\_i )\\), with the spending key only known by the receiver, and sender 
-offset private key \\(k\_{Oi}\\), only known by the sender. The signature challenge consists of all the transaction 
-output metadata, effectively forming a contract between the sender and receiver, making all those values non-malleable 
-and ensuring only the sender and receiver can enter into this contract. (See [Signature on Commitment values] by F. 
-Zhang et. al. and [Commitment Signature] by G. Yu. for details about this signature.)
+offset private key \\(k\_{Oi}\\), only known by the sender. (_Note that \\( k\_{Oi} \\) should be treated as a nonce._) 
+The signature challenge consists of all the transaction output metadata, effectively forming a contract between the 
+sender and receiver, making all those values non-malleable and ensuring only the sender and receiver can enter into 
+this contract. (See [Signature on Commitment values] by F. Zhang et. al. and [Commitment Signature] by G. Yu. for 
+details about this signature.)
 
 Note that the [Commitment Signature] is an aggregated signature between the sender and receiver, which is 
 constructed as follows.
+
+<u>Sender:</u>
 
 The sender portion of the public nonce is:
 
@@ -284,7 +287,11 @@ R_{MSi} &= r_{MSi_a} \cdot H + r_{MSi_b} \cdot G
 $$
 
 The sender sends \\(K\_{Oi}, R_{MSi}\\) to the receiver, who now has all the required information to calculate the final 
-challenge. The receiver portion of the public nonce is:
+challenge. 
+
+<u>Receiver:</u>
+
+The receiver portion of the public nonce is:
 
 $$
 \begin{aligned}
@@ -313,7 +320,11 @@ b_{MRi} &= r_{MRi_b} + e(k_i)
 $$
 
 The receiver sends \\( s_{MRi} = (a_{MRi}, b_{MRi}, R_{MRi} ) \\) along with the other partial transaction information to 
-the sender. The sender starts by calculating the final challenge (16) and then completes their part of the aggregated 
+the sender.
+
+<u>Sender:</u>
+
+The sender starts by calculating the final challenge (16) and then completes their part of the aggregated 
 Commitment Signature.
 
 $$
@@ -338,6 +349,8 @@ s_{Mi} &= (a_{Mi}, b_{Mi}, R_{Mi} ) \\\\
 \tag{7}
 $$
 
+<u>Verifier:</u>
+
 This is verified by the following:
 
 $$
@@ -346,6 +359,8 @@ a_{Mi} \cdot H + b_{Mi} \cdot G = R_{Mi} + (C_i + K_{Oi})e
 \end{aligned}
 \tag{8}
 $$
+
+**Prevent leaking sender nonces**
 
 However, when evaluating (8) it is evident that the receiver can calculate \\( r_{MSi_a} \\) as follows:
 
@@ -441,6 +456,8 @@ s_{Si} = (a_{Si}, b_{Si}, R_{Si} )
 \tag{13}
 $$
 
+<u>Sender:</u>
+
 Where
 
 $$
@@ -452,6 +469,8 @@ e &= \hash{ R_{Si} \cat \alpha_i \cat \input_i \cat K_{Si} \cat C_i} \\\\
 \end{aligned}
 \tag{14}
 $$
+
+<u>Verifier:</u>
 
 This is verified by the following:
 
@@ -913,11 +932,26 @@ When spending the multi-party input:
 
 ### Multi-party considerations
 
-Multi-party in this context refers to `n-of-n` parties creating a transaction output and `m-of-n` parties spending a 
-transaction input. We have three options to do this:
-- using the [m-of-n script] TariScript;
-- sharding the spending key;
+Multi-party in this context refers to `n-of-n` parties creating a single combined transaction output and `m-of-n` 
+parties spending a single combined transaction input. We have some options to do this:
+- using the [m-of-n script] TariScript without sharding the spending key;
 - combination of the [m-of-n script] TariScript and sharding the spending key;
+- sharding the spending key combined with the [NoOp script] TariScript;
+
+If the spending key \\( k_i \\) is sharded for any of these options the commitment definition changes to:
+
+$$
+\begin{aligned}
+C_i = v_i \cdot H  + \sum_\psi (k_{i\_\psi} \cdot G) \\; \\; \\; \text{ for each receiver party } \psi
+\end{aligned}
+\tag{1b}
+$$
+
+The sender-receiver interaction can be categorized as follows, however, for simplicity we can assume that each
+multi-party side will have a single party acting as the dealer:
+- Multi-party senders can create the single output and send it to a single receiver.
+- A single sender can create the single output and send it to multi-party receivers.
+- Multi-party senders can create the single output and send it to multi-party receivers.
 
 The multi-party impact on the transaction output, transaction input and script offset is discussed below.
 
@@ -926,10 +960,12 @@ The multi-party impact on the transaction output, transaction input and script o
 If multiple senders and receiver parties need to create an aggregate `metadata_signature` for a single multi-party
 transaction output, there are two secrets that warrant our attention; the script offset private key \\( k\_{Oi} \\)
 controlled by the senders and the spending key \\( k_i \\) controlled by the receivers. Depending on the protocol
-design, one or both secrets may be sharded amongst all parties. The script offset private key \\( k\_{Oi} \\) will
-always be sharded amongst all parties, but the spending key \\( k_i \\) may or may not be sharded.
+design, one or both secrets may be sharded amongst all parties. 
 
-The aggregate sender terms in (10) and (11) collected by the sender's dealer change to:
+<u>Sharding the script offset private key:</u>
+
+If the script offset private key \\( k\_{Oi} \\) is sharded, the aggregate sender terms in (10) and (11) collected by 
+the sender's dealer change to:
 
 $$
 \begin{aligned}
@@ -941,12 +977,14 @@ $$
 $$
 \begin{aligned}
 a_{MSi} &= 0 \\\\
-b_{MSi} &= \sum_\omega (r_{{MSi_b}\_\omega} + e(k\_{{Oi}_\omega})) \\; \\; \\; \text{ for each sender party } \omega
+b_{MSi} &= \sum_\omega (r_{{MSi_b}\_\omega} + e \cdot k\_{{Oi}_\omega}) \\; \\; \\; \text{ for each sender party } \omega
 \end{aligned}
 \tag{11b}
 $$
 
-If the spending key \\( k_i \\) is also sharded, the receiver's dealer needs to collect shards and combine them. The
+<u>Sharding the spending key:</u>
+
+If the spending key \\( k_i \\) is sharded, the receiver's dealer needs to collect shards and combine them. The
 aggregate receiver terms in (3) and (5) collected by the receiver's dealer change to:
 
 $$
@@ -968,8 +1006,11 @@ $$
 
 If multiple senders need to create an aggregate `script_signature` for a multi-party transaction input, again, there are
 two secrets that warrant our attention, the script private key \\( k_{Si} \\) and the spending key \\( k_i \\).
-Depending on the protocol design, one or both secrets may be sharded amongst all parties. The script private key
-\\( k_{Si} \\) will always be sharded amongst all parties, but the spending key \\( k_i \\) may or may not be shared.
+Depending on the protocol design, one or both secrets may be sharded amongst all parties, with some limitations:
+- Sharding the script private key will always be applicable for an [m-of-n script] TariScript.
+- Sharding the script private key will never be applicable for a [NoOp script] TariScript.
+
+<u>Sharding only the script private key:</u>
 
 If only the script private key \\( k_{Si} \\) will be sharded the aggregate terms in (14) collected by the sender's 
 dealer change to:
@@ -983,6 +1024,8 @@ e &= \hash{ R_{Si} \cat \alpha_i \cat \input_i \cat K_{Si} \cat C_i} \\\\
 \end{aligned}
 \tag{14b}
 $$
+
+<u>Sharding the script private key and the spending key:</u>
 
 If both the script private key \\( k_{Si} \\) and the spending key \\( k_i \\) will be sharded the aggregate terms
 in (14) collected by the sender's dealer change to:
@@ -1005,17 +1048,53 @@ done with Pedersen Verifiable Secret Sharing (PVSS), similar to
 The dealer will reconstruct the \\( k_{i\_j} \\) shards of the missing parties and add them to their shard before
 combining.
 
-#### Multi-party script offset
+<u>Sharding only the spending key:</u>
 
-For multiple senders, aggregate terms are collected by the sender's dealer and (16) become:
+If only the spending key \\( k_i \\) will be sharded the aggregate terms in (14) collected by the sender's dealer 
+change to:
 
 $$
 \begin{aligned}
-\so = \sum_\omega \so_\omega = \sum_\omega \left( \sum_j\mathrm{k_{Sj}} - \sum_i\mathrm{k_{Oi}} \right) \_\omega \\; \text{for each input}, j,\\, \text{and each output}, i \\; \text{ for each sender party } \omega
+R_{Si} &= r_{Si_a} \cdot H + \sum_\omega ( r_{{Si_b}\_\omega} \cdot G ) \\; \\; \\; \text{ for each sender party } \omega \\\\
+a_{Si}  &= r_{Si_a} +  e(v_{i}) \\\\
+b_{Si} &= \sum_\omega ( r_{{Si_b}\_\omega} + e \cdot  k_{i\_\omega} ) + e \cdot k_{Si} \\; \\; \\; \text{ for each sender party } \omega \\\\
+e &= \hash{ R_{Si} \cat \alpha_i \cat \input_i \cat K_{Si} \cat C_i} \\\\
+\end{aligned}
+\tag{14d}
+$$
+
+
+#### Multi-party script offset
+
+For multiple senders, aggregate terms are collected by the sender's dealer and (16) changes according to which of the
+secrets have been sharded:
+
+<u>Sharding only the script private key:</u>
+
+$$
+\begin{aligned}
+\so = \sum_\omega \left( \sum_j\mathrm{k_{Sj}} \right) \_\omega - \sum_i\mathrm{k_{Oi}} \\; \\; \text{for each input}, j,\\, \text{and each output}, i \\; \text{ for each sender party } \omega
 \end{aligned}
 \tag{16b}
 $$
 
+<u>Sharding only the script offset private key:</u>
+
+$$
+\begin{aligned}
+\so = \sum_j\mathrm{k_{Sj}} - \sum_\omega \left( \sum_i\mathrm{k_{Oi}} \right) \_\omega \\; \\; \text{for each input}, j,\\, \text{and each output}, i \\; \text{ for each sender party } \omega
+\end{aligned}
+\tag{16c}
+$$
+
+<u>Sharding the script private key and the script offset private key:</u>
+
+$$
+\begin{aligned}
+\so = \sum_\omega \left( \sum_j\mathrm{k_{Sj}} - \sum_i\mathrm{k_{Oi}} \right) \_\omega \\; \\; \text{for each input}, j,\\, \text{and each output}, i \\; \text{ for each sender party } \omega
+\end{aligned}
+\tag{16d}
+$$
 
 ### Preventing Cut-through with the Script Offset
 
@@ -1136,21 +1215,20 @@ script.
 
 Where possible, the "usual" notation is used to denote terms commonly found in cryptocurrency literature. Lower case 
 characters are used as private keys, while uppercase characters are used as public keys. New terms introduced by 
-TariScript are assigned greek lowercase letters in most cases. The capital letter subscripts, _R_ and _S_ refer to a 
-UTXO _receiver_ and _script_ respectively.
+TariScript are assigned greek lowercase letters in most cases. 
 
-| Symbol                    | Definition                                                                                                                         |
-|---------------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| \\( \script_i \\)         | An output script for output _i_, serialised to binary.                                                                             |
-| \\( F_i \\)               | Output features for UTXO _i_.                                                                                                      |
-| \\( f_t \\)               | Transaction fee for transaction _t_.                                                                                               |
-| \\( (k_{Oi}\, K_{Oi}) \\) | The private - public keypair for the UTXO sender offset key.                                                                       |
-| \\( (k_{Si}\, K_{Si}) \\) | The private - public keypair for the script key. The script, \\( \script_i \\) resolves to \\( K_S \\) after completing execution. |
-| \\( \so_t \\)             | The script offset for transaction _t_, see (16)                                                                                    |
-| \\( C_i \\)               | A Pedersen commitment to a value \\( v_i \\), see (1)                                                                              |
-| \\( \input_i \\)          | The serialised input for script \\( \script_i \\)                                                                                  |
-| \\( s_{Si} \\)            | A script signature for output \\( i \\), see (13 - 15)                                                                             |
-| \\( s_{Mi} \\)            | A metadata signature for output \\( i \\), see (2 - 12)                                                                            |
+| Symbol                    | Definition                                                                                                                                                 |
+|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| \\( \script_i \\)         | An output script for output _i_, serialised to binary.                                                                                                     |
+| \\( F_i \\)               | Output features for UTXO _i_.                                                                                                                              |
+| \\( f_t \\)               | Transaction fee for transaction _t_.                                                                                                                       |
+| \\( (k_{Oi}\, K_{Oi}) \\) | The private - public keypair for the UTXO sender offset key. Note that \\( k_{Oi} \\) should be treated as a nonce.                                        |
+| \\( (k_{Si}\, K_{Si}) \\) | The private - public keypair for the script key. The script, \\( \script_i \\) resolves to \\( K_S \\) after completing execution.                         |
+| \\( \so_t \\)             | The script offset for transaction _t_, see (16)                                                                                                            |
+| \\( C_i \\)               | A Pedersen commitment to a value \\( v_i \\), see (1)                                                                                                      |
+| \\( \input_i \\)          | The serialised input for script \\( \script_i \\)                                                                                                          |
+| \\( s_{Si} \\)            | A script signature for output \\( i \\), see (13 - 15)                                                                                                     |
+| \\( s_{Mi} \\)            | A metadata signature for output \\( i \\), see (2 - 12) - the capital letter subscripts, _R_ and _S_ refer to a UTXO _receiver_ and _sender_ respectively. |
 
 ## Extensions
 
@@ -1180,6 +1258,19 @@ validation.
 
 Thanks to David Burkett for proposing a method to prevent cut-through and willingness to discuss ideas.
 
+# Change Log
+
+| Date        | Change                                       | Author                        |
+|:------------|:---------------------------------------------|:------------------------------|
+| 17 Aug 2020 | First draft                                  | CjS77                         |
+| 11 Feb 2021 | Major update                                 | CjS77, SWvheerden, philipr-za |
+| 26 Apr 2021 | Clarify one sided payment rules              | SWvheerden                    |
+| 31 May 2021 | Including full script in transaction outputs | philipr-za                    |
+| 04 Jun 2021 | Remove beta range-proof calculation          | SWvheerden                    |
+| 22 Jun 2021 | Change script_signature type to ComSig       | hansieodendaal                |
+| 30 Jun 2021 | Clarify Tari Script nomenclature             | hansieodendaal                |
+| 06 Oct 2022 | Minor improvemnts in legibility              | stringhandler                 |
+
 [data commitments]: https://phyro.github.io/grinvestigation/data_commitments.html
 [LIP-004]: https://github.com/DavidBurkett/lips/blob/master/lip-0004.mediawiki
 [Scriptless script]: https://tlu.tarilabs.com/cryptography/scriptless-scripts/introduction-to-scriptless-scripts.html
@@ -1197,4 +1288,5 @@ Thanks to David Burkett for proposing a method to prevent cut-through and willin
 [sender offset]: Glossary.md#sender-offset-keypair
 [script offset]: Glossary.md#script-offset
 [m-of-n script]: RFC-0202_TariScriptOpcodes.md#checkmultisigverifyaggregatepubkeym-n-public-keys-msg
+[NoOp script]: RFC-0202_TariScriptOpcodes.md#noop
 [Mimblewimble]: Glossary.md?#mimblewimble

--- a/src/RFC-0202_TariScriptOpcodes.md
+++ b/src/RFC-0202_TariScriptOpcodes.md
@@ -320,12 +320,12 @@ push 0.
 * Fails with `INVALID_INPUT` if the top stack element is not a PublicKey or Commitment
 * Fails with `INVALID_INPUT` if the second stack element is not a Signature
 
-##### CheckSigVerify(Msg),
+##### CheckSigVerify(Msg)
 
 Identical to [`CheckSig`](#checksigmsg), except that nothing is pushed to the stack if the signature is valid, and the
 operation fails with `VERIFY_FAILED` if the signature is invalid.
 
-##### CheckMultiSig(Msg)
+##### CheckMultiSig(m, n, public keys, Msg)
 
 Pop $m$ signatures from the stack. If $m$ signatures out of the provided $n$ public keys sign the 32-byte message,
 push 1 to the stack, otherwise push 0.
@@ -337,10 +337,17 @@ push 1 to the stack, otherwise push 0.
 * Fails with `STACK_UNDERFLOW` if the stack has fewer than $m$ items.
 * Fails with `INVALID_INPUT` if $m$ stack elements are not a `Signature`.
 
-##### CheckMultiSigVerify(Msg),
+##### CheckMultiSigVerify(m, n, public keys, Msg)
 
 Identical to [`CheckMultiSig`](#checkmultisigmsg), except that nothing is pushed to the stack if the signatures are valid, and the
 operation fails with `VERIFY_FAILED` if the signatures are invalid.
+
+
+
+##### CheckMultiSigVerifyAggregatePubKey(m, n, public keys, Msg)
+
+Pop m signatures from the stack. If m signatures out of the provided n public keys sign the 32-byte message,
+push the aggregate of the public keys to the stack, otherwise fails with VERIFY_FAILED.
 
 ##### ToRistrettoPoint,
 


### PR DESCRIPTION
Description
---
Added aggregate metadata and script signatures to the transaction output and input (RFC-0201) and multi-sig opcodes (RFC-0202).

Motivation and Context
---
This is handy for multiple parties (`m-of-n`) to create outputs and spend outputs. 

To create a multi-party output `n-of-n` receiver parties need to:
- agree on the `m-of-n` TariScript script out of band;
- create an aggregated receiver portion of the metadata signature if the spending key is sharded. 

To spend an `m-of-n` input, `m` parties need to agree on the `m-of-n` TariScript input out of band and create an aggregated script signature.

_**Main additions to RFC-0201 text is shown below**_

---
![image](https://user-images.githubusercontent.com/39146854/195515312-1c47523d-3f72-40d0-84b3-c23da1635119.png)

![image](https://user-images.githubusercontent.com/39146854/195294096-f793f42e-9361-4a0e-a354-6f9f857b4922.png)

![image](https://user-images.githubusercontent.com/39146854/195294117-eb7543ed-5846-4dd3-9291-a6ac8a71d230.png)

![image](https://user-images.githubusercontent.com/39146854/195294135-fc1ef62b-beb4-4e60-a1c8-2758d625e9b4.png)

---

How Has This Been Tested?
---
`mdbook serve` renders fine

