### PR TITLE
docs: update emoji ID RFC-0152 algorithms

### DIFF
--- a/src/RFC-0152_EmojiId.md
+++ b/src/RFC-0152_EmojiId.md
@@ -73,9 +73,9 @@ For Tari, we propose encoding values, the node ID in particular and masking the 
 * Should be be able to detect if the address used belongs to the correct network. 
 ## The specification
 
-### The emoji character map
+### Emoji map
 An emoji alphabet of 256 characters is selected. Each emoji is assigned a unique index from 0 to 255 inclusive. The
-list of selected emojis are:
+list of selected emojis is:
 
 | | | | | | | | | | | | | | | | |
 |--|--|--|--|--|--|--|--|--|--|--|--|--|--|--|--|
@@ -98,71 +98,48 @@ list of selected emojis are:
 
 
 The emoji have been selected such that:
-* Similar-looking emoji are excluded from the map. e.g. Neither 😁 or 😄 should be included. Similarly, the Irish and
+* Similar-looking emoji are excluded from the map. For example, neither 😁 or 😄 should be included. Similarly, the Irish and
   Côte d'Ivoire flags look very similar, and both should be excluded.
-* Modified emoji (skin tones, gender modifiers) are excluded. Only the "base" emoji is considered.
+* Modified emoji (skin tones, gender modifiers) are excluded. Only the "base" emoji are considered.
+
+The selection of an alphabet with 256 symbols means there is a direct mapping between bytes and emoji.
 
 ### Encoding
 
-The selection of an alphabet with 256 symbols means there is a direct mapping between bytes and emoji. For each byte
-in the input data to be encoded, map the byte to the corresponding emoji using the emoji map. The resulting
-concatenation of emoji characters is the emoji string.
+ The emoji ID is calculated from a node public key `B` (serialized as 32 bytes) and a network identifier `N` (serialized as 8 bits) as follows:
 
-### Emoji ID definition
+* Use the [DammSum](https://github.com/cypherstack/dammsum) algorithm with `k = 8` and `m = 32` to compute an 8-bit checksum `C` using `B` as input.
+* Compute the masked checksum `C' = C XOR N`.
+* Encode `B` into an emoji string using the emoji map.
+* Encode `C'` into an emoji character using the emoji map.
+* Concatenate `B` and `C'` as the emoji ID.
 
-The emoji ID is a string of 33 symbols from the emoji alphabet. It uses this bitmap:
-
-```text
-+-----------------------------+--------------------------+
-|  Node public key (256 bits) | MaskedChecksum (8 bits)  |
-+-----------------------------+--------------------------+
-```
-
- The emoji ID is calculated from a node public key serialized as 32 bytes (`B`) as follows:
-
-* Use the [DammSum](https://github.com/cypherstack/dammsum) algorithm with `k = 8` and `m = 32` to compute an 8-bit
-masked checksum `'C` from `B` and network `N`.
-* Encode `B` into an emoji string.
-* Encode `'C` into an emoji string.
-* Concatenate `B` and `'C` as the emoji ID.
-
-#### Checksum effectiveness
-It is important to note that by masking the checksum we technically reduce the effectiveness of the checksum. These emoji ids wont
-however, be sent over the wire in raw form and its far more likely that they will just be copied thus it's important to verify the
-network of the wallet.
-The chance of this is:
-
-$$
-\begin{aligned}
-\text{mistake chance} =  n/256
-\end{aligned}
-\tag{1}
-$$
-Where \(n\) is the number of networks we have.
-
-### Checksum 
-
-For the MaskedChecksum we use the [DammSum](https://github.com/cypherstack/dammsum) algorithm with `k = 8` and `m = 32` to compute an 8-bit
-Checksum `C` from the public key `B`.
-To assert that the network that the public key comes from is the expected network, we mask the checksum with the network. 
-We calculate the MaskedChecksum `'C` as `C XOR N` where `N` is the network defined as 8-bits.
+The result is 33 emoji characters.
 
 ### Decoding
 
-One can extract the node public key from an emoji ID as follows:
+The node public key is obtained from an emoji ID and a network identifier `N` (serialized to 8 bits) as follows:
 
 * Assert that the emoji ID contains exactly 33 valid emoji characters from the emoji alphabet. If not, return an error.
 * Decode the emoji ID as an emoji string by mapping each emoji character to a byte value using the emoji map, producing
-33 bytes. Let `B` be the first 32 bytes and `'C` be the last byte.
-* Calculate `C` by `'C XOR N`.
-* Use the DammSum validation algorithm on `B` to assert that `C` is a valid checksum. If not, return an error.
+33 bytes. Let `B` be the first 32 bytes and `C'` be the last byte.
+* Compute the unmasked checksum `C = C' XOR N`.
+* Use the DammSum validation algorithm on `B` to assert that `C` is the correct checksum. If not, return an error.
 * Attempt to deserialize `B` as a public key. If this fails, return an error. If it succeeds, return the public key.
+
+#### Checksum effectiveness
+It is important to note that masking the checksum reduces its effectiveness.
+Namely, if an emoji ID is presented with a different network identifier, and if there is a transmission error, it is possible for the result to decode in a seemingly valid way with a valid checksum after unmasking.
+If both conditions occur randomly, the likelihood of this occurring is `n / 256` for `n` possible network identifiers.
+
+Since emoji ID will typically be copied digitally and therefore not particularly subject to transmission errors, so it seems unlikely for these conditions to coincide in practice.
 
 ## Change Log
 
-| Date         | Change                   | Author     |
-|:-------------|:-------------------------|:-----------|
-| 2022-11-10   | Initial stable           | SWvHeerden |
+| Date         | Change                   | Author        |
+|:-------------|:-------------------------|:--------------|
+| 2022-11-10   | Initial stable           | SWvHeerden    |
+| 2022-11-11   | Algorithm improvements   | AaronFeickert |
 
 [Communication Node]: Glossary.md#communication-node
 [Node ID]: Glossary.md#node-id


### PR DESCRIPTION
Description
---
Updates the emoji ID encoding and decoding algorithms in [RFC-0152](https://rfc.tari.com/RFC-0152_EmojiId.html) for clarity. Makes other miscellaneous changes for a smoother read.

Closes [issue 61](https://github.com/tari-project/rfcs/issues/61).

Motivation and Context
---
The recent [PR 48](https://github.com/tari-project/rfcs/pull/48) updates the emoji ID RFC-0152 to include checksum masking, which enables the use of network identifiers. This work updates the encoding and decoding algorithm descriptions for clarity. It also makes other assorted changes for grammar and readability.

How Has This Been Tested?
---
Built locally and examined to ensure nothing exploded.