### PR TITLE
chore: rename thaum to tari

### DIFF
--- a/src/RFC-0303_DanOverview.md
+++ b/src/RFC-0303_DanOverview.md
@@ -84,7 +84,7 @@ These components include:
 * Validator Nodes - VNs validate smart contracts and earn fees for doing so.
 * Cerberus consensus engine - highly scalable, high-speed sharded BFT consensus engine.
 * Tari Virtual Machine - Runs smart contracts in a secure sandbox.
-* Thaums - the unit of magic that fuels the Tari DAN.
+* Tari - the token that fuels the Tari DAN.
 
 The remainder of this document describes these elements in a little more detail and how they relate to each other.
 
@@ -93,7 +93,7 @@ The remainder of this document describes these elements in a little more detail 
 Obviously, the most important role of the Tari base layer is to issue and secure the base Tari token.
 As it relates to the DAN, the base layer also serves as an immutable global registry for several key pieces of data:
 * It maintains the register of all validator nodes.
-* It provides the only means of minting more [Thaum]s into the DAN economy.
+* It provides the only means of minting more [Tari] into the DAN economy.
 * It maintains the register of all DAN contract templates.
 
 The base layer also forces the DAN to make progress in the case of a Byzantine stoppage.
@@ -138,7 +138,7 @@ Validator nodes must be able to
 Steps 1 - 3 are carried out in the Tari Virtual Machine (TVM).
 Step 4 is achieved by communicating with peers via the DAN consensus layer.
 
-[Thaums](#thaums-and-the-turbine-model) exist at the Validator node level, and VNs earn fees, in Thaums, for each 
+[Tari](#tari-and-the-turbine-model) exist at the Validator node level, and VNs earn fees, in Tari, for each 
 instruction that it aids in getting finalised.
 
 ### DAN consensus layer
@@ -167,21 +167,22 @@ The TVM is able to
 * Execute calls on the contract.
 * Persist and restore the state of the contract.
 
-### Thaums and the turbine model
+### Tari and the turbine model
 
-Thaums is a [unit of magic](https://discworld.fandom.com/wiki/Thaum). Thaums are used to power the DAN's economic 
-engine. Thaums are created with a one-way perpetual peg as described in [RFC-0320]. Briefly, Tari is burnt to create 
-Thaums, which are used to pay for the execution of instructions on the DAN. A portion of instruction fees are burnt 
-with every instruction to provide a constant source of demand for Thaums in the DAN.
+Tari is used to power the DAN's economic 
+engine. Tari is minted via a one-way perpetual peg as described in [RFC-0320]. Briefly, Minotari are burnt to create 
+Tari, which are used to pay for the execution of instructions on the DAN. A portion of instruction fees are burnt 
+with every instruction to provide a constant source of demand for Tari in the DAN.
 
-There is no peg out back to the base layer for Thaums. The reason for this is explained in [RFC-0320]. Thaum holders wishing to convert back to Tari will be able to 
-perform a submarine swap with a Tari seller. We also anticipate that exchanges will list the Thaum-Tari pair to 
-enable easy conversion of Thaums back to Tari.
+There is no peg out back to the base layer for Tari. The reason for this is explained in [RFC-0320]. 
+Tari holders wishing to convert back to Tari will be able to perform a submarine swap with a Tari seller. 
+We also anticipate that exchanges will list the Tari-Minotari pair to enable easy conversion of Tari back to Minotari.
 
 # Change Log
 
 | Date        | Change              | Author     |
 |:------------|:--------------------|:-----------|
+| 23 Oct 2023 | Thaum -> Tari       | CjS77      |
 | 1 Nov 2022  | High-level overview | CjS77      |
 | 26 Oct 2022 | First outline       | SWvHeerden |
 

--- a/src/RFC-0310_SubmarineSwaps.md
+++ b/src/RFC-0310_SubmarineSwaps.md
@@ -317,7 +317,7 @@ standard Mimblewimble rules and signatures.
 When Bob sees that the Minotari UTXO that Alice created is mined on the Minotari blockchain with the correct script, Bob can
 publish the Tari transaction containing the Tari commitment with the aggregate key \\(X = X_a + X_b + k_i \cdot G \\).
 
-### Claim Tari 
+### Claim Minotari 
 
 When Alice sees that the Tari commitment that Bob created is confirmed on the second layer containing the correct aggregate 
 key \\(X\\), she can provide Bob with the required `pre_image` to spend the Minotari UTXO. She does not have the 
@@ -325,7 +325,7 @@ missing key \\(x_b \\) to claim the Tari yet, but it will be revealed when Bob c
 
 Bob can now supply the `pre_image` and his Tari private key as transaction input to unlock the script.
 
-### Claim Minotari
+### Claim Tari
 
 Alice can now see that Bob spent the Minotari UTXO, and by examining the `input_data` required to satisfy the script, she 
 can learn Bob's secret Tari key. Although this private key \\( x_b \\) is now public knowledge, her part of the Tari spend key 

--- a/src/RFC-0310_SubmarineSwaps.md
+++ b/src/RFC-0310_SubmarineSwaps.md
@@ -46,8 +46,7 @@ technological merits of the potential system outlined herein.
 
 ## Goals
 
-This Request for Comment (RFC) aims to describe how an Atomic swap between Tari and Thaum will be created.
-> Note: Name is still pending going with Wrapped Tari aka Thaum for this document till a proper name has been decided apon. 
+This Request for Comment (RFC) aims to describe how an Atomic swap between Tari and Minotari will be created.
 
 ## Related Requests for Comment
 
@@ -74,81 +73,86 @@ Any comments, changes or questions to this PR can be made in one of the followin
 
 ## Description
 
-To be able to exchange Tari and Thaum without the use of some centralized exhange service, we need to do Submarine swaps or Atomic swaps between the two.
-We want to keep Thaum as bare bones as possible with if possible just a commitment and perhaps a rangeproof, this means that we will not have access to
-smart contract features typically required for doing submarine swaps. This does not mean it is not possible to do atomic swaps with non smart contract coins,
-look at [RFC-0241: AtomicSwap XMR](RFC-0241_AtomicSwapXMR.md) to see how this is done with Tari and Monero.
+To be able to exchange Tari and Minotari without the use of some centralized exchange service, we need to do Submarine swaps or Atomic swaps between the two.
+We want to keep Tari as bare bones as possible with if possible just a commitment and perhaps a range proof, this means that we will not have access to
+smart contract features typically required for doing submarine swaps. This does not mean it is not possible to do atomic swaps with non-smart contract coins,
+look at [RFC-0241: AtomicSwap XMR](RFC-0241_AtomicSwapXMR.md) to see how this is done with Minotari and Monero.
 
 ## Method
 
-The primary, happy path outline of a Tari - Thaum submarine swap is described here, and more detail will follow. We assume
-that Alice wants to trade her Tari for Bob's Thaum.
+The primary, happy path outline of a Tari - Minotari submarine swap is described here, and more detail will follow. We assume
+that Alice wants to trade her Minotari for Bob's Tari.
 
-* Negotiation - Both parties negotiate the value and other details of the Tari and Thaum commitment's.
+* Negotiation - Both parties negotiate the value and other details of the Tari and Minotari commitments.
 * Commitment - Both parties commit to the keys, nonces, inputs, and outputs to use for the transaction.
-* Tari payment - Alice makes the Tari payment to a UTXO containing a "special" script described below.
-* Thaum Payment - The Thaum payment is made to a multiparty [scriptless script](https://tlu.tarilabs.com/cryptography/introduction-to-scriptless-scripts) commitment.
-* Claim Tari - Bob redeems the Tari, and in doing so, reveals the Thaum private key to Alice only.
-* Claim Thaum - Alice may claim the Thaum using the revealed key.
+* Minotari payment - Alice makes the Minotari payment to a UTXO containing a "special" script described below.
+* Tari Payment - The Tari payment is made to a multiparty [scriptless script](https://tlu.tarilabs.com/cryptography/introduction-to-scriptless-scripts) commitment.
+* Claim Minotari - Bob redeems the Minotari, and in doing so, reveals the Tari private key to Alice only.
+* Claim Tari - Alice may claim the Tari using the revealed key.
 
 Please take note of the notation used in [TariScript] and specifically notation used on the signatures on the [transaction inputs](RFC-0201_TariScript.md#transaction-input-changes) and on the signatures on the [transaction outputs](RFC-0201_TariScript.md#transaction-output-changes).
 We will note other notations in the [Notation](#notation) section.
 
 ## TL;DR
 
-The scheme revolves around Alice, who wants to exchange her Tari for Bob's Thaum. Because they don't trust each other, 
+The scheme revolves around Alice, who wants to exchange her Minotari for Bob's Tari. Because they don't trust each 
+other, 
 they have to commit some information to do the exchange. And if something goes wrong here, we want to ensure that we can 
-refund both parties either in Thaum or Tari.
+refund both parties either in Tari or Minotari.
 
-How this works is that Alice and Bob create a shared output on both chains. The Thaum output is a simple aggregate key 
-to unlock the commitment, while multiple keys are needed to unlock the Tari UTXO. An aggregate key locks this Thaum commitment
-that neither Alice nor Bob knows, but they both know half of the key. The current Tari block height determines the unlocking 
-key for the Tari UTXO.
+How this works is that Alice and Bob create a shared output on both chains. The Tari output is a simple aggregate key 
+to unlock the commitment, while multiple keys are needed to unlock the Minotari UTXO. An aggregate key locks this Tari commitment
+that neither Alice nor Bob knows, but they both know half of the key. The current Minotari block height determines the 
+unlocking key for the Minotari UTXO.
 
 The process is started by Alice and Bob exchanging and committing to some information. Alice is the first to publish a 
-transaction, which creates the Tari UTXO. If Bob is happy that the Tari UTXO has been mined and verifies all the 
-information, he will publish a transaction to create the Thaum commitment.
+transaction, which creates the Minotari UTXO. If Bob is happy that the Minotari UTXO has been mined and verifies all 
+the information, he will publish a transaction to create the Tari commitment.
 
-The TariScript script on the UTXO ensures that they will have to reveal their portion of the Thaum key when either 
-Alice or Bob spends this. This disclosure allows the other party to claim the Thaum by being the only one to own the 
-complete Thaum aggregate key.
+The TariScript script on the UTXO ensures that they will have to reveal their portion of the Tari key when either 
+Alice or Bob spends this. This disclosure allows the other party to claim the Tari by being the only one to own the 
+complete Tari aggregate key.
 
-The script will ensure that at any point in time, at least someone can claim the Tari UTXO, and if that person does so, 
-the other party can claim the Thaum commitment by looking at the spending data. It has two lock heights, determining who can 
-claim the Tari UTXO if the happy path fails. Before the first lock height, only Bob can claim the Tari; we call this the 
+The script will ensure that at any point in time, at least someone can claim the Minotari UTXO, and if that person 
+does so,  the other party can claim the Tari commitment by looking at the spending data. It has two lock heights, 
+determining who can claim the Minotari UTXO if the happy path fails. Before the first lock height, only Bob can claim 
+the Tari; we call this the 
 swap transaction.
 
-If Bob disappears after Alice has posted the Tari UTXO, Alice can claim the Tari after the first lock height and before 
-the second lock height; we call this the refund transaction. It ensures that Alice can reclaim her Tari if Bob 
-disappears, and if Bob reappears, he can reclaim his Thaum.
+If Bob disappears after Alice has posted the Minotari UTXO, Alice can claim the Minotari after the first lock height and before 
+the second lock height; we call this the refund transaction. It ensures that Alice can reclaim her Minotari if Bob 
+disappears, and if Bob reappears, he can reclaim his Tari.
 
-That leaves us with the scenario where Alice disappears after Bob posts the Thaum transaction, in which case we need to 
-protect Bob. After the second lock height, only Bob can claim the Tari; we call this the lapse transaction. The lapse 
-transaction will reveal Bob's Thaum key so that if Alice reappears, she can claim the Thaum.
+That leaves us with the scenario where Alice disappears after Bob posts the Tari transaction, in which case we need to 
+protect Bob. After the second lock height, only Bob can claim the Minotari; we call this the lapse transaction. The lapse 
+transaction will reveal Bob's Tari key so that if Alice reappears, she can claim the Tari.
 
 ## Heights, Security, and other considerations
 
 We need to consider a few things for this to be secure, as there are possible scenarios that can reduce the security in the atomic swap. 
 
 When looking at the two lock heights, the first lock height should be sufficiently large enough to give ample time for Alice to post the Tari UTXO transaction and for it to be mined with a safe number of confirmations,
-and for Bob to post the Monero transaction and for it to be mined with a safe number of confirmations. The second lock
-height should give ample time for Alice after the first lock height to re-claim her Tari. Larger heights here might make
+and for Bob to post the Tari transaction and for it to be mined with a safe number of confirmations. The second lock
+height should give ample time for Alice after the first lock height to re-claim her Minotari. Larger heights here might make
 refunds slower, but it should be safer in giving more time to finalize this. 
 
-Allowing both to claim the Tari after the second lock height is, on face value, a safer option. This can be done by enabling
-either party to claim the script with the lapse transaction. The counterparty can then claim the Monero. However, this
-will open up an attack vector to enable either party to claim the Monero while claiming the Tari. Either party could trivially
+Allowing both to claim the Minotari after the second lock height is, on face value, a safer option. This can be done by enabling
+either party to claim the script with the lapse transaction. The counterparty can then claim the Tari. However, this
+will open up an attack vector to enable either party to claim the Tari while claiming the Minotari. Either party could 
+trivially
 pull off such a scheme by performing a front-running attack and having a bit of luck. The counterparty monitors all broadcast 
 transactions to base nodes. Upon identifying the lapse transaction, they do two things; in quick succession, broadcast 
-their lapse transaction and the transaction to claim the Monero, both with sufficiently high fees. Base nodes will 
-prefer to mine transactions with the higher fees, and thus the counterparty can walk away with both the Tari and the 
-Monero.
+their lapse transaction and the transaction to claim the Tari, both with sufficiently high fees. Base nodes will 
+prefer to mine transactions with the higher fees, and thus the counterparty can walk away with both the Minotari and the 
+Tari.
 
-It is also possible to prevent the transaction from being mined after being submitted to the mempool. This can be caused by a combination
-of a too busy network, not enough fees, or a too-small period in the time locks. When one of these atomic swap transactions gets published to a mempool, we effectively already have all the details exposed. For the atomic swaps, it means we already revealed part of the Monero key, although
-the actual Tari transaction has not been mined. But this is true for any HTLC or like script on any blockchain. But in the odd
-chance that this does happen whereby the fees are too little and time locks not enough, it should be possible to do a child-pays-for-parent
-transaction to bump up the fees on the transaction to get it mined and confirmed.
+It is also possible to prevent the transaction from being mined after being submitted to the mempool. 
+This can be caused by a combination of a too busy network, not enough fees, or a too-small period in the time locks.
+When one of these atomic swap transactions gets published to a mempool, we effectively  already have all the details 
+exposed. For the atomic swaps, it means we already revealed part of the Tari key, although the actual Minotari 
+transaction has not been mined. But this is true for any HTLC or like script on any blockchain. 
+But in the odd  chance that this does happen whereby the fees are too little and time locks not enough, it should be 
+possible to do a child-pays-for-parent transaction to bump up the fees on the transaction to get it mined and confirmed.
 
 ## Key construction
 
@@ -168,7 +172,7 @@ $$
 
 ## Key security
 
-The risk of publicly exposing part of the Thaum private key is still secure because of how [ECC](https://cryptobook.nakov.com/asymmetric-key-ciphers/elliptic-curve-cryptography-ecc#private-key-public-key-and-the-generator-point-in-ecc) works. We can
+The risk of publicly exposing part of the Tari private key is still secure because of how [ECC](https://cryptobook.nakov.com/asymmetric-key-ciphers/elliptic-curve-cryptography-ecc#private-key-public-key-and-the-generator-point-in-ecc) works. We can
 add two secret keys together and share the public version of both. And at the same time, we know that no one can calculate
 the secret key with just one part.
 
@@ -200,13 +204,13 @@ hardware. Thus this is still secure even though we leaked part of the secret key
 
 ### Detail
 
-We rely purely on TariScript to enforce the exposure of the private Thaum aggregate keys. Based on [Point Time Lock Contracts](https://suredbits.com/payment-points-part-1/), 
-the script forces the spending party to supply their Thaum private key part as input data to the script, evaluated via the operation `ToRistrettoPoint`. This TariScript 
-operation will publicly reveal part of the aggregated Thaum private key, but this is still secure: see [Key security](#key-security).
+We rely purely on TariScript to enforce the exposure of the private Tari aggregate keys. Based on [Point Time Lock Contracts](https://suredbits.com/payment-points-part-1/), 
+the script forces the spending party to supply their Tari private key part as input data to the script, evaluated via the operation `ToRistrettoPoint`. This TariScript 
+operation will publicly reveal part of the aggregated Tari private key, but this is still secure: see [Key security](#key-security).
 
 The simplicity of this method lies therein that the spending party creates all transactions on their 
 own. Bob requires a pre-image from Alice to complete the swap transaction; Alice needs to verify that Bob published the 
-Thaum transaction and that everything is complete as they have agreed. If she is happy, she will provide Bob with the 
+Tari transaction and that everything is complete as they have agreed. If she is happy, she will provide Bob with the 
 pre-image to claim the Tari UTXO.
 
 
@@ -240,26 +244,27 @@ The Script used for the Tari UTXO is as follows:
    ENDIF
 ```
 
-Before `height_1`, Bob can claim the Tari UTXO by supplying `pre_image` and his private Thaum key part `x_b`. After 
-`height_1` but before `height_2`, Alice can claim the Tari UTXO by supplying her private Thaum key part `x_a`. After 
-`height_2`, Bob can claim the Tari UTXO by providing his private Thaum key part `x_b`.
+Before `height_1`, Bob can claim the Minotari UTXO by supplying `pre_image` and his private Tari key part `x_b`. After 
+`height_1` but before `height_2`, Alice can claim the Minotari UTXO by supplying her private Tari key part `x_a`. After 
+`height_2`, Bob can claim the Minotari UTXO by providing his private Tari key part `x_b`.
 
 ### Negotiation
 
 Alice and Bob have to negotiate the exchange rate and the amount exchanged in the atomic swap. They also need to decide 
 how the two UTXO's will look on the blockchain. To accomplish this, the following needs to be finalized:
 
-* Amount of Tari to swap for the amount of Thaum
-* Thaum public key parts \\(X_a\\), \\(X_b\\) ,and its aggregate form \\(X\\)
-* Tari [script key] parts \\(K_{Sa}\\), \\(K_{Sb}\\) 
-* The [TariScript] to be used in the Tari UTXO
-* The blinding factor \\(k_i\\) for the Tari UTXO, which can be a Diffie-Hellman between their Tari addresses.
+* Amount of Minotari to swap for the amount of Tari
+* Tari public key parts \\(X_a\\), \\(X_b\\) ,and its aggregate form \\(X\\)
+* Minotari [script key] parts \\(K_{Sa}\\), \\(K_{Sb}\\) 
+* The [TariScript] to be used in the Minotari UTXO
+* The blinding factor \\(k_i\\) for the Minotari UTXO, which can be a Diffie-Hellman between their Tari network 
+  addresses.
 
 
 ### Key selection
 
-Using (1), we create the Thaum keys as they are multi-party aggregate keys.
-The Thaum key parts for Alice and Bob is constructed as follows:
+Using (1), we create the Tari keys as they are multi-party aggregate keys.
+The Tari key parts for Alice and Bob is constructed as follows:
 
 
 $$
@@ -290,56 +295,56 @@ This phase allows Alice and Bob to commit to using their keys.
 Alice needs to provide Bob with the following:
 
 * Script public key: \\( K_{Sa}\\)
-* Thaum public key \\( X_a'\\)
+* Tari public key \\( X_a'\\)
 
 Bob needs to provide Alice with the following:
 
 * Script public key: \\( K_{Sb}\\)
-* Thaum public key \\( X_b'\\)
+* Tari public key \\( X_b'\\)
 
 Using the above equations in (7), Alice and Bob can calculate \\(X\\), \\(X_a\\), \\(X_b\\)
 
 
 
-### Tari payment
+### Minotari payment
 
-Alice will construct the Tari UTXO with the correct [script](#tariscript) and publish the containing transaction to the 
-blockchain, knowing that she can reclaim her Tari if Bob vanishes or tries to break the agreement. This is done with 
+Alice will construct the Minotari UTXO with the correct [script](#tariscript) and publish the containing transaction to the 
+blockchain, knowing that she can reclaim her Minotari if Bob vanishes or tries to break the agreement. This is done with 
 standard Mimblewimble rules and signatures.
 
-### Thaum payment
+### Tari payment
 
-When Bob sees that the Tari UTXO that Alice created is mined on the Tari blockchain with the correct script, Bob can
-publish the Thaum transaction containing the Thaum commitment with the aggregate key \\(X = X_a + X_b + k_i \cdot G \\).
+When Bob sees that the Minotari UTXO that Alice created is mined on the Minotari blockchain with the correct script, Bob can
+publish the Tari transaction containing the Tari commitment with the aggregate key \\(X = X_a + X_b + k_i \cdot G \\).
 
 ### Claim Tari 
 
-When Alice sees that the Thaum commitment that Bob created is confirmed on the second layer containing the correct aggregate 
-key \\(X\\), she can provide Bob with the required `pre_image` to spend the Tari UTXO. She does not have the 
-missing key \\(x_b \\) to claim the Thaum yet, but it will be revealed when Bob claims the Tari. 
+When Alice sees that the Tari commitment that Bob created is confirmed on the second layer containing the correct aggregate 
+key \\(X\\), she can provide Bob with the required `pre_image` to spend the Minotari UTXO. She does not have the 
+missing key \\(x_b \\) to claim the Tari yet, but it will be revealed when Bob claims the Minotari. 
 
-Bob can now supply the `pre_image` and his Monero private key as transaction input to unlock the script.
+Bob can now supply the `pre_image` and his Tari private key as transaction input to unlock the script.
 
-### Claim Thaum
+### Claim Minotari
 
-Alice can now see that Bob spent the Tari UTXO, and by examining the `input_data` required to satisfy the script, she 
-can learn Bob's secret Thaum key. Although this private key \\( x_b \\) is now public knowledge, her part of the Thaum spend key 
-is still private, and thus only she knows the complete Thaum spend key. She can use this knowledge to claim the Thaum commitment.
+Alice can now see that Bob spent the Minotari UTXO, and by examining the `input_data` required to satisfy the script, she 
+can learn Bob's secret Tari key. Although this private key \\( x_b \\) is now public knowledge, her part of the Tari spend key 
+is still private, and thus only she knows the complete Tari spend key. She can use this knowledge to claim the Tari commitment.
 
 ### The refund
 
-If something goes wrong and Bob never publishes the Thaum or disappears, Alice needs to wait for the lock height
-`height_1` to pass. This will allow her to reclaim her Tari, but in doing so, she needs to publish her Thaum secret key 
-as input to the script to unlock the Tari. When Bob comes back online, he can use this public knowledge to reclaim his 
-Thaum, as only he knows both parts of the Thaum commitment spend key.
+If something goes wrong and Bob never publishes the Tari or disappears, Alice needs to wait for the lock height
+`height_1` to pass. This will allow her to reclaim her Minotari, but in doing so, she needs to publish her Tari secret key 
+as input to the script to unlock the Minotari. When Bob comes back online, he can use this public knowledge to reclaim his 
+Tari, as only he knows both parts of the Tari commitment spend key.
 
 
 ### The lapse transaction
 
 If something goes wrong and Alice never gives Bob the required `pre_image`, Bob needs to wait for the lock height
-`height_2` to pass. This will allow him to claim the Tari he wanted all along, but in doing so, he needs to publish
-his Thaum secret key as input to the script to unlock the Tari. When Alice comes back online, she can use this public 
-knowledge to claim the Thaum she wanted all along as only she now knows both parts of the Thaum commitment spend key.
+`height_2` to pass. This will allow him to claim the Minotari he wanted all along, but in doing so, he needs to publish
+his Tari secret key as input to the script to unlock the Minotari. When Alice comes back online, she can use this public 
+knowledge to claim the Tari she wanted all along as only she now knows both parts of the Tari commitment spend key.
 
 
 ## Notation
@@ -355,9 +360,9 @@ assigned greek lowercase letters in most cases. Some terms used here are noted d
 | subscript l                 | \\( _l \\)            | The lapse transaction |
 | subscript a                 | \\( _a \\)            | Belongs to Alice |
 | subscript b                 | \\( _b \\)            | Belongs to Bob |
-| Thaum key                    | \\( X \\)             | Aggregate Thaum public key |
-| Alice's Thaum key            | \\( X_a \\)           | Alice's partial Thaum public key |
-| Bob's Thaum key              | \\( X_b \\)           | Bob's partial Thaum public key  |
+| Tari key                    | \\( X \\)             | Aggregate Tari public key |
+| Alice's Tari key            | \\( X_a \\)           | Alice's partial Tari public key |
+| Bob's Tari key              | \\( X_b \\)           | Bob's partial Tari public key  |
 | Script key                  | \\( K_s \\)           | The [script key] of the utxo |
 | Alice's Script key          | \\( K_sa \\)          | Alice's partial [script key]  |
 | Bob's Script key            | \\( K_sb \\)          | Bob's partial [script key]  |
@@ -365,6 +370,13 @@ assigned greek lowercase letters in most cases. Some terms used here are noted d
 | Bob's adaptor signature     | \\( b'_{Sb} \\)       | Bob's adaptor signature for the \\( b_{Sb} \\) of the script_signature of the utxo |
 | Ristretto G generator       | \\(k \cdot G  \\)     | Value k over Curve25519 G generator encoded with Ristretto|
 
+
+# Change Log
+
+| Date        | Change        | Author     |
+|:------------|:--------------|:-----------|
+| 23 Oct 2023 | Thaum -> Tari | CjS77      |
+| 15 Nov 2022 | First outline | SWvHeerden |
 
 [HTLC]: Glossary.md#hashed-time-locked-contract
 [Mempool]: Glossary.md#mempool

--- a/src/RFC-0320_TurbineModel.md
+++ b/src/RFC-0320_TurbineModel.md
@@ -48,10 +48,9 @@ technological merits of the potential system outlined herein.
 
 ## Goals
 
-The Thaum is a [unit of magic](https://discworld.fandom.com/wiki/Thaum). Thaums are used to power the DAN's economic
-engine.
+Tari is used to power the DAN's economic engine.
 
-This RFC describes the motivation and mechanism of the Tari to Dan peg-in mechanism. 
+This RFC describes the motivation and mechanism of the Minotari to DAN peg-in mechanism. 
 
 ## Related Requests for Comment
 
@@ -76,7 +75,7 @@ side-chains, like [elements]. All of them have particular trade-offs and difficu
 For Tari, we propose a slightly different approach: A one-way peg with persistent 2nd-layer burn.
 
 Because the operating principle is quite similar to that of a gas turbine, we call this approach the _turbine model_.
-Fuel (Tari) is fed into the turbine, which is burnt (also burnt :)) which produces a hot, motive gas (Thaums) that 
+Fuel (Minotari) is fed into the turbine, which is burnt (also burnt :)) which produces a hot, motive gas (Tari) that 
 drives the engine (the DAN). The exhaust gas is ejected from the rear of the turbine (a portion of the instruction 
 fees are burnt).
 
@@ -94,8 +93,8 @@ Let's briefly consider the trilemma from the point of view of the DAN.
 #### Monetary policy
 
 We are effectively forced to control monetary policy.
-Or put another way, we can't let people freely mint their own Thaums. Unfortunately, even though we have "chosen" to
-control supply, it's difficult for us to control the Thaums supply in practice. In the physical world, the money 
+Or put another way, we can't let people freely mint their own Tari. Unfortunately, even though we have "chosen" to
+control supply, it's difficult for us to control the Tari supply in practice. In the physical world, the money 
 supply is typically managed by a central bank, with the emphasis on "central".
 
 The designers of a decentralised monetary system have precious few levers available to control supply and no simple ones.
@@ -139,36 +138,37 @@ model:
 
 ![turbine](./assets/turbine.png)
 
-The DAN Thaum supply is increased by user peg-in deposits, and any other mechanism that we may want to enforce, 
+The DAN Tari supply is increased by user peg-in deposits, and any other mechanism that we may want to enforce, 
 such as asset issuer financing. 
 
-To prevent the eventual collapse of the Thaum price to zero, there must be an exhaust mechanism that continually 
-removes Thaums from the system..
+To prevent the eventual collapse of the Tari price to zero, there must be an exhaust mechanism that continually 
+removes Tari from the system..
 
-The simplest exhaust mechanism is to simply burn a fraction of Thaums fees from every transaction! These can be very
-low. Presumably, over the long-run the burn rate should approximately match the Tari base layer tail emission.
+The simplest exhaust mechanism is to simply burn a fraction of Tari fees from every transaction! These can be very
+low. Presumably, over the long-run the burn rate should approximately match the Minotari blockchain tail emission.
 
-The exhaust places a permanent upward pressure on the Thaums exchange rate; but it will never exceed 1:1 with Tari,
-since any premium will be immediately arbitraged away. This is because anyone can _always_ burn as much Tari as they 
-wish and mint Thaums at a 1:1 ratio on the DAN and then sell them for a risk-free profit. This action will increase 
-the supply of Thaums and drive the price back down to parity.
+The exhaust places a permanent upward pressure on the Tari exchange rate; but it will never exceed 1:1 with Minotari,
+since any premium will be immediately arbitraged away. This is because anyone can _always_ burn as much Minotari as they 
+wish and mint Tari at a 1:1 ratio on the DAN and then sell them for a risk-free profit. This action will increase 
+the supply of Tari and drive the price back down to parity.
 
-If the exhaust is temporarily insufficient to hold the peg, the Thaums price will drop below 1 XTR. This will 
-immediately shut off deposits because submarine swaps will a be cheaper route to obtaining Thaums than burning 
-Tari (which are always 1:1). Since the exhausts upward price pressure is a constant force, the Thaums price will 
+If the exhaust is temporarily insufficient to hold the peg, the Tari price will drop below 1 XTR. This will 
+immediately shut off deposits because submarine swaps will a be cheaper route to obtaining Tari than burning 
+Minotari (which are always 1:1). Since the exhausts upward price pressure is a constant force, the Tari price will 
 eventually approach 1:1 again.
 
-Over time, we expect this mechanism to provide a somewhat stable peg between Thaum and Tari with the Thaum price 
+Over time, we expect this mechanism to provide a somewhat stable peg between Tari and Minotari with the Tari price 
 occasionally dropping below parity and possibly remaining there for some time. As secondary markets for the 
-Tari-Thaum pair matures, this event will immediately create a bid on Thaums, since -- in the absence of catastrophic 
-failure -- speculators know that the Thaum price will eventually return to parity, causing upward pressure to come into 
+Tari-Minotari pair matures, this event will immediately create a bid on Tari, since -- in the absence of catastrophic 
+failure -- speculators know that the Tari price will eventually return to parity, causing upward pressure to come into 
 play quickly and efficiently.
 
 # Change Log
 
-| Date        | Change      | Author     |
-|:------------|:------------|:-----------|
-| 1 Nov 2022  | First draft | CjS77      |
+| Date        | Change        | Author |
+|:------------|:--------------|:-------|
+| 23 Nov 2023 | Thaum -> Tari | CjS77  |
+| 1 Nov 2022  | First draft   | CjS77  |
 
 [space-chains]: https://www.youtube.com/watch?v=N2ow4Q34Jeg
 [drive-chains]: https://www.drivechain.info/


### PR DESCRIPTION
Description
---

The whimsical and Discworld-related placeholder name for DAN tokens was `Thaum`. This has since been renamed to Tari. (And L1 tokens are now Minotari).

