### PR TITLE
fix(htlc stabilising): update htlc rfcs

### DIFF
--- a/src/RFC-0202_TariScriptOpcodes.md
+++ b/src/RFC-0202_TariScriptOpcodes.md
@@ -466,7 +466,7 @@ Is `PKH` equal to the hash of Bob's public key?
 
 The script has completed without errors, and Bob's public key remains on the stack.
 
-###  Time-locked contract
+###  Multiparty Time-locked contract
 
 Alice sends some Tari to Bob. If he doesn't spend it within a certain timeframe (up till block 4000), then she is also
 able to spend it back to herself.

--- a/src/RFC-0230_HTLC.md
+++ b/src/RFC-0230_HTLC.md
@@ -2,7 +2,7 @@
 
 ## Time-related Transactions
 
-![status: draft](theme/images/status-draft.svg)
+![status: stable](theme/images/status-stable.svg)
 
 **Maintainer(s)**: [S W van Heerden](https://github.com/SWvheerden) and [Philip Robinson](https://github.com/philipr-za)
 
@@ -115,7 +115,10 @@ ENDIF
 
 A more detailed analysis of the execution of this kind of script can be found at [Time-locked Contact](RFC-0202_TariScriptOpcodes.md#time-locked-contract)
 
-
+| Date        | Change        | Author     |
+|:------------|:--------------|:-----------|
+| 01 Feb 2019 | First draft   | SWvheerden |
+| 31 Oct 2022 | Stable update | brianp     |
 
 [HTLC]: Glossary.md#hashed-time-locked-contract
 [Mempool]: Glossary.md#mempool


### PR DESCRIPTION
Description
---
Originally I deprecated this RFC in favour of moving the content into the TariScript opcodes examples section. The two examples are similar but hidden in the details of the opcodes example is that it's a multiparty transaction where the one in the 0230 example is not. So I've left the RFC separated as it more closely matches the implementation and atomic swap use case.

Updated the naming in the opcode rfc just for disambiguation purposes.

Motivation and Context
---
Stabilising 

How Has This Been Tested?
---

