### PR TITLE
fix: coin base rules

### DIFF
--- a/src/RFC-0120_Consensus.md
+++ b/src/RFC-0120_Consensus.md
@@ -118,6 +118,8 @@ A coinbase transaction contained in a block MUST:
 * have a value exactly equal to the emission at the block height it was minted (see [emission schedule]) 
   plus the total transaction fees within the block
 * have a lock-height as per consensus
+* can not have a offset except 0
+* can not have a script offset except 0
   
 A coinbase transaction contained in a block CAN:
 * include any arbitrary 64 bytes of extra data, [coinbase-extra]
@@ -370,6 +372,7 @@ done by the whole network, and verification of sorting is exceptionally cheap.
 |:------------|:--------------------|:----------|
 | 11 Oct 2022 | First stable        | SWvHeerden|
 | 13 Mar 2023 | Add mention of coinbase extra        | SWvHeerden|
+| 05 Jun 2023 | Add coinbase excess rule       | SWvHeerden|
 
 
 


### PR DESCRIPTION
Description
---
Current implementation of the coinbase builder makes these 0, but we do not have a rule that specifies they have to be 0. 

Motivation and Context
---
If they are not zero, you cannot do validation on the coinbase kernel. 
The script_offset makes zero difference on the malleability of the kernel so its not required. There is also no spending script key, meaning you leak the private key to sender_offset key. 
The transactions offset makes it impossible to test the value of the kernel in any block that has more than the coinbase transaction. 



