### PR TITLE
feat: range proof proving efficiency

### DIFF
--- a/src/RFC-0181_BulletproofsPlus.md
+++ b/src/RFC-0181_BulletproofsPlus.md
@@ -251,13 +251,17 @@ This means single-proof verification has $b = 1$.
 | Bulletproofs   | $b[2\operatorname{lg}(mn) + m + 4] + 2mn + 2$ |
 | Bulletproofs+  | $b[2\operatorname{lg}(mn) + m + 3] + 2mn + p + 1$ |
 
-Verification in Bulletproofs+ is slightly faster than in Bulletproofs.
+Verification in Bulletproofs+ is slightly faster than in Bulletproofs in theory.
+
+In practice, verification of a single 64-bit range proof in the [Tari Bulletproofs+](https://github.com/tari-project/bulletproofs-plus) implementation is comparable to an [updated fork](https://github.com/tari-project/bulletproofs) of the [Dalek Bulletproofs](https://github.com/dalek-cryptography/bulletproofs) implementation, though verification of an aggregated proof is notably slower.
 
 ### Proving efficiency
 
 It is more challenging to compare proving efficiency, since generation of a range proof does not reduce cleanly to a single multiscalar multiplication evaluation for either Bulletproofs or Bulletproofs+ range proofs.
 However, we note that the overall complexity between the inner-product arguments in the proving systems is similar in terms of group operations; outside of these inner-product arguments, Bulletproofs+ requires fewer group operations.
 Overall efficiency is likely to depend on specific optimizations.
+
+In practice, verification of a single 64-bit range proof in the Tari Bulletproofs+ implementation is about 10% faster than in the Dalek Bulletproofs updated fork.
 
 ## Changelog
 

--- a/src/RFC-0181_BulletproofsPlus.md
+++ b/src/RFC-0181_BulletproofsPlus.md
@@ -253,6 +253,12 @@ This means single-proof verification has $b = 1$.
 
 Verification in Bulletproofs+ is slightly faster than in Bulletproofs.
 
+### Proving efficiency
+
+It is more challenging to compare proving efficiency, since generation of a range proof does not reduce cleanly to a single multiscalar multiplication evaluation for either Bulletproofs or Bulletproofs+ range proofs.
+However, we note that the overall complexity between the inner-product arguments in the proving systems is similar in terms of group operations; outside of these inner-product arguments, Bulletproofs+ requires fewer group operations.
+Overall efficiency is likely to depend on specific optimizations.
+
 ## Changelog
 
 | Date        | Change              | Author |
@@ -261,3 +267,4 @@ Verification in Bulletproofs+ is slightly faster than in Bulletproofs.
 | 13 Jan 2022 | Performance updates | brianp |
 | 20 Jul 2023 | Sum optimization    | Aaron  |
 | 31 Jul 2023 | Notation and efficiency | Aaron  |
+| 3 Aug 2023 | Proving efficiency note | Aaron |

--- a/src/RFC-0181_BulletproofsPlus.md
+++ b/src/RFC-0181_BulletproofsPlus.md
@@ -261,7 +261,7 @@ It is more challenging to compare proving efficiency, since generation of a rang
 However, we note that the overall complexity between the inner-product arguments in the proving systems is similar in terms of group operations; outside of these inner-product arguments, Bulletproofs+ requires fewer group operations.
 Overall efficiency is likely to depend on specific optimizations.
 
-In practice, verification of a single 64-bit range proof in the Tari Bulletproofs+ implementation is about 10% faster than in the Dalek Bulletproofs updated fork.
+In practice, generation of a single 64-bit range proof in the Tari Bulletproofs+ implementation is about 10% faster than in the Dalek Bulletproofs updated fork, with similar performance for aggregated proofs.
 
 ## Changelog
 


### PR DESCRIPTION
Description
---
Adds a brief note about range proof proving efficiency. Adds rough benchmarks against Bulletproofs.

Motivation and Context
---
It was [suggested](https://github.com/tari-project/rfcs/pull/103#issuecomment-1663380301) to add information about proving efficiency to range proof [RFC-0181](https://rfc.tari.com/RFC-0181_BulletproofsPlus.html).

Quantifying proving efficiency is more subtle than verification efficiency, since proof generation doesn't reduce to a multiscalar multiplication operation and requires a variable number of rounds. Instead of bogging down the RFC with a long list of group element operation counts, this PR adds a more general note.

Informal benchmark comparing the [Tari implementation](https://github.com/tari-project/bulletproofs-plus) to the [corresponding Bulletproofs fork](https://github.com/tari-project/bulletproofs) are included.

How Has This Been Tested?
---
The changes build and appear to render correctly.
