### PR TITLE
docs: rfc-0250 covenants stabilized

### DIFF
--- a/src/RFC-0250_Covenants.md
+++ b/src/RFC-0250_Covenants.md
@@ -2,7 +2,7 @@
 
 ## Covenants
 
-![status: draft](theme/images/status-draft.svg)
+![status: stable](theme/images/status-stable.svg)
 
 **Maintainer(s)**: [Stanley Bondi](https://github.com/sdbondi)
 
@@ -10,7 +10,7 @@
 
 [The 3-Clause BSD Licence](https://opensource.org/licenses/BSD-3-Clause).
 
-Copyright 2021 The Tari Development Community
+Copyright 2022 The Tari Development Community
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 following conditions are met:
@@ -65,11 +65,11 @@ use-cases, such as
 ## Introduction
 
 The Tari protocol already provides programmable consensus, through [TariScript], that restricts whether a [UTXO]
-may be included as an input to a transaction (a.k.a spent). The scope of information [TariScript] is inherently limited,
+may be included as an input to a transaction (a.k.a spent). The scope of information within [TariScript] is inherently limited,
 by the [TariScript Opcodes] and the input data provided by a spender. Once the requirements of the script are met,
 a spender may generate [UTXO]s of their choosing, within the constraints of [MimbleWimble].
 
-This RFC aims to expand the capabilities of Tari protocol by adding _additional requirements_, called covenants
+This RFC expands the capabilities of Tari protocol by adding _additional requirements_, called covenants
 that allow the owner(s) of a [UTXO] to control the composition of a _subsequent_ transaction.
 
 Covenants are not a new idea and have been proposed and implemented in various forms by others.
@@ -94,7 +94,7 @@ outputs from other boxes as long as balance is maintained.
 This results in an interesting dilemma: how do we allow rules that dictate how future outputs look only armed with
 the knowledge that the rule must apply to one or more outputs?
 
-In this RFC, we propose a covenant scheme that allows the [UTXO] originator to express a _filter_ that must be
+In this RFC, we datail a covenant scheme that allows the [UTXO] originator to express a _filter_ that must be
 satisfied for a subsequent spending transaction to be considered valid.
 
 ## Assumptions
@@ -438,6 +438,13 @@ xor(
 - `filter_script_match(<pattern>)`
 - `filter_covenant_match(<pattern>)`
 
+# Change Log
+
+| Date        | Change        | Author |
+|:------------|:--------------|:-------|
+| 17 Oct 2021 | First draft   | sbondi |
+| 08 Oct 2022 | Stable update | brianp |
+
 [commitment]: ./Glossary.md#commitment
 [tari codebase]: https://github.com/tari-project/tari
 [handshake]: https://handshake.org/files/handshake.txt
@@ -450,3 +457,4 @@ xor(
 [vaults]: https://hackingdistributed.com/2016/02/26/how-to-implement-secure-bitcoin-vaults/
 [tariscript]: ./Glossary.md#tariscript
 [mimblewimble]: ./Glossary.md#mimblewimble
+[TariScript Opcodes]: ./RFC-0202_TariScriptOpcodes.md

--- a/src/RFC-0250_Covenants.md
+++ b/src/RFC-0250_Covenants.md
@@ -160,23 +160,26 @@ enum CovenantArg {
     // data size: 32 bytes
     Commitment(PedersonCommitment),
     // byte code: 0x04
-    // data size: 64 bytes
-    Signature(Signature),
+    // data size: variable
+    TariScript(TariScript),
     // byte code: 0x05
-    // data size: variable
-    Script(TariScript),
-    // byte code: 0x06
-    // data size: variable
+    // data size: <= 4096 bytes
     Covenant(Covenant),
-    // byte code: 0x07
+    // byte cide: 0x06
     // data size: variable
-    VarInt(VarInt),
-    // byte code: 0x08
-    // data size: 1 byte
-    Field(FieldKey),
-    // byte code: 0x09
+    Uint(u64),
+    // byte cide: 0x07
     // data size: variable
-    Fields(Vec<FieldKey>),
+    OutputField(OutputField),
+    // byte cide: 0x08
+    // data size: variable
+    OutputFields(OutputFields),
+    // byte cide: 0x09
+    // data size: variable
+    Bytes(Vec<u8>),
+    // byte cide: 0x0a
+    // data size: 1 bytes
+    OutputType(OutputType),
 }
 ```
 
@@ -185,18 +188,17 @@ enum CovenantArg {
 Fields from each output in the output set may be brought into a covenant filter.
 The available fields are defined as follows:
 
-| Tag Name                            | Byte Code | Returns                           |
-| ----------------------------------- | --------- | --------------------------------- |
-| `field::commitment`                 | 0x00      | output.commitment                 |
-| `field::script`                     | 0x01      | output.script                     |
-| `field::sender_offset_public_key`   | 0x02      | output.sender_offset_public_key   |
-| `field::covenant`                   | 0x03      | output.covenant                   |
-| `field::features`                   | 0x04      | output.features                   |
-| `field::features_flags`             | 0x05      | output.features.flags             |
-| `field::features_maturity`          | 0x06      | output.features.maturity          |
-| `field::features_unique_id`         | 0x07      | output.features.unique_id         |
-| `field::features_parent_public_key` | 0x08      | output.features.parent_public_key |
-| `field::features_metadata`          | 0x09      | output.features.metadata          |
+| Tag Name                             | Byte Code | Returns                            |
+|--------------------------------------|-----------|------------------------------------|
+| `field::commitment`                  | 0x00      | output.commitment                  |
+| `field::script`                      | 0x01      | output.script                      |
+| `field::sender_offset_public_key`    | 0x02      | output.sender_offset_public_key    |
+| `field::covenant`                    | 0x03      | output.covenant                    |
+| `field::features`                    | 0x04      | output.features                    |
+| `field::features_output_type`        | 0x05      | output.features.output_type        |
+| `field::features_maturity`           | 0x06      | output.features.maturity           |
+| `field::features_metadata`           | 0x07      | output.features.metadata           |
+| `field::features_sidechain_features` | 0x08      | output.features.sidechain_features |
 
 Each field tag returns a consensus encoded byte representation of the value contained in the field.
 How those bytes are interpreted depends on the covenant. For instance, `filter_fields_hashed_eq` will

--- a/src/RFC-0250_Covenants.md
+++ b/src/RFC-0250_Covenants.md
@@ -94,7 +94,7 @@ outputs from other boxes as long as balance is maintained.
 This results in an interesting dilemma: how do we allow rules that dictate how future outputs look only armed with
 the knowledge that the rule must apply to one or more outputs?
 
-In this RFC, we datail a covenant scheme that allows the [UTXO] originator to express a _filter_ that must be
+In this RFC, we detail a covenant scheme that allows the [UTXO] originator to express a _filter_ that must be
 satisfied for a subsequent spending transaction to be considered valid.
 
 ## Assumptions


### PR DESCRIPTION
Description
---
Updates include:

- Correcting opcodes on CovenentArg, Output field tags, operations, and filters
- Removing the NFT example referencing a deprecated RFC
- Updated naming and examples of removed/renamed filters and operations

Motivation and Context
---
Prep'n for wen moon.

How Has This Been Tested?
---
Compared it to the code a bit.
