### PR TITLE
fix: rfc-0121 is deprecated

### DIFF
--- a/src/RFC-0120_Consensus.md
+++ b/src/RFC-0120_Consensus.md
@@ -355,11 +355,9 @@ final Merkle root. Input, output, and kernel ordering within a block is, therefo
 The block MUST be transmitted in canonical ordering. The advantage of this approach is that sorting does not need to be 
 done by the whole network, and verification of sorting is exceptionally cheap.
 
-Transaction outputs are sorted lexicographically by the byte representation of their Pedersen commitment i.e. ( \\(k \cdot G + v \cdot H\\) ).
-
-Transaction kernels are sorted lexicographically by the excess signature byte representation.
-Transaction inputs are sorted lexicographically by the [hash of the output](RFC-0121_ConsensusEncoding.md#transaction-output) that is spent by the input.
-Transaction kernels are sorted lexicographically by the excess signature byte representation.
+- Transaction outputs are sorted lexicographically by the byte representation of their Pedersen commitment i.e. ( \\(k \cdot G + v \cdot H\\) ).
+- Transaction kernels are sorted lexicographically by the excess signature byte representation.
+- Transaction inputs are sorted lexicographically by the hash of the output that is spent by the input.
 
 # Change Log
 

--- a/src/RFC-0131_Mining.md
+++ b/src/RFC-0131_Mining.md
@@ -119,8 +119,8 @@ Tari's proof-of-work mining algorithm is summarized below:
 
 ### Tari mining hash
 
-First, the block header is hashed with the 256-bit Blake2b hashing algorithm based using the approach described in
-[consensus encoding](RFC-0121_ConsensusEncoding). The fields are hashed in the order:
+First, the block header is hashed with the 256-bit Blake2b hashing algorithm using the approach described in
+consensus encoding. The fields are hashed in the order:
 - version
 - previous header hash
 - timestamp

--- a/src/RFCD-0121_ConsensusEncoding.md
+++ b/src/RFCD-0121_ConsensusEncoding.md
@@ -2,7 +2,7 @@
 
 ## Consensus Encoding
 
-![status: deprecated](theme/images/status-draft.svg)
+![status: deprecated](theme/images/status-deprecated.svg)
 
 **Maintainer(s)**: [Stanley Bondi](https://github.com/sdbondi)
 

--- a/src/RFCD-0121_ConsensusEncoding.md
+++ b/src/RFCD-0121_ConsensusEncoding.md
@@ -2,7 +2,7 @@
 
 ## Consensus Encoding
 
-![status: draft](theme/images/status-draft.svg)
+![status: deprecated](theme/images/status-draft.svg)
 
 **Maintainer(s)**: [Stanley Bondi](https://github.com/sdbondi)
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -7,7 +7,6 @@
   - [RFC-0110: Base nodes](RFC-0110_BaseNodes.md)
   - [RFC-0111: Base node architecture](RFC-0111_BaseNodeArchitecture.md)
   - [RFC-0120: Consensus rules](RFC-0120_Consensus.md)
-  - [RFC-0121: Consensus encoding](RFC-0121_ConsensusEncoding.md)
   - [RFC-0131: Mining](RFC-0131_Mining.md)
   - [RFC-0132: Merge Mining Monero](RFC-0132_Merge_Mining_Monero.md)
   - [RFC-0140: Synchronizing the Blockchain: Archival and Pruned modes](RFC-0140_Syncing_and_seeding.md)
@@ -47,7 +46,7 @@
 - [Deprecated RFCs](deprecated.md)
 
   - [RFC-0010: Tari code structure and organization](RFCD-0010_CodeStructure.md)
-  - [RFC-0100: Tari base layer](RFCD-0100_BaseLayer.md)
+  - [RFC-0121: Consensus encoding](RFCD-0121_ConsensusEncoding.md)
   - [RFC-0130: Mining](RFCD-0130_Mining.md)
   - [RFC-0300: The Digital Assets Network](RFCD-0300_DAN.md)
   - [RFC-0301: Namespace Registration](RFCD-0301_NamespaceRegistration.md)


### PR DESCRIPTION
Description
---
Moved old RFC-0121 describing Consensus Encoding to the deprecated section.

Motivation and Context
---
Initial implementation is deprecated in favor of `borsh`

How Has This Been Tested?
---

