### PR TITLE
fix(rfc140): rename title for clarity

### DIFF
--- a/src/RFC-0140_Syncing_and_seeding.md
+++ b/src/RFC-0140_Syncing_and_seeding.md
@@ -1,6 +1,6 @@
 # RFC-0140/SyncAndSeeding
 
-## Syncing Strategies and Objectives
+## Synchronizing the Blockchain: Archival and Pruned Modes
 
 ![status: draft](theme/images/status-draft.svg)
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -10,7 +10,7 @@
     - [RFC-0121: Consensus encoding](RFC-0121_ConsensusEncoding.md)
   - [RFC-0131: Mining](RFC-0131_Mining.md)
   - [RFC-0132: Merge Mining Monero](RFC-0132_Merge_Mining_Monero.md)
-  - [RFC-0140: Sync and Seeding](RFC-0140_Syncing_and_seeding.md)
+  - [RFC-0140: Synchronizing the Blockchain: Archival and Pruned modes](RFC-0140_Syncing_and_seeding.md)
   - [RFC-0150: Wallets](RFC-0150_Wallets.md)
   - [RFC-0152: Emoji ID](RFC-0152_EmojiId.md)
   - [RFC-0153: Staged Wallet Security](RFC-0153_StagedWalletSecurity.md)


### PR DESCRIPTION
Rename the title of this RFC so that it is easier to find pruned mode details.

There isn't a dedicated "pruned mode" RFC, and in some places we want to reference it. I had to find this by using the search, so this is an attempt to make it easier to find by the Summary tree