### PR TITLE
chore: edits and numbering fix

### DIFF
--- a/src/RFC-0305_Consensus.md
+++ b/src/RFC-0305_Consensus.md
@@ -1,4 +1,4 @@
-# RFC-0304/Consensus
+# RFC-0305/Consensus
 
 ## The Tari Network Consensus Layer
 
@@ -50,7 +50,7 @@ technological merits of the potential system outlined herein.
 ## Goals
 
 This Request for Comment (RFC) describe the consensus mechanism known as Cerberus as it is implemented in Tari.
-Tari implements the Cerberus variant known as Optimistic Cerberus, for the most part, with Hotstuff BFT replacing
+Tari implements the Cerberus variant known as Pessimistic Cerberus, for the most part, with Hotstuff BFT replacing
 pBFT as described in the Cerberus paper.
 
 This RFC serves to document any deviations from the academic paper as well as finer-grained details of the

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -30,7 +30,7 @@
   - [RFC-0313: Validator Node Registration](RFC-0313_VNRegistration.md)
   - [RFC-0320: The turbine model](RFC-0320_TurbineModel.md)
 
-- [RFC-0304: The Tari Network Consensus Layer](RFC-0304_Consensus.md)
+- [RFC-0305: The Tari Network Consensus Layer](RFC-0305_Consensus.md)
   - [RFC-0314: Validator node committee selection](RFC-0314_VNCSelection.md)
   - [RFC-0330: The Cerberus-Hotstuff consensus algorithm](RFC-0330_Cerberus.md)
   - [RFC-0331: Indexers](RFC-0331_Indexers.md)


### PR DESCRIPTION
RFC-304 was already taken. Renaming to RFC-305.

We use P-cerb, not O-Cerb.

Other editorial changes.



