### PR TITLE
fix: upgrade mdbook

### DIFF
--- a/.github/workflows/rfc_deploy.yml
+++ b/.github/workflows/rfc_deploy.yml
@@ -14,8 +14,7 @@ jobs:
 
       - name: Install 🦀
         run: |
-          curl -L https://github.com/badboy/mdbook-mermaid/releases/download/v0.10.0/mdbook-mermaid-v0.10.0-x86_64-unknown-linux-gnu.tar.gz | tar xvz
-          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.8/mdbook-v0.4.8-x86_64-unknown-linux-gnu.tar.gz | tar xvz
+          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.36/mdbook-v0.4.36-x86_64-unknown-linux-gnu.tar.gz
 
       - name: Build 🛠
         run: |


### PR DESCRIPTION
Locally, mermaid works fine on v0.4.34. The workflow still has 0.4.10, so I'm assuming upgrading will fix the mermaid not displaying properly issue.



