### PR TITLE
fix: stablecoin rfc title

### DIFF
--- a/src/RFC-0385_StableCoins.md
+++ b/src/RFC-0385_StableCoins.md
@@ -1,6 +1,6 @@
 # RFC-0385/StableCoin
 
-## Digital Assets Network
+## Privacy-enabled Stablecoin contract design
 
 ![status: draft](theme/images/status-draft.svg)
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -49,7 +49,7 @@
   - [RFC-8001: Multi-party transactions](RFC-8001_MultiPartyTransactions.md)
   - [RFC-8002: Transaction protocol](RFC-8002_TransactionProtocol.md)
   - [RFC-8003: Tari Use Cases](RFC-8003_TariUseCases.md)
-  - [RFC-0385: Tari stablecoin specification](RFC-0385_StableCoins.md)
+  - [RFC-0385: Privacy-enabled Stablecoin contract design](RFC-0385_StableCoins.md)
   
 - [Deprecated RFCs](deprecated.md)
 


### PR DESCRIPTION
The title was wrong and inconsistent in the ToC



