### PR TITLE
chore: deprecate rfc-0100

### DIFF
--- a/src/RFC-0001_overview.md
+++ b/src/RFC-0001_overview.md
@@ -52,7 +52,6 @@ The aim of this proposal is to provide a very high-level perspective of the movi
 
 ## Related Requests for Comment
 
-- [RFC-0100: Base layer](RFC-0100_BaseLayer.md)
 - [RFC-0303: Digital asset network](RFC-0303_DanOverview.md)
 - [RFC-0131: Tari mining][RFC-131]
 - [RFC-0201: TariScript][RFC-201]

--- a/src/RFC-0110_BaseNodes.md
+++ b/src/RFC-0110_BaseNodes.md
@@ -53,7 +53,6 @@ their general approach for doing so.
 
 ## Related Requests for Comment
 
-* [RFC-0100: Base Layer](RFC-0100_BaseLayer.md)
 * [RFC-0140: SyncAndSeeding](RFC-0140_Syncing_and_seeding.md)
 
 $$

--- a/src/RFC-0120_Consensus.md
+++ b/src/RFC-0120_Consensus.md
@@ -52,7 +52,6 @@ The aim of this Request for Comment (RFC) is to describe the fields that a block
 
 ## Related Requests for Comment
 
-* [RFC-0100: Base Layer](RFC-0100_BaseLayer.md)
 * [RFC-0122: Burn outputs](RFC-0122_Burning.md)
 * [RFC-0130: Mining](RFCD-0130_Mining.md)
 * [RFC-0140: SyncAndSeeding](RFC-0140_Syncing_and_seeding.md)

--- a/src/RFC-0121_ConsensusEncoding.md
+++ b/src/RFC-0121_ConsensusEncoding.md
@@ -53,7 +53,6 @@ signature challenges used in base-layer consensus.
 
 ## Related Requests for Comment
 
-* [RFC-0100: Base Layer](RFC-0100_BaseLayer.md)
 * [RFC-0120: Consensus](RFC-0120_Consensus.md)
 
 ## Description

--- a/src/RFC-0122_Burning.md
+++ b/src/RFC-0122_Burning.md
@@ -52,7 +52,6 @@ The aim of this Request for Comment (RFC) is to describe the process of Burning 
 
 ## Related Requests for Comment
 
-* [RFC-0100: Base Layer](RFC-0100_BaseLayer.md)
 * [RFC-0120: Consensus](RFC-0120_Consensus.md)
 
 ## Description

--- a/src/RFC-0131_Mining.md
+++ b/src/RFC-0131_Mining.md
@@ -52,7 +52,6 @@ This document describes the final proof-of-work strategy proposal for Tari main 
 
 ## Related Requests for Comment
 
-* [RFC-0100: Base Layer](RFC-0100_BaseLayer.md)
 * [RFC-0110: Base Nodes](RFC-0110_BaseNodes.md)
 
 This RFC replaces and deprecates [RFC-0130: Mining](RFCD-0130_Mining.md)

--- a/src/RFC-0150_Wallets.md
+++ b/src/RFC-0150_Wallets.md
@@ -53,7 +53,7 @@ Tari [wallet] module. The module exposes the core wallet functionality on which 
 
 ## Related Requests for Comment
 
-* [RFC-0100: Base Layer](./RFC-0100_BaseLayer.md)
+* [RFC-0111: Base Node Architecture](./RFC-0111_BaseNodeArchitecture.md)
 
 This RFC is derived from a proposal first made in [this issue](https://github.com/tari-project/tari/issues/17).
 

--- a/src/RFC-0170_NetworkCommunicationProtocol.md
+++ b/src/RFC-0170_NetworkCommunicationProtocol.md
@@ -53,7 +53,7 @@ This document will introduce the Tari communication network and the communicatio
 
 ## Related RFCs
 
-* [RFC-0100: The Tari Base Layer](RFC-0100_BaseLayer.md)
+* [RFC-0111: Base Node Architecture](./RFC-0111_BaseNodeArchitecture.md)
 * [RFC-0303: DAN Overview](RFCD-0303_DanOverview.md)
 
 ## Description

--- a/src/RFC-0190_Mempool.md
+++ b/src/RFC-0190_Mempool.md
@@ -70,7 +70,7 @@ The Mempool is used for storing and managing unconfirmed [transactions][transact
 
 ## Related RFCs
 
-* [RFC-0100: The Tari Base Layer](RFC-0100_BaseLayer.md)
+* [RFC-0111: Base Node Architecture](./RFC-0111_BaseNodeArchitecture.md)
 
 ## Description
 

--- a/src/RFC-0303_DanOverview.md
+++ b/src/RFC-0303_DanOverview.md
@@ -53,7 +53,7 @@ Digital Assets Network (DAN).
 
 ## Related Requests for Comment
 
-* [RFC-0100: Base Layer](RFC-0100_BaseLayer.md)
+* [RFC-0111: Base Node Architecture](./RFC-0111_BaseNodeArchitecture.md)
 
 ## Description
 

--- a/src/RFC-0320_TurbineModel.md
+++ b/src/RFC-0320_TurbineModel.md
@@ -55,7 +55,7 @@ This RFC describes the motivation and mechanism of the Tari to Dan peg-in mechan
 
 ## Related Requests for Comment
 
-* [RFC-0100: Base Layer](RFC-0100_BaseLayer.md)
+* [RFC-0111: Base Node Architecture](./RFC-0111_BaseNodeArchitecture.md)
 * [RFC-0303: Digital Assets Network](RFC-0303_DanOverview.md)
 
 ## Description

--- a/src/RFC-8002_TransactionProtocol.md
+++ b/src/RFC-8002_TransactionProtocol.md
@@ -59,7 +59,7 @@ The goal is to describe a transaction protocol that:
 
 ## Related Requests for Comment
 
-* [RFC-0100: The Base Layer](RFC-0100_BaseLayer.md)
+* [RFC-0111: Base Node Architecture](./RFC-0111_BaseNodeArchitecture.md)
 
 ## Description
 

--- a/src/RFCD-0100_BaseLayer.md
+++ b/src/RFCD-0100_BaseLayer.md
@@ -2,7 +2,7 @@
 
 ## The Tari Base Layer
 
-![status: draft](theme/images/status-draft.svg)
+![status: deprecated](theme/images/status-deprecated.svg)
 
 **Maintainer(s)**: [Cayle Sharrock](https://github.com/CjS77)
 

--- a/src/RFCD-0130_Mining.md
+++ b/src/RFCD-0130_Mining.md
@@ -53,7 +53,7 @@ the primary functionality required of the Mining Server and Mining Worker.
 
 ## Related Requests for Comment
 
-* [RFC-0100: Base Layer](RFC-0100_BaseLayer.md)
+* [RFC-0111: Base Node Architecture](./RFC-0111_BaseNodeArchitecture.md)
 * [RFC-0110: Base Nodes](RFC-0110_BaseNodes.md)
 
 ## Description

--- a/src/RFCD-0300_DAN.md
+++ b/src/RFCD-0300_DAN.md
@@ -53,7 +53,6 @@ Digital Assets Network (DAN)
 
 ## Related Requests for Comment
 
-* [RFC-0100: Base Layer](RFC-0100_BaseLayer.md)
 * [RFC-0311: Digital Assets](RFC-0311_AssetTemplates.md)
 * [RFCD-0340: VN Consensus Overview](RFCD-0340_VNConsensusOverview.md)
 * [RFCD-0302: Validator Nodes](RFCDD-0302_ValidatorNodes.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -3,7 +3,7 @@
 [About the Tari RFC documents](about.md)
 
 - [RFC-0001: An overview of the Tari network](RFC-0001_overview.md)
-- [RFC-0100: The Tari Base Layer](RFC-0100_BaseLayer.md)
+- [The Tari Base Layer](base_layer.md)
   - [RFC-0110: Base nodes](RFC-0110_BaseNodes.md)
   - [RFC-0111: Base node architecture](RFC-0111_BaseNodeArchitecture.md)
   - [RFC-0120: Consensus rules](RFC-0120_Consensus.md)
@@ -47,6 +47,7 @@
 - [Deprecated RFCs](deprecated.md)
 
   - [RFC-0010: Tari code structure and organization](RFCD-0010_CodeStructure.md)
+  - [RFC-0100: Tari base layer](RFCD-0100_BaseLayer.md)
   - [RFC-0130: Mining](RFCD-0130_Mining.md)
   - [RFC-0300: The Digital Assets Network](RFCD-0300_DAN.md)
   - [RFC-0301: Namespace Registration](RFCD-0301_NamespaceRegistration.md)

--- a/src/base_layer.md
+++ b/src/base_layer.md
@@ -1,0 +1,25 @@
+# The Tari Base Layer
+
+The Tari Base Layer network comprises the following major pieces of software:
+
+- Base Layer full node implementation. The base layer full nodes are the consensus-critical pieces of software for the
+  Tari base layer and cryptocurrency. The base nodes validate and transmit transactions and blocks, and maintain
+  consensus about the longest valid proof-of-work blockchain.
+- Peer-to-peer communications network. All blockchain systems need a messaging mechanism. The Tari project has 
+  built its own peer-to-peer, end-to-end encrypted, DHT-based communications platform. It utilises the 
+  [Noise protocol](https://noiseprotocol.org/) and [Tor](https://www.torproject.org/)  to be highly secure and 
+  anonymous. Devices behind NATs and firewalls can use Tari's communication tools with ease.
+- Mining software. Miners perform proof-of-work to secure the base layer and compete to submit the
+  next valid block into the Tari blockchain. Tari uses two Proof of Work (PoW) algorithms, the first is 
+  [merge-mined](RFC-0132_Merge_Mining_Monero.md) 
+  with Monero, and the second is the native [SHA3x](RFC-0131_Mining.md) algorithm.
+  The Tari source provides three alternatives for Tari miners:
+  - A standalone miner for SHA3 mining
+  - A merge-mining proxy to be used with XMRig to merge mine Tari with Monero
+- Wallet software. Client software and Application Programming Interfaces (APIs) offering means to construct 
+  transactions, query nodes for information and maintain personal private keys. The reference design includes a 
+  wallet library, an C FFI interface, gRPC client and server code, a multi-platform console text-based wallet, and 
+  Aurora, the mobile wallet. 
+
+The RFCs in this section go into great describing how the various components work, and how they fit together to 
+provide the backbone of the Tari ecosystem.


### PR DESCRIPTION
This RFC was more introduction than any sort of technical specification. It makes more sense to turn it into the section introduction and deprecate the original.



