### PR TITLE
docs: add a glossary entry for commitment and public key signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-# RFC
+# RFCs
 
-RFC documents for the Tari protocol
+This repository contains requests for comment (RFCs) for Tari protocols.
 
-These documents are in the form of an mdbook. The rendered version of these docs can be found at https://rfc.tari.com
+These documents are in the form of an [`mdbook`](https://rust-lang.github.io/mdBook/). The rendered version of the main branch of the repository is deployed to https://rfc.tari.com.
 
-## View local rendered version
+## Building
 
-- run `cargo install mdbook`
+You can build and serve the RFCs locally while working on them, and navigate the resulting `mdbook` site as if it were deployed.
 
-- in the `/RFC` folder run `mdbook serve`
+To do so:
+- Navigate to the repository directory in a terminal
+- Install the `mdbook` tool: `cargo install mdbook`
+- Serve the site: `mdbook serve`
+- View the rendered versions in a browser using the link provided in your terminal: `http://localhost:3000`
 
-- in a browser navigate to [`localhost:3000`](http://localhost:3000)
+The server will detect changes you make to files and rebuild automatically, but you will need to manually refresh pages in your browser to see the updates.

--- a/src/Glossary.md
+++ b/src/Glossary.md
@@ -148,6 +148,16 @@ A commitment is a cryptographic primitive that allows one to commit to a chosen 
 others, with the ability to reveal the committed value later. Commitments are designed so that one cannot change the
 value or statement after they have committed to it.
 
+## Commitment and Public Key Signature
+
+[commitment and public key signature]: #commitment-and-public-key-signature
+
+A mathematical assertion of knowledge of the opening of a [commitment] and the private key corresponding to a public key, and
+which is bound to a message to produce a signature. In the context of Tari protocols, it is used to construct a
+[metadata signature] and script signature for transactions.
+
+Specifically, it is a Schnorr-type conjunction proof that uses the Fiat-Shamir technique for message binding.
+
 ## Communication Node
 
 [communication node]: #communication-node "A communication node that is responsible for maintaining the Tari
@@ -256,7 +266,7 @@ verified transactions from the mempool to build up transaction [block]s.
 
 [metadata signature]: #metadata-signature
 
-The metadata signature is an aggregated Commitment Signature ("ComSig") signature, attached to a transaction output and
+The metadata signature is a [commitment and public key signature], attached to a transaction output and
 signed with a combination of the homomorphic commitment private values \\( (v\_i \\, , \\, k\_i )\\), the spending key
 known only to the receiver, and sender offset private key \\(k\_{Oi}\\) known only to the sender. This prevents
 malleability of the UTXO metadata.
@@ -398,7 +408,7 @@ The script offset provides a proof that every script public key \\( K\_{Si} \\) 
 [sender offset key]: #sender-offset-keypair
 
 The sender offset private - public keypair, (\\( k\_{Oi} \\),\\( K\_{Oi} \\)), is used by the sender of an output to
-lock all its metadata by virtue of a [sender metadata signature].
+lock all its metadata by virtue of a [metadata signature].
 
 ## Spending Key
 

--- a/src/RFC-0201_TariScript.md
+++ b/src/RFC-0201_TariScript.md
@@ -263,13 +263,12 @@ C_i = v_i \cdot H  + k_i \cdot G
 \tag{1}
 $$
 
-The [metadata signature] is a combined commitment and public key signature signed with the private values of the commitment \\( (v\_i \\, , \\, k\_i )\\)
+The [metadata signature] is a [commitment and public key signature] signed with the private values of the commitment \\( (v\_i \\, , \\, k\_i )\\)
 known by the receiver, and sender 
 offset private key \\(k\_{Oi}\\), only known by the sender.
 The signature challenge consists of all the transaction output metadata, effectively forming a contract between the 
 sender and receiver, making all those values non-malleable and ensuring only the sender and receiver can enter into 
-this contract. (See [this PR](https://github.com/tari-project/tari-crypto/pull/131) for more details on this representation
-proof.)
+this contract.
 
 Note that:
 - The UTXO has a positive value \\( v \\) like any normal UTXO.
@@ -314,7 +313,7 @@ pub struct TransactionInput {
 }
 ```
 
-The `script_signature` is signed with a [commitment and public key representation proof](https://github.com/tari-project/tari-crypto/pull/131) using a combination of the output commitment 
+The `script_signature` is a [commitment and public key signature] using a combination of the output commitment 
 private values \\( (v\_i \\, , \\, k\_i )\\) and [script private key] \\(k\_{Si}\\) to prove ownership thereof. It 
 signs the script, the script input, [script public key] and the commitment.
 
@@ -597,18 +596,17 @@ Thanks to David Burkett for proposing a method to prevent cut-through and willin
 [data commitments]: https://phyro.github.io/grinvestigation/data_commitments.html
 [LIP-004]: https://github.com/DavidBurkett/lips/blob/master/lip-0004.mediawiki
 [Scriptless script]: https://tlu.tarilabs.com/cryptography/scriptless-scripts/introduction-to-scriptless-scripts.html
-[Signature on Commitment values]: https://documents.uow.edu.au/~wsusilo/ZCMS_IJNS08.pdf
-[Commitment Signature]: https://eprint.iacr.org/2020/061.pdf
 [cut-through]: https://tlu.tarilabs.com/protocols/grin-protocol-overview/MainReport.html#cut-through
 [standard Mimblewimble protocol]: https://tlu.tarilabs.com/protocols/mimblewimble-1/MainReport.html
 [bitcoin transaction]: https://en.bitcoin.it/wiki/Transaction
 
 [TariScript]: Glossary.md#tariscript
 [metadata signature]: Glossary.md#metadata-signature
+[commitment and public key signature]: Glossary.md#commitment-and-public-key-signature
 [script private key]: Glossary.md#script-keypair
 [script public key]: Glossary.md#script-keypair
 [sender offset]: Glossary.md#sender-offset-keypair
 [script offset]: Glossary.md#script-offset
 [m-of-n script]: RFC-0202_TariScriptOpcodes.md#checkmultisigverifyaggregatepubkeym-n-public-keys-msg
 [NoOp script]: RFC-0202_TariScriptOpcodes.md#noop
-[Mimblewimble]: Glossary.md?#mimblewimble
+[Mimblewimble]: Glossary.md#mimblewimble


### PR DESCRIPTION
Description
---
Updates the [glossary](https://rfc.tari.com/Glossary.html) to add an entry for commitment and public key signatures, and references this entry in [RFC-0201](https://rfc.tari.com/RFC-0201_TariScript.html). Also updates the [`readme`](https://github.com/tari-project/rfcs/blob/main/README.md) for improved clarity on building and serving the `mdbook` locally.

Motivation and Context
---
A [recent PR](https://github.com/tari-project/rfcs/pull/54) updates RFC-0201 to reference commitment and public key signatures via links to [an implementation PR](https://github.com/tari-project/tari-crypto/pull/131). This work moves the description of these signatures to the glossary.

Also updates the `readme` to provide better clarity and specificity on how to build and serve the RFC `mdbook` locally.

How Has This Been Tested?
---
Built locally, with manual testing of links.
