### PR TITLE
docs: rfc-323 tari throttle

### DIFF
--- a/src/RFC-0323_TariThrottle.md
+++ b/src/RFC-0323_TariThrottle.md
@@ -1,0 +1,701 @@
+# RFC-0323/TariThrottle
+
+## The Tari throttle, or Layer 2 burn rate controller
+
+![status: draft](theme/images/status-draft.svg)
+
+**Maintainer(s)**: [Cayle Sharrock](https://github.com/CjS77)
+
+# Licence
+
+[The 3-Clause BSD Licence](https://opensource.org/licenses/BSD-3-Clause).
+
+Copyright 2022 The Tari Development Community
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of this document must retain the above copyright notice, this list of conditions and the following
+   disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS DOCUMENT IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS", AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+## Language
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",
+"NOT RECOMMENDED", "MAY" and "OPTIONAL" in this document are to be interpreted as described in
+[BCP 14](https://tools.ietf.org/html/bcp14) (covering RFC2119 and RFC8174) when, and only when, they appear in all capitals, as
+shown here.
+
+## Disclaimer
+
+This document and its content are intended for information purposes only and may be subject to change or update
+without notice.
+
+This document may include preliminary concepts that may or may not be in the process of being developed by the Tari
+community. The release of this document is intended solely for review and discussion by the community of the
+technological merits of the potential system outlined herein.
+
+## Goals
+
+This RFC provides an introductory exploratory analysis into the mechanisms behind a proposed Tari throttle: a Layer 
+2 controller for the L2 fee burn rate to control the Tari circulating supply. 
+
+## Related Requests for Comment
+
+* [RFC-0303: The Digital Assets Network Overview](RFC-0303_DanOverview.md)
+* [RFC-0320: The turbine model](RFC-0320_TurbineModel.md)
+                               
+## Table of Contents
+
+- [Summary](#summary)
+- [PID controllers](#pid-controllers)
+- [Tari throttle](#tari-throttle)
+  - [Controller parameters](#controller-parameters)
+  - [Controller inputs](#controller-inputs)
+    - [Fee models](#fee-models)
+    - [Emission model](#emission-model)
+    - [Miscellaneous parameters](#miscellaneous-parameters)
+    - [Integer control](#integer-control)
+  - [The simulations](#the-simulations)
+    - [Controller parameters](#controller-parameters-1)
+    - [Target supply](#target-supply)
+    - [Fee models](#fee-models-1)
+  - [Results](#results)
+    - [21 billion Tari target supply](#21-billion-tari-target-supply)
+    - [18 billion Tari target supply](#18-billion-tari-target-supply)
+    - [15 billion Tari target supply](#15-billion-tari-target-supply)
+  - [Discussion](#discussion)
+    - [Low fees growth](#low-fees-growth)
+    - [High fees growth](#high-fees-growth)
+    - [Unstable fee revenue](#unstable-fee-revenue)
+    - [Slower growth with tapering fees](#slower-growth-with-tapering-fees)
+    - [Strong growth with tapering fees](#strong-growth-with-tapering-fees)
+  - [Conclusions](#conclusions)
+
+## Summary
+
+TariThrottle is a simple process controller designed to modulate the layer two burn rate in order to achieve two 
+goals:
+
+* Primarily, keep the emission and burn rate roughly balanced (ensuring long-term sustainability of Tari), and
+* Secondarily, to maintain the total circulating supply at a target value (satisfying an implicit assumption in 
+  cryptocurrencies that token supplies are finite).
+
+A proof-of-concept controller has been implemented and tested in a simulation environment ([repo]). As the results 
+below attest, the controller logic is sufficient to achieve these goals, even under highly volatile layer two fee 
+conditions. 
+
+However, the controller achieves the goals at the expense of a rapidly changing layer two burn rate, which may be 
+detrimental to the sustainability of validator nodes. 
+
+At the risk of the tail wagging the dog, the primary conclusion of this study is that the TariThrottle controller 
+should likely _not_ aim to maintain a supply target, but instead to ensure a sustainable layer two ecosystem, to 
+whit:
+
+* maintain a constant demand gradient so that under normal circumstances there is _always_ a demand for new Tari and 
+  thus Minotari are constantly being burnt to satisfy this demand,
+* marginal Validator Nodes are able to operate at or near break-even rates, while maintaining a healthy reserve of 
+  capacity for surge demand, and 
+* the supply of Minotari is sustainable over the long-term.
+
+Therefore, the conclusion of this study is not to abandon the original targets of the TariThrottle completely, 
+but to adjust the priority of the primary goal (a sustainable long-term balance), and make it subservient to the 
+primary goal of ensuring a constant demand gradient.
+
+A modified Tari throttle model that seeks to achieve these aims is outside of the scope of this RFC and is left for 
+a follow-up study.
+
+## PID controllers
+
+TariThrottle is based on a simple
+[PID controller](https://en.wikipedia.org/wiki/Proportional%E2%80%93integral%E2%80%93derivative_controller) design.
+
+PID controllers are a type of control system that uses feedback to control the system.  They are widely used in
+industrial control systems and have been used in many other applications.
+
+The PID controller has three components:
+* Proportional: This component is proportional to the error between the setpoint and the current value.  It is
+  the primary component of the controller and is used to drive the system towards the setpoint.
+* Integral: This component is proportional to the integral of the error over time.  It is used to eliminate
+  steady-state error.
+* Derivative: This component is proportional to the rate of change of the error.  It is used to reduce overshoot
+  and oscillation.
+
+## Tari throttle
+
+The `burn-sim` [repo]sitory was used to generate the results in this exploratory study.
+
+The primary module in the repository is the `TariThrottle` struct.
+
+This struct holds the following data:
+
+* The [#controller_parameters],
+* The output variable, `burn_rate`, and
+* The three functions that describe how the controller responds to the input variables.
+
+## Controller parameters
+
+The controller parameters are used to tune the controller behaviour. It allows the same code to favour slightly 
+different strategies within the same broader control goals without having to change the code.
+
+Specifically, the controller parameters are:
+
+* `kp`: determines the weight of the net burn component of the controller.  The net burn component is the difference
+  between the emission and the current rate of L2 token burn. When emission equals burn, the total supply of Tari
+  will remain constant.
+* `ki`: determines the weight of the integral component of the controller.  This is calculated as the difference
+  between the current total supply and the target supply. If the total circulating supply is at the target value, 
+  then this term will be zero.
+* `kd`: determines the weight of the derivative component of the controller.  This is currently not used, since the
+  controller is able to adequately control supply with just the proportional and integral terms.
+* `target_supply`: the target circulating supply of Tari.
+* `trigger_at`: the block height at which the controller logic becomes active.
+* `max`: the maximum burn rate that the controller will allow.
+* `min`: the minimum burn rate that the controller will allow. The maximum and minimum are important parameters to 
+  prevent extreme burn rates that could be detrimental to the sustainability of the network.
+
+## Controller inputs
+        
+The controller operates on `periods`. A period is the number of blocks over which the controller will operate 
+without being able to change the burn rate. In practice, this is determined by the epoch length of the Layer two. 
+
+The total quantity of fees collected across the entire network is only known at the end of every epoch. This is a 
+key input into the controller, and therefore we are limited to updating the burn rate at the end of each epoch as well.
+                              
+### Fee models
+Since we don't know what the Tari fees will be in the future, we can only carry out simulations based on various 
+_scenarios_ of fee growth. For example, we can model a low fee environment, an exponential fee growth environment, a 
+highly volatile fee environment, and so on. 
+
+In this study, we looked at the following fee models:
+
+* `Sigmoidal`: a sigmoidal growth model, which looks like an exponential growth model initially, but then levels off 
+  as the fees approach a maximum value. This is the most likely pattern to appear in practice, since it incorporates 
+  the idea that as fees become very high, the minimum transaction fee can be reduced that that total fee revenue 
+  remains constant, even as the network usage (in terms of transactions per second) continues to grow.
+* `Exponential`: a simple exponential growth model. This model assumes a constant annual growth rate in network fees.
+* `Sinusoidal`: a highly volatile fee environment, where the fees oscillate between a minimum and maximum value. This 
+  is the not likely scenario to appear in practice, but it is useful to test the robustness of the controller 
+  logic.
+* `Linear`: a simple linear growth model. This model assumes a constant annual growth rate in network fees. We 
+  simulate two versions of this model, one representing very low fee growth, and the other representing very high 
+  fee growth.
+
+### Emission model
+
+The second input to the controller is the number of token emitted over the preceding period. This is straightforward 
+to model, since the emission curve is known _a priori_. The currently proposed Minotari mainnet emission curve 
+parameters were used to generate the emission inputs for this study, including a 30% premine and a 1% tail emission 
+inflation rate.
+
+### Miscellaneous parameters
+
+The `trigger_at` parameter was generally set to start the controller after the first year of operation, when we 
+expect the layer two to go live on mainnet.
+
+The `target_supply` parameter was set to 15, 18 and 21 billion Tari to determine the effect of different supply 
+targets.
+
+The `initital_value`was set to `min` to allow the circulating supply to approach the target supply as quickly as 
+possible.
+
+The `min` and `max` parameters were set to 5% and 50% fee burn rates respectively.
+
+THe `period` was set to 720 blocks, or roughly one day. The epoch length for Tari has not been finalised yet, but it 
+should not be wildly different from this value.
+
+### Integer control
+
+Typical PID controllers use floating-point math in their control algorithms. However, the TariThrottle controller 
+will be run on a distributed set of machines that may be operating under different models for floating-point 
+operations, since the IEEE leaves some aspects of floating-point math 
+[unspecified](https://randomascii.wordpress.com/2013/07/16/floating-point-determinism/).
+
+This is not permissible in Tari, and therefore an integer-based approach to control is implemented in the `tari-sim` 
+[repo]sitory.
+
+Simply put, this involves scaling the error values by a constant to convert them to integers of roughly the same 
+order of magnitude, (via `error_i_scale`). The control parameters are also integers, expressed as "parts per million" 
+so that a value of 500,000 corresponds to 0.5 for example, while 10 corresponds to 0.00001. This give sufficient
+granularity to the control parameters to allow for effective tuning of the controller.
+
+
+## The simulations
+                         
+### Controller parameters
+
+A preliminary set of simulations was run to set the controller parameters to values that roughly achieve the stated 
+goal above. These simulations are omitted for brevity, but the result indicate that the following parameter range 
+provide a good balance between robustness and responsiveness of the Tari throttle:
+
+* `kp` = 0.0001 - 0.0003. A value closer to 100ppm gives more weight to achieving the target supply, while a value 
+  closer to 300ppm gives more weight to the net burn rate.  The simulations run scenarios for a `ki` values of 100,
+  200 and 300 ppm.
+* `ki` = -0.00035. This value is negative, since if we're above the target supply, we must increase the burn rate, 
+  and vice versa.
+* `kd` = 0. This value is not used in the current implementation, since the controller is able to adequately control 
+  supply with just the proportional and integral terms.
+
+### Target supply
+
+The simulations were run for target supplies of 15, 18 and 21 billion Tari. Simulations were run for target below 
+the quoted "initial supply" of 21 billion Tari, since this actually as very difficult value to achieve in practice 
+since the earliest it is possible to even reach this value (at ZERO burn rate) is after 28 - 30 years. This offers 
+very little flexibility to the control logic, and could easily introduce instability into the layer two ecosystem.
+
+For this reason, simulations were run with alternative target supplies of 15 and 18 billion Tari to compare how the 
+controller reacts with more scope to adjust the burn rate.
+
+### Fee models
+
+Five different fee models scenarios were employed:
+
+1. "Strong growth, tapering fees". This scenario describes strong fee growth in the network, reaching 2,500,000 XTR
+   in collected fees a day three years after the layer two launch with a maximum 
+   network fee rate of 5,000,000 Tari per day, or 58 XTR/s. At a minimum fee of 0.01 Tari per transaction, this 
+   corresponds to a network activity of around 5,800 tx/s, or roughly double the average activity of the Visa 
+   network. The 'tapering fees' part of the scenario refers to the fact that this scenario does allow the network to 
+   continue to grow, but that the total fee revenue remains somewhat constant by reducing the minimum transaction 
+   fee. This also matches the expectation that the price of XMR increases with network activity, and so reducing the 
+   transaction fee maintains sub-penny transaction fees in nominal USD terms.
+2. "Slower growth, tapering fees". This scenario is identical to "Strong growth, tapering fees", but with a lower 
+   maximum fee rate of 1,000,000 Tari per day, reaching 50% of this activity only 5 years after launch.
+3. "25% annual fee growth". This scenario describes a network that grows at 25% per year, without 
+   compensating by decreasing the minimum transaction fee.
+4. "10% annual fee growth". This scenario describes a network that grows at 10% per year, without 
+   compensating by decreasing the minimum transaction fee.
+5. "Unstable fees, low frequency". This scenario describes a network that has highly volatile fees, 
+   oscillating between 0 and 500,000 XTR per day over a 90-day period. This is not a realistic scenario, but it
+    is useful to test the robustness of the controller logic.
+6. "Unstable fees, high frequency". This scenario describes a network that has highly volatile fees, 
+   oscillating between 0 and 1,000,000 XTR per day over a 14-day period. This is not a very realistic scenario, but it
+    is useful to test the robustness of the controller logic under extremely volatile conditions.
+
+## Results
+
+A simulation was run for every combination of the variations in `kp`, `target_supply`, and `fee_model`. The results
+of all 54 simulation runs are given below.
+
+### 21 billion Tari target supply
+
+All of the following simulations were run with a target supply of 21 billion Tari.
+
+### 10% annual fee growth (low fee scenario)
+
+![10% annual fee growth](/assets/rfc-323/throttle_21000000000.000000%20T_10%25%20annual%20fee%20growth_0.000100.svg)
+
+Figure 1. Supply target: 21 billion XTR. 10% annual fee growth fee model. `kp` = 0.000100.
+
+![10% annual fee growth](/assets/rfc-323/throttle_21000000000.000000%20T_10%25%20annual%20fee%20growth_0.000200.svg)
+
+Figure 2. Supply target: 21 billion XTR. 10% annual fee growth fee model. `kp` = 0.000200.
+
+![10% annual fee growth](/assets/rfc-323/throttle_21000000000.000000%20T_10%25%20annual%20fee%20growth_0.000300.svg)
+
+Figure 3. Supply target: 21 billion XTR. 10% annual fee growth fee model. `kp` = 0.000300.
+
+### 10% annual fee growth (high fee scenario)
+
+![25% annual fee growth](/assets/rfc-323/throttle_21000000000.000000%20T_25%25%20annual%20fee%20growth_0.000100.svg)
+
+Figure 4. Supply target: 21 billion XTR. 25% annual fee growth fee model. `kp` = 0.000100.
+
+![25% annual fee growth](/assets/rfc-323/throttle_21000000000.000000%20T_25%25%20annual%20fee%20growth_0.000300.svg)
+
+Figure 5. Supply target: 21 billion XTR. 25% annual fee growth fee model. `kp` = 0.000300.
+
+### Slower growth, tapering fees
+
+![Slower growth, tapering fees](/assets/rfc-323/throttle_21000000000.000000%20T_Slower%20growth%2C%20tapering%20fees_0.000100.svg)
+
+Figure 6. Supply target: 21 billion XTR. Slower growth, tapering fees fee model. `kp` = 0.000100.
+
+![Slower growth, tapering fees](/assets/rfc-323/throttle_21000000000.000000%20T_Slower%20growth%2C%20tapering%20fees_0.000200.svg)
+
+Figure 7. Supply target: 21 billion XTR. Slower growth, tapering fees fee model. `kp` = 0.000200.
+
+![Slower growth, tapering fees](/assets/rfc-323/throttle_21000000000.000000%20T_Slower%20growth%2C%20tapering%20fees_0.000300.svg)
+
+Figure 8. Supply target: 21 billion XTR. Slower growth, tapering fees fee model. `kp` = 0.000300.
+
+### Strong growth, tapering fees
+
+![Strong growth, tapering fees](/assets/rfc-323/throttle_21000000000.000000%20T_Strong%20growth%2C%20tapering%20fees_0.000100.svg)
+
+Figure 9. Supply target: 21 billion XTR. Strong growth, tapering fees fee model. `kp` = 0.000100.
+
+![Strong growth, tapering fees](/assets/rfc-323/throttle_21000000000.000000%20T_Strong%20growth%2C%20tapering%20fees_0.000200.svg)
+
+Figure 10. Supply target: 21 billion XTR. Strong growth, tapering fees fee model. `kp` = 0.000200.
+
+![Strong growth, tapering fees](/assets/rfc-323/throttle_21000000000.000000%20T_Strong%20growth%2C%20tapering%20fees_0.000300.svg)
+
+Figure 11. Supply target: 21 billion XTR. Strong growth, tapering fees fee model. `kp` = 0.000300.
+
+### Unstable fees, high frequency
+
+![Unstable fees, high frequency](/assets/rfc-323/throttle_21000000000.000000%20T_Unstable%20fees%2C%20high%20frequency_0.000100.svg)
+
+Figure 12. Supply target: 21 billion XTR. Unstable fees, high frequency fee model. `kp` = 0.000100.
+
+![Unstable fees, high frequency](/assets/rfc-323/throttle_21000000000.000000%20T_Unstable%20fees%2C%20high%20frequency_0.000300.svg)
+
+Figure 13. Supply target: 21 billion XTR. Unstable fees, high frequency fee model. `kp` = 0.000300.
+
+### Unstable fees, low frequency
+
+![Unstable fees, low frequency](/assets/rfc-323/throttle_21000000000.000000%20T_Unstable%20fees%2C%20low%20frequency_0.000100.svg)
+
+Figure 14. Supply target: 21 billion XTR. Unstable fees, low frequency fee model. `kp` = 0.000100.
+
+![Unstable fees, low frequency](/assets/rfc-323/throttle_21000000000.000000%20T_Unstable%20fees%2C%20low%20frequency_0.000200.svg)
+
+Figure 15. Supply target: 21 billion XTR. Unstable fees, low frequency fee model. `kp` = 0.000200.
+
+![Unstable fees, low frequency](/assets/rfc-323/throttle_21000000000.000000%20T_Unstable%20fees%2C%20low%20frequency_0.000300.svg)
+
+Figure 16. Supply target: 21 billion XTR. Unstable fees, low frequency fee model. `kp` = 0.000300.
+
+### 18 billion Tari target supply
+
+All of the following simulations were run with a target supply of 18 billion Tari.
+
+### 10% annual fee growth (low fee scenario)
+
+![10% annual fee growth](/assets/rfc-323/throttle_18000000000.000000%20T_10%25%20annual%20fee%20growth_0.000100.svg)
+
+Figure 17. Supply target: 18 billion XTR. 10% annual fee growth fee model. `kp` = 0.000100.
+
+![10% annual fee growth](/assets/rfc-323/throttle_18000000000.000000%20T_10%25%20annual%20fee%20growth_0.000200.svg)
+
+Figure 18. Supply target: 18 billion XTR. 10% annual fee growth fee model. `kp` = 0.000200.
+
+![10% annual fee growth](/assets/rfc-323/throttle_18000000000.000000%20T_10%25%20annual%20fee%20growth_0.000300.svg)
+
+Figure 19. Supply target: 18 billion XTR. 10% annual fee growth fee model. `kp` = 0.000300.
+
+### 10% annual fee growth (high fee scenario)
+
+![25% annual fee growth](/assets/rfc-323/throttle_18000000000.000000%20T_25%25%20annual%20fee%20growth_0.000100.svg)
+
+Figure 20. Supply target: 18 billion XTR. 25% annual fee growth fee model. `kp` = 0.000100.
+
+![25% annual fee growth](/assets/rfc-323/throttle_18000000000.000000%20T_25%25%20annual%20fee%20growth_0.000200.svg)
+
+Figure 21. Supply target: 18 billion XTR. 25% annual fee growth fee model. `kp` = 0.000200.
+
+![25% annual fee growth](/assets/rfc-323/throttle_18000000000.000000%20T_25%25%20annual%20fee%20growth_0.000300.svg)
+
+Figure 22. Supply target: 18 billion XTR. 25% annual fee growth fee model. `kp` = 0.000300.
+
+### Slower growth, tapering fees
+
+![Slower growth, tapering fees](/assets/rfc-323/throttle_18000000000.000000%20T_Slower%20growth%2C%20tapering%20fees_0.000100.svg)
+
+Figure 23. Supply target: 18 billion XTR. Slower growth, tapering fees fee model. `kp` = 0.000100.
+
+![Slower growth, tapering fees](/assets/rfc-323/throttle_18000000000.000000%20T_Slower%20growth%2C%20tapering%20fees_0.000200.svg)
+
+Figure 24. Supply target: 18 billion XTR. Slower growth, tapering fees fee model. `kp` = 0.000200.
+
+![Slower growth, tapering fees](/assets/rfc-323/throttle_18000000000.000000%20T_Slower%20growth%2C%20tapering%20fees_0.000300.svg)
+
+Figure 25. Supply target: 18 billion XTR. Slower growth, tapering fees fee model. `kp` = 0.000300.
+
+### Strong growth, tapering fees
+
+![Strong growth, tapering fees](/assets/rfc-323/throttle_18000000000.000000%20T_Strong%20growth%2C%20tapering%20fees_0.000100.svg)
+
+Figure 26. Supply target: 18 billion XTR. Strong growth, tapering fees fee model. `kp` = 0.000100.
+
+![Strong growth, tapering fees](/assets/rfc-323/throttle_18000000000.000000%20T_Strong%20growth%2C%20tapering%20fees_0.000200.svg)
+
+Figure 27. Supply target: 18 billion XTR. Strong growth, tapering fees fee model. `kp` = 0.000200.
+
+![Strong growth, tapering fees](/assets/rfc-323/throttle_18000000000.000000%20T_Strong%20growth%2C%20tapering%20fees_0.000300.svg)
+
+Figure 28. Supply target: 18 billion XTR. Strong growth, tapering fees fee model. `kp` = 0.000300.
+
+### Unstable fees, high frequency
+
+![Unstable fees, high frequency](/assets/rfc-323/throttle_18000000000.000000%20T_Unstable%20fees%2C%20high%20frequency_0.000100.svg)
+
+Figure 29. Supply target: 18 billion XTR. Unstable fees, high frequency fee model. `kp` = 0.000100.
+
+![Unstable fees, high frequency](/assets/rfc-323/throttle_18000000000.000000%20T_Unstable%20fees%2C%20high%20frequency_0.000200.svg)
+
+Figure 30. Supply target: 18 billion XTR. Unstable fees, high frequency fee model. `kp` = 0.000200.
+
+![Unstable fees, high frequency](/assets/rfc-323/throttle_18000000000.000000%20T_Unstable%20fees%2C%20high%20frequency_0.000300.svg)
+
+Figure 31. Supply target: 18 billion XTR. Unstable fees, high frequency fee model. `kp` = 0.000300.
+
+### Unstable fees, low frequency
+
+![Unstable fees, low frequency](/assets/rfc-323/throttle_18000000000.000000%20T_Unstable%20fees%2C%20low%20frequency_0.000100.svg)
+
+Figure 32. Supply target: 18 billion XTR. Unstable fees, low frequency fee model. `kp` = 0.000100.
+
+![Unstable fees, low frequency](/assets/rfc-323/throttle_18000000000.000000%20T_Unstable%20fees%2C%20low%20frequency_0.000200.svg)
+
+Figure 33. Supply target: 18 billion XTR. Unstable fees, low frequency fee model. `kp` = 0.000200.
+
+![Unstable fees, low frequency](/assets/rfc-323/throttle_18000000000.000000%20T_Unstable%20fees%2C%20low%20frequency_0.000300.svg)
+
+Figure 34. Supply target: 18 billion XTR. Unstable fees, low frequency fee model. `kp` = 0.000300.
+
+### 15 billion Tari target supply
+
+All of the following simulations were run with a target supply of 15 billion Tari.
+
+### 10% annual fee growth (low fee scenario)
+
+![10% annual fee growth](/assets/rfc-323/throttle_15000000000.000000%20T_10%25%20annual%20fee%20growth_0.000100.svg)
+
+Figure 35. Supply target: 15 billion XTR. 10% annual fee growth fee model. `kp` = 0.000100.
+
+![10% annual fee growth](/assets/rfc-323/throttle_15000000000.000000%20T_10%25%20annual%20fee%20growth_0.000200.svg)
+
+Figure 36. Supply target: 15 billion XTR. 10% annual fee growth fee model. `kp` = 0.000200.
+
+![10% annual fee growth](/assets/rfc-323/throttle_15000000000.000000%20T_10%25%20annual%20fee%20growth_0.000300.svg)
+
+Figure 37. Supply target: 15 billion XTR. 10% annual fee growth fee model. `kp` = 0.000300.
+
+### 10% annual fee growth (high fee scenario)
+
+![25% annual fee growth](/assets/rfc-323/throttle_15000000000.000000%20T_25%25%20annual%20fee%20growth_0.000100.svg)
+
+Figure 38. Supply target: 15 billion XTR. 25% annual fee growth fee model. `kp` = 0.000100.
+
+![25% annual fee growth](/assets/rfc-323/throttle_15000000000.000000%20T_25%25%20annual%20fee%20growth_0.000300.svg)
+
+Figure 39. Supply target: 15 billion XTR. 25% annual fee growth fee model. `kp` = 0.000300.
+
+### Slower growth, tapering fees
+
+![Slower growth, tapering fees](/assets/rfc-323/throttle_15000000000.000000%20T_Slower%20growth%2C%20tapering%20fees_0.000100.svg)
+
+Figure 40. Supply target: 15 billion XTR. Slower growth, tapering fees fee model. `kp` = 0.000100.
+
+![Slower growth, tapering fees](/assets/rfc-323/throttle_15000000000.000000%20T_Slower%20growth%2C%20tapering%20fees_0.000200.svg)
+
+Figure 41. Supply target: 15 billion XTR. Slower growth, tapering fees fee model. `kp` = 0.000200.
+
+![Slower growth, tapering fees](/assets/rfc-323/throttle_15000000000.000000%20T_Slower%20growth%2C%20tapering%20fees_0.000300.svg)
+
+Figure 42. Supply target: 15 billion XTR. Slower growth, tapering fees fee model. `kp` = 0.000300.
+
+### Strong growth, tapering fees
+
+![Strong growth, tapering fees](/assets/rfc-323/throttle_15000000000.000000%20T_Strong%20growth%2C%20tapering%20fees_0.000100.svg)
+
+Figure 43. Supply target: 15 billion XTR. Strong growth, tapering fees fee model. `kp` = 0.000100.
+
+![Strong growth, tapering fees](/assets/rfc-323/throttle_15000000000.000000%20T_Strong%20growth%2C%20tapering%20fees_0.000200.svg)
+
+Figure 44. Supply target: 15 billion XTR. Strong growth, tapering fees fee model. `kp` = 0.000200.
+
+![Strong growth, tapering fees](/assets/rfc-323/throttle_15000000000.000000%20T_Strong%20growth%2C%20tapering%20fees_0.000300.svg)
+
+Figure 45. Supply target: 15 billion XTR. Strong growth, tapering fees fee model. `kp` = 0.000300.
+
+### Unstable fees, high frequency
+
+![Unstable fees, high frequency](/assets/rfc-323/throttle_15000000000.000000%20T_Unstable%20fees%2C%20high%20frequency_0.000100.svg)
+
+Figure 46. Supply target: 15 billion XTR. Unstable fees, high frequency fee model. `kp` = 0.000100.
+
+![Unstable fees, high frequency](/assets/rfc-323/throttle_15000000000.000000%20T_Unstable%20fees%2C%20high%20frequency_0.000200.svg)
+
+Figure 47. Supply target: 15 billion XTR. Unstable fees, high frequency fee model. `kp` = 0.000200.
+
+![Unstable fees, high frequency](/assets/rfc-323/throttle_15000000000.000000%20T_Unstable%20fees%2C%20high%20frequency_0.000300.svg)
+
+Figure 48. Supply target: 15 billion XTR. Unstable fees, high frequency fee model. `kp` = 0.000300.
+
+### Unstable fees, low frequency
+
+![Unstable fees, low frequency](/assets/rfc-323/throttle_15000000000.000000%20T_Unstable%20fees%2C%20low%20frequency_0.000100.svg)
+
+Figure 49. Supply target: 15 billion XTR. Unstable fees, low frequency fee model. `kp` = 0.000100.
+
+![Unstable fees, low frequency](/assets/rfc-323/throttle_15000000000.000000%20T_Unstable%20fees%2C%20low%20frequency_0.000200.svg)
+
+Figure 50. Supply target: 15 billion XTR. Unstable fees, low frequency fee model. `kp` = 0.000200.
+
+![Unstable fees, low frequency](/assets/rfc-323/throttle_15000000000.000000%20T_Unstable%20fees%2C%20low%20frequency_0.000300.svg)
+
+Figure 51. Supply target: 15 billion XTR. Unstable fees, low frequency fee model. `kp` = 0.000300.
+
+## Discussion
+
+### Low fees growth
+
+Figures 1-3, 17-19, and 35-37 show the results of the simulations for the 10% annual fee growth scenario. None of
+these scenarios produce sufficient fees to bring the circulating supply to the target within the 33-year simulation
+timeframe. The common feature of these simulations is that the controller hits the maximum burn rate of 50% and stays
+there for the remainder of the simulation. Increasing the `max` burn rate to a higher value might succeed in achieving
+the target supply, but this might mean that validator nodes cannot operate at break-even rates.
+
+Ultimately a poor growth in fee revenue -- in this model, never exceeding 30 tx/s over 30 years of operation, 
+represents a failure mode, not just of the controller, but of the network as a whole, since Tari adoption has never 
+taken off, and there's nothing a controller can do to fix that.
+
+### High fees growth
+
+At the other end of the spectrum, if Tari achieves runaway success, _and the minimum transaction fee is never 
+reduced to compensate_, then the controller will nominally be able to achieve the target supply. This is shown in 
+Figures 4-5. 
+In Figures 20-21, and 38-39, the tapering of supply only begins towards the end of the simulation period.
+
+However, it should be noted that indefinite fee growth is not sustainable from a token supply point of view, _unless 
+the inflation rate of the emission curve is increased to compensate_. This is not evident in these charts, but if 
+the simulation were to continue for several more years, the fee growth would eventually set the burn rate to its 
+minimum of 5% and the total circulating supply would eventually fall to zero.
+
+So, a few things to note about this scenario:
+
+* It's very unlikely to happen in practice that 25% network growth is achieved consistently for 30-40 years. 
+  Therefore, this scenario is largely illustrative of the controller's ability to handle extreme fee growth. And 
+  within fairly wide limits, we demonstrate that the throttle manages this very well.
+* The minimum burn rate of 5% could be reduced further without negatively impacting validator node revenues (in fact 
+  reducing the burn rate is beneficial for validator nodes).
+* In practice, it is not unreasonable to expect that the price of Tari in nominal USD terms would increase as the 
+  network usage increases, and so the minimum transaction fee would have to be reduced to maintain sub-penny 
+  transaction fees -- keeping the Tari network cheap to use for the average user. This entails that the total fee 
+  revenue would taper off, even as the network continues to grow. The Sigmoidal [fee model] is a better 
+  representation of this eventuality.
+
+### Unstable fee revenue
+
+Figures 12-16, 29-34, and 46-51 show the controller's response to various scenarios under which the fee revenue is 
+oscillating wildly. Under some scenarios, the target supply cannot be achieved even with the controller at minimum 
+burn rates. But in Figures 14-16, 32-34 and 46-51, the controller is able to maintain the supply target with very 
+small amounts of oscillation, by matching the fee oscillation with an oscillating burn rate.
+
+While this demonstrates that the throttle is able to achieve its design goals, one must question whether the
+wildly oscillating burn rates needed to achieve these goals are healthy for the network: 
+
+To maintain a constant 
+supply, as the fees increase, the burn rate _decreases_ to try and match the emission (which is roughly constant 
+over the oscillation period). From a validator node perspective, the portion of fees paid to them increases as fees 
+increase. That sounds great, but when fees decrease, they receive a _smaller_ percentage of the shrinking pool of 
+fees, and so they are doubly disadvantaged. Marginal validator nodes will be hit twice as hard, and be forced off 
+the network due to unfavourable economics, reducing the overall network capacity. When fees pick up again, 
+additional capacity will come online, but the lag between the increased usage and capacity could well lead to a 
+degradation in the user experience.
+
+### Slower growth with tapering fees
+
+The previous scenarios provide valuable insights into the controller's ability to handle extremes in network demand 
+in terms of fee growth patterns. However, these scenarios are not likely to play out in reality, at least not for 
+extended multi-decade periods.
+
+The scenarios represented in the "tapering fees" series are more indicative of the long-term macro behaviour of the 
+Tari fee growth. The two specific scenarios in this category reflect an initial exponential growth period followed 
+by a more sustainable linear fee growth rate, corresponding to reducing the minimum transaction fee over time while the 
+network continues to grow.
+
+In the "Slower growth" variant, the fee revenue grows from zero to 1,000,000 XTR per day over 5 years, and then 
+increases by 100,000 XTR/d per year after that.
+
+Figures 6-8 are all quite similar. These all use 21 billion XTR as a target and differ only in the weighting applied 
+to trying to achieve the target supply, vs. balancing burn rate and emission. 
+
+The slow growth rate allows the supply to reach the target value of 21 billion in about 20 years, at which point the 
+burn rate adjusts slightly to between 15% and 20% to maintain the target supply.
+
+Figures 23-25 shows what happens with a target supply of 18 billion XTR. Here the target is reached much sooner, 
+after around 9 years of mainnet operation. Here the effect is more pronounced, since an additional 3 billion XTR
+must be burned to maintain the target supply compared to the scenario with a 21 billion XTR target. But the 
+controller manages to maintain the target supply without much trouble.
+
+Figures 40-42 show the scenario with a target supply of 15 billion XTR. The lower target requires several years of 
+`max` burn with the supply overshooting the target before being pulled back onto the target. 
+
+### Strong growth with tapering fees
+
+The "Strong growth" variant of the tapering fees scenario assumes a much higher adoption rate, with fees growing to 
+5,000,000 XTR/d over 3 years, and then growing by 100,000 XTR/d per year after that.
+
+Figures 9-11 show the results of the simulations with a target supply of 21 billion XTR. Here the controller cannot 
+meet the target supply since it would require a burn rate of under 5%. This is illustrated by the purple lines not 
+moving off the `min` burn rate level for the entirety of the simulation period.
+
+Figures 26-28 show the results of the simulations with a target supply of 18 billion XTR. Here the controller is 
+able to meet the target supply, but only just. The burn rate rises only slightly above the `min` burn rate level
+and is essentially "just holding on".
+
+Finally, Figures 43-45 tell a similar but slightly more exaggerated version of the story.
+
+In practice, if the strong growth scenario were to play out, several interventions would be necessary to give the 
+controller room to maneuver. These would include reducing the `min` burn rate, and reucing the minimum transaction
+fee to maintain sub-penny transaction fees.
+
+## Conclusions
+
+This study shows that the TariThrottle controller is able to maintain a dual mandate of maintaining a target 
+circulating supply of Tari as well as a steady net burn rate over a wide range of fee growth scenarios.
+
+Some scenarios are unlikely to play out as described in practice. But they give valuable insights into how the 
+controller would respond in stressful situations, short-term shocks and deviations, and offer an indication of the 
+robustness of the controller algorithm.
+
+The main scenario where the controller failed was where the fee growth was so low that the maximum burn rate was 
+less than the tail emission. Under these conditions, the total supply exceeds the target supply. In practice, this 
+mode represents a failure of the Tari ecosystem as a whole. A limiting controller would not be the greatest concern 
+at this point.
+
+However, the biggest conclusion to draw from this study is that the stated dual mandate goals of controlling for a 
+target circulating supply is ill-advised.
+
+There are several scenarios where maintaining a target supply is detrimental to the sustainability of 
+validator nodes and to the ability of the network to provide surge capacity during sudden high periods of network demand.
+
+The oscillating fee revenue scenarios are particularly illuminating, since they demonstrate that as fees are falling,
+the controller _increases_ the burn rate to try and match the emission. This results in a double loss of revenue for
+validator nodes, since they're receiving a smaller slice of a shrinking pie. This will force them offline sooner 
+than they otherwise would have. When fees recover, it may take some time for those nodes to come back online, and as 
+a result, users experience lags in the network.
+
+It's clear that some additional studies are needed. In particular, we need to identify and maximise for the health of 
+the network, rather than a fixed supply target. Sometimes these two goals will be aligned, but it behooves us to 
+remember which variables represent the tail, and which represent the dog.
+
+As a start, the following conditions are critical to be met at all times to ensure a healthy network:
+* There must be a **near-constant** driving force to burn Minotari and redeem them as Tari. Similar to how a kite 
+  must always have tension in the string for the operator to be able to fly the kite. Brief periods of slack, 
+  corresponding to the price of Tari dropping below 1 XTR, are acceptable, since the operator can draw the slack 
+  in to regain tension (by continuing to burn Tari with no new redemptions), but if the situation persists, the kite 
+  will crash. 
+* Marginal validator nodes must be able to operate at break-even rates at approximately 50% utilisation. Marginal 
+  VNs are those that can spin up very quickly to meet surge demand, but are more expensive to run because of this. 
+  Typically, VNs running on spot EC2 instances fall into this category.
+* Base-load validator nodes must be able to operate at break-even rates at approximately 20% utilisation. Base VNs are 
+  those that are always online, and are typically running on reserved EC2 instances are even cheaper server 
+  infrastructure. The 20% value means that they will stay online all the time, as well as having 5x surge capacity 
+  in reserve at all times.
+* The minimum transaction fee should be under 1c in USD terms.
+
+A throttle the incorporates these target conditions will be the subject of future work.
+
+
+
+
+
+
+
+
+[repo]: https://github.com/tari-project/burn-sim "TariThrottle simulation repository"

--- a/src/RFC-0323_TariThrottle.md
+++ b/src/RFC-0323_TariThrottle.md
@@ -88,13 +88,13 @@ This RFC provides an introductory exploratory analysis into the mechanisms behin
 TariThrottle is a simple process controller designed to modulate the layer two burn rate in order to achieve two 
 goals:
 
-* Primarily, keep the emission and burn rate roughly balanced (ensuring long-term sustainability of Tari), and
+* Primarily, keep the emission and burn rate roughly balanced (ensuring the long-term sustainability of Tari), and
 * Secondarily, to maintain the total circulating supply at a target value (satisfying an implicit assumption in 
   cryptocurrencies that token supplies are finite).
 
-A proof-of-concept controller has been implemented and tested in a simulation environment ([repo]). As the results 
-below attest, the controller logic is sufficient to achieve these goals, even under highly volatile layer two fee 
-conditions. 
+A proof-of-concept controller has been implemented and tested in a simulation environment ([repository]). As the 
+results below attest, the controller logic is sufficient to achieve these goals, even under highly volatile layer 
+two fee conditions. 
 
 However, the controller achieves the goals at the expense of a rapidly changing layer two burn rate, which may be 
 detrimental to the sustainability of validator nodes. 
@@ -106,7 +106,8 @@ whit:
 * maintain a constant demand gradient so that under normal circumstances there is _always_ a demand for new Tari and 
   thus Minotari are constantly being burnt to satisfy this demand,
 * marginal Validator Nodes are able to operate at or near break-even rates, while maintaining a healthy reserve of 
-  capacity for surge demand, and 
+  capacity for surge demand, 
+* minimum transaction fees remain below $0.01 in today's money, and 
 * the supply of Minotari is sustainable over the long-term.
 
 Therefore, the conclusion of this study is not to abandon the original targets of the TariThrottle completely, 
@@ -121,8 +122,8 @@ a follow-up study.
 TariThrottle is based on a simple
 [PID controller](https://en.wikipedia.org/wiki/Proportional%E2%80%93integral%E2%80%93derivative_controller) design.
 
-PID controllers are a type of control system that uses feedback to control the system.  They are widely used in
-industrial control systems and have been used in many other applications.
+PID controllers are a type of control system that uses feedback to maintain a system in a desired state.  They are 
+widely used in industrial control systems.
 
 The PID controller has three components:
 * Proportional: This component is proportional to the error between the setpoint and the current value.  It is
@@ -134,20 +135,21 @@ The PID controller has three components:
 
 ## Tari throttle
 
-The `burn-sim` [repo]sitory was used to generate the results in this exploratory study.
+The `burn-sim` [repository] was used to generate the results in this exploratory study.
 
 The primary module in the repository is the `TariThrottle` struct.
 
 This struct holds the following data:
 
-* The [#controller_parameters],
-* The output variable, `burn_rate`, and
+* The [controller parameters](#controller-parameters),
+* The output variable, `burn_rate`. The burn rate is defined as the fraction of fees collected on the layer 2 that 
+  are burnt as exhaust (see the [turbine model]), and
 * The three functions that describe how the controller responds to the input variables.
 
 ## Controller parameters
 
-The controller parameters are used to tune the controller behaviour. It allows the same code to favour slightly 
-different strategies within the same broader control goals without having to change the code.
+The controller parameters are used to tune the controller behaviour. They give operators the ability to fine-tune 
+the behaviour of the controller without having to change the underlying code.
 
 Specifically, the controller parameters are:
 
@@ -167,11 +169,13 @@ Specifically, the controller parameters are:
 
 ## Controller inputs
         
-The controller operates on `periods`. A period is the number of blocks over which the controller will operate 
-without being able to change the burn rate. In practice, this is determined by the epoch length of the Layer two. 
+The controller operates over `periods`. A period is the number of blocks over which the controller will operate 
+without being able to change the burn rate. In practice, this is determined by the epoch length of the Layer two.  
 
 The total quantity of fees collected across the entire network is only known at the end of every epoch. This is a 
 key input into the controller, and therefore we are limited to updating the burn rate at the end of each epoch as well.
+
+For this study, the period length is set to 720 blocks, or roughly one day.
                               
 ### Fee models
 Since we don't know what the Tari fees will be in the future, we can only carry out simulations based on various 
@@ -182,19 +186,16 @@ In this study, we looked at the following fee models:
 
 * `Sigmoidal`: a sigmoidal growth model, which looks like an exponential growth model initially, but then levels off 
   as the fees approach a maximum value. This is the most likely pattern to appear in practice, since it incorporates 
-  the idea that as fees become very high, the minimum transaction fee can be reduced that that total fee revenue 
-  remains constant, even as the network usage (in terms of transactions per second) continues to grow.
+  the idea that as fees become very high, the minimum transaction fee can be reduced so that total fee revenue 
+  grows sustainably, even as the network usage (in terms of transactions per second) continues to grow.
 * `Exponential`: a simple exponential growth model. This model assumes a constant annual growth rate in network fees.
 * `Sinusoidal`: a highly volatile fee environment, where the fees oscillate between a minimum and maximum value. This 
   is the not likely scenario to appear in practice, but it is useful to test the robustness of the controller 
   logic.
-* `Linear`: a simple linear growth model. This model assumes a constant annual growth rate in network fees. We 
-  simulate two versions of this model, one representing very low fee growth, and the other representing very high 
-  fee growth.
 
 ### Emission model
 
-The second input to the controller is the number of token emitted over the preceding period. This is straightforward 
+The second input to the controller is the number of tokens emitted over the preceding period. This is straightforward 
 to model, since the emission curve is known _a priori_. The currently proposed Minotari mainnet emission curve 
 parameters were used to generate the emission inputs for this study, including a 30% premine and a 1% tail emission 
 inflation rate.
@@ -215,7 +216,7 @@ The `min` and `max` parameters were set to 5% and 50% fee burn rates respectivel
 THe `period` was set to 720 blocks, or roughly one day. The epoch length for Tari has not been finalised yet, but it 
 should not be wildly different from this value.
 
-### Integer control
+### Integer-based division
 
 Typical PID controllers use floating-point math in their control algorithms. However, the TariThrottle controller 
 will be run on a distributed set of machines that may be operating under different models for floating-point 
@@ -223,7 +224,7 @@ operations, since the IEEE leaves some aspects of floating-point math
 [unspecified](https://randomascii.wordpress.com/2013/07/16/floating-point-determinism/).
 
 This is not permissible in Tari, and therefore an integer-based approach to control is implemented in the `tari-sim` 
-[repo]sitory.
+[repository].
 
 Simply put, this involves scaling the error values by a constant to convert them to integers of roughly the same 
 order of magnitude, (via `error_i_scale`). The control parameters are also integers, expressed as "parts per million" 
@@ -235,7 +236,7 @@ granularity to the control parameters to allow for effective tuning of the contr
                          
 ### Controller parameters
 
-A preliminary set of simulations was run to set the controller parameters to values that roughly achieve the stated 
+A preliminary batch of simulations was run to set the controller parameters to values that roughly achieve the stated 
 goal above. These simulations are omitted for brevity, but the result indicate that the following parameter range 
 provide a good balance between robustness and responsiveness of the Tari throttle:
 
@@ -249,10 +250,14 @@ provide a good balance between robustness and responsiveness of the Tari throttl
 
 ### Target supply
 
-The simulations were run for target supplies of 15, 18 and 21 billion Tari. Simulations were run for target below 
-the quoted "initial supply" of 21 billion Tari, since this actually as very difficult value to achieve in practice 
-since the earliest it is possible to even reach this value (at ZERO burn rate) is after 28 - 30 years. This offers 
-very little flexibility to the control logic, and could easily introduce instability into the layer two ecosystem.
+The simulations were run for target circulating supplies of 15, 18 and 21 billion Tari. 
+
+Target values other than the quoted "initial supply" of 21 billion Tari were used, because it is actually quite 
+difficult to achieve the 21 billion target in practice. This is because the earliest it is possible to even reach 
+this value (at ZERO burn rate) is after about 15 years. 
+
+This offers very little flexibility to the control logic, and could easily introduce instability into the layer two 
+ecosystem.
 
 For this reason, simulations were run with alternative target supplies of 15 and 18 billion Tari to compare how the 
 controller reacts with more scope to adjust the burn rate.
@@ -261,31 +266,31 @@ controller reacts with more scope to adjust the burn rate.
 
 Five different fee models scenarios were employed:
 
-1. "Strong growth, tapering fees". This scenario describes strong fee growth in the network, reaching 2,500,000 XTR
-   in collected fees a day three years after the layer two launch with a maximum 
-   network fee rate of 5,000,000 Tari per day, or 58 XTR/s. At a minimum fee of 0.01 Tari per transaction, this 
+1. "Strong growth, tapering fees". This scenario describes strong fee growth in the network, reaching 5,000,000 
+   Tari per day around 6 years after the launch of the layer 2. At a minimum fee of 0.01 Tari per transaction, this 
    corresponds to a network activity of around 5,800 tx/s, or roughly double the average activity of the Visa 
-   network. The 'tapering fees' part of the scenario refers to the fact that this scenario does allow the network to 
-   continue to grow, but that the total fee revenue remains somewhat constant by reducing the minimum transaction 
-   fee. This also matches the expectation that the price of XMR increases with network activity, and so reducing the 
-   transaction fee maintains sub-penny transaction fees in nominal USD terms.
+   network. The 'tapering fees' part of the scenario refers to the fact that this scenario does allow 
+   the network to continue to grow, but that the total fee revenue grows at a modest 100,000 XTR/d per year. This 
+   would be achieved by reducing the minimum transaction fee. This also matches the expectation that the price of 
+   XMR increases with network activity, and so reducing the transaction fee maintains sub-penny transaction fees in 
+   nominal USD terms.
 2. "Slower growth, tapering fees". This scenario is identical to "Strong growth, tapering fees", but with a lower 
-   maximum fee rate of 1,000,000 Tari per day, reaching 50% of this activity only 5 years after launch.
+   maximum fee rate of 1,000,000 Tari per day.
 3. "25% annual fee growth". This scenario describes a network that grows at 25% per year, without 
    compensating by decreasing the minimum transaction fee.
 4. "10% annual fee growth". This scenario describes a network that grows at 10% per year, without 
    compensating by decreasing the minimum transaction fee.
-5. "Unstable fees, low frequency". This scenario describes a network that has highly volatile fees, 
+5. "Unstable fees, low frequency". This scenario describes a network that has volatile fees, 
    oscillating between 0 and 500,000 XTR per day over a 90-day period. This is not a realistic scenario, but it
     is useful to test the robustness of the controller logic.
-6. "Unstable fees, high frequency". This scenario describes a network that has highly volatile fees, 
+6. "Unstable fees, high frequency". This scenario describes a network that has extremely volatile fees, 
    oscillating between 0 and 1,000,000 XTR per day over a 14-day period. This is not a very realistic scenario, but it
     is useful to test the robustness of the controller logic under extremely volatile conditions.
 
 ## Results
 
 A simulation was run for every combination of the variations in `kp`, `target_supply`, and `fee_model`. The results
-of all 54 simulation runs are given below.
+of all 50+ simulation runs are given below.
 
 ### 21 billion Tari target supply
 
@@ -544,7 +549,7 @@ Figure 51. Supply target: 15 billion XTR. Unstable fees, low frequency fee model
 ### Low fees growth
 
 Figures 1-3, 17-19, and 35-37 show the results of the simulations for the 10% annual fee growth scenario. None of
-these scenarios produce sufficient fees to bring the circulating supply to the target within the 33-year simulation
+these scenarios produce sufficient fees to reduce the circulating supply to the target within the 33-year simulation
 timeframe. The common feature of these simulations is that the controller hits the maximum burn rate of 50% and stays
 there for the remainder of the simulation. Increasing the `max` burn rate to a higher value might succeed in achieving
 the target supply, but this might mean that validator nodes cannot operate at break-even rates.
@@ -556,8 +561,10 @@ taken off, and there's nothing a controller can do to fix that.
 ### High fees growth
 
 At the other end of the spectrum, if Tari achieves runaway success, _and the minimum transaction fee is never 
-reduced to compensate_, then the controller will nominally be able to achieve the target supply. This is shown in 
-Figures 4-5. 
+reduced to compensate_, then the controller will be able to maintain the target circulating supply of Tari during the 
+33-year simulation timeframe. 
+
+This is shown in Figures 4 and 5.
 In Figures 20-21, and 38-39, the tapering of supply only begins towards the end of the simulation period.
 
 However, it should be noted that indefinite fee growth is not sustainable from a token supply point of view, _unless 
@@ -575,18 +582,21 @@ So, a few things to note about this scenario:
 * In practice, it is not unreasonable to expect that the price of Tari in nominal USD terms would increase as the 
   network usage increases, and so the minimum transaction fee would have to be reduced to maintain sub-penny 
   transaction fees -- keeping the Tari network cheap to use for the average user. This entails that the total fee 
-  revenue would taper off, even as the network continues to grow. The Sigmoidal [fee model] is a better 
+  revenue would taper off, even as the network continues to grow. The Sigmoidal [fee model](#fee-models) is a better 
   representation of this eventuality.
 
 ### Unstable fee revenue
 
 Figures 12-16, 29-34, and 46-51 show the controller's response to various scenarios under which the fee revenue is 
-oscillating wildly. Under some scenarios, the target supply cannot be achieved even with the controller at minimum 
-burn rates. But in Figures 14-16, 32-34 and 46-51, the controller is able to maintain the supply target with very 
-small amounts of oscillation, by matching the fee oscillation with an oscillating burn rate.
+oscillating wildly. Under some scenarios, notably Figures 12 and 13, the target supply cannot be achieved even with the 
+controller at minimum burn rates. This is symptomatic of the point made previously that a target supply of 21 
+billion offers very little room for the controller to maneuver. 
+
+In Figures 14-16, 32-34 and 46-51, the controller is able to maintain the supply target with very 
+small amounts of oscillation, by synchronising the fee oscillation with an oscillating burn rate.
 
 While this demonstrates that the throttle is able to achieve its design goals, one must question whether the
-wildly oscillating burn rates needed to achieve these goals are healthy for the network: 
+wildly oscillating burn rates needed to achieve these goals are healthy for the network. 
 
 To maintain a constant 
 supply, as the fees increase, the burn rate _decreases_ to try and match the emission (which is roughly constant 
@@ -618,9 +628,9 @@ The slow growth rate allows the supply to reach the target value of 21 billion i
 burn rate adjusts slightly to between 15% and 20% to maintain the target supply.
 
 Figures 23-25 shows what happens with a target supply of 18 billion XTR. Here the target is reached much sooner, 
-after around 9 years of mainnet operation. Here the effect is more pronounced, since an additional 3 billion XTR
-must be burned to maintain the target supply compared to the scenario with a 21 billion XTR target. But the 
-controller manages to maintain the target supply without much trouble.
+after around 9 years of mainnet operation. In these simulations, the effect of the controller is more pronounced, 
+since an additional 3 billion XTR must be burned to maintain the target supply compared to the scenario with a 21 
+billion XTR target.
 
 Figures 40-42 show the scenario with a target supply of 15 billion XTR. The lower target requires several years of 
 `max` burn with the supply overshooting the target before being pulled back onto the target. 
@@ -653,13 +663,14 @@ Some scenarios are unlikely to play out as described in practice. But they give 
 controller would respond in stressful situations, short-term shocks and deviations, and offer an indication of the 
 robustness of the controller algorithm.
 
-The main scenario where the controller failed was where the fee growth was so low that the maximum burn rate was 
-less than the tail emission. Under these conditions, the total supply exceeds the target supply. In practice, this 
-mode represents a failure of the Tari ecosystem as a whole. A limiting controller would not be the greatest concern 
-at this point.
+The most common instances of the controller failing to achieve its target was when the fee growth was so low that 
+the maximum burn rate was less than the tail emission. 
 
-However, the biggest conclusion to draw from this study is that the stated dual mandate goals of controlling for a 
-target circulating supply is ill-advised.
+Under these conditions, the tokens that are emitted exceed the maximum that can be burnt. In practice, this 
+mode represents a failure of the Tari ecosystem as a whole and a limiting controller would not be the greatest 
+concern at this point.
+
+However, the biggest conclusion to draw from this study is that the stated dual mandate is ill-advised.
 
 There are several scenarios where maintaining a target supply is detrimental to the sustainability of 
 validator nodes and to the ability of the network to provide surge capacity during sudden high periods of network demand.
@@ -670,12 +681,19 @@ validator nodes, since they're receiving a smaller slice of a shrinking pie. Thi
 than they otherwise would have. When fees recover, it may take some time for those nodes to come back online, and as 
 a result, users experience lags in the network.
 
+Many scenarios illustrate that the controller can effectively do nothing for between 5 and 15 years while it waits 
+for the circulating supply to reach its target. This effectively means that the controller is powerless to do 
+anything to help with validator node profitability or excessive network fees during this period, because its 
+control mandate is misaligned with the health of the network.
+
 It's clear that some additional studies are needed. In particular, we need to identify and maximise for the health of 
 the network, rather than a fixed supply target. Sometimes these two goals will be aligned, but it behooves us to 
 remember which variables represent the tail, and which represent the dog.
 
-As a start, the following conditions are critical to be met at all times to ensure a healthy network:
-* There must be a **near-constant** driving force to burn Minotari and redeem them as Tari. Similar to how a kite 
+As a minimum, the following factors should be considered, since they directly relate to the health of the ecosystem, 
+in that they incentivise validation nodes to remain online and keep the Tari network affordable: 
+
+* There must be a **near-constant** driving force to burn Minotari and redeem them as Tari, similar to how a kite 
   must always have tension in the string for the operator to be able to fly the kite. Brief periods of slack, 
   corresponding to the price of Tari dropping below 1 XTR, are acceptable, since the operator can draw the slack 
   in to regain tension (by continuing to burn Tari with no new redemptions), but if the situation persists, the kite 
@@ -683,13 +701,14 @@ As a start, the following conditions are critical to be met at all times to ensu
 * Marginal validator nodes must be able to operate at break-even rates at approximately 50% utilisation. Marginal 
   VNs are those that can spin up very quickly to meet surge demand, but are more expensive to run because of this. 
   Typically, VNs running on spot EC2 instances fall into this category.
-* Base-load validator nodes must be able to operate at break-even rates at approximately 20% utilisation. Base VNs are 
-  those that are always online, and are typically running on reserved EC2 instances are even cheaper server 
-  infrastructure. The 20% value means that they will stay online all the time, as well as having 5x surge capacity 
-  in reserve at all times.
+* Long-term validator nodes must be able to operate at break-even rates at approximately 20% utilisation. These 
+  nodes are those that are always online, and are typically running on reserved EC2 instances or even cheaper server 
+  infrastructure. The 20% value means that they will stay online all the time, whilst keeping 5x surge capacity 
+  in reserve.
+* The supply of Minotari never goes to zero.
 * The minimum transaction fee should be under 1c in USD terms.
 
-A throttle the incorporates these target conditions will be the subject of future work.
+A controller model that incorporates these target conditions will be the subject of future work.
 
 
 
@@ -698,4 +717,5 @@ A throttle the incorporates these target conditions will be the subject of futur
 
 
 
-[repo]: https://github.com/tari-project/burn-sim "TariThrottle simulation repository"
+[repository]: https://github.com/tari-project/burn-sim "TariThrottle simulation repository"
+[turbine model]: /RFC-0320_TurbineModel.html "Turbine model"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -54,6 +54,7 @@
   - [RFC-8002: Transaction protocol](RFC-8002_TransactionProtocol.md)
   - [RFC-8003: Tari Use Cases](RFC-8003_TariUseCases.md)
   - [RFC-0385: Privacy-enabled Stablecoin contract design](RFC-0385_StableCoins.md)
+  - [RFC-0323: Tari throttle exploratory analysis](RFC-0323_TariThrottle.md)
   
 - [Deprecated RFCs](deprecated.md)
 

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_10% annual fee growth_0.000100.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_10% annual fee growth_0.000100.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+10% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,956 88,947 93,939 97,931 102,923 106,914 111,906 115,899 120,891 124,883 129,876 133,869 138,861 142,854 147,847 151,840 156,833 160,827 165,820 169,813 174,807 178,801 183,794 187,788 192,782 196,776 201,770 205,765 210,759 214,753 219,748 223,742 228,737 232,732 237,727 241,722 246,716 250,712 255,707 259,702 264,697 268,692 273,688 277,683 282,679 286,674 291,670 295,666 300,662 304,658 309,653 313,649 318,645 322,642 327,638 331,634 336,630 340,627 345,623 349,619 354,616 358,613 363,609 367,606 372,602 376,599 381,596 385,593 390,590 394,587 399,584 403,581 408,578 412,575 417,572 421,569 426,567 430,564 435,561 439,559 444,556 448,554 453,551 457,549 462,546 466,544 471,542 475,539 480,537 484,535 489,533 493,530 498,528 502,526 506,524 511,522 515,520 520,518 524,516 529,514 533,512 538,510 542,509 547,507 551,505 556,503 560,502 565,500 569,498 574,497 578,495 583,493 587,492 592,490 596,489 601,487 605,486 610,484 614,483 619,481 623,480 628,479 632,477 637,476 641,475 646,473 650,472 655,471 659,470 664,468 668,467 673,466 677,465 682,464 686,463 691,462 695,460 700,459 704,458 709,457 713,456 718,455 722,454 727,453 731,452 736,451 740,451 745,450 749,449 754,448 758,447 763,446 767,445 772,444 776,444 781,443 785,442 790,441 794,440 799,440 803,439 808,438 812,438 817,437 821,436 826,435 830,435 835,434 839,433 844,433 848,432 853,432 857,431 862,430 866,430 871,429 875,429 880,428 884,427 889,427 893,426 898,426 902,425 907,425 911,424 916,424 920,423 925,423 929,422 934,422 938,421 943,421 947,420 952,420 956,419 961,419 965,418 970,418 974,417 979,417 983,416 988,416 992,415 997,415 1001,414 1006,414 1010,413 1015,413 1019,412 1024,412 1028,411 1033,411 1037,410 1042,410 1046,409 1051,409 1055,408 1060,408 1064,407 1069,407 1073,406 1078,406 1082,405 1087,405 1091,404 1096,404 1100,403 1105,403 1109,402 1114,402 1118,401 1123,401 1127,400 1132,400 1136,399 1141,399 1145,398 1150,398 1154,397 1159,397 1163,396 1168,396 1172,395 1177,395 1181,394 1186,394 1190,393 1195,393 1199,392 1204,392 1208,391 1213,391 1217,390 1222,390 1226,389 1231,389 1235,388 1240,388 1244,387 1249,387 1253,386 1258,386 1262,385 1267,385 1271,384 1276,384 1280,383 1285,383 1289,382 1294,382 1298,381 1303,381 1307,380 1312,380 1316,379 1321,379 1325,378 1330,378 1334,377 1339,377 1343,376 1348,376 1352,375 1357,374 1361,374 1366,373 1370,373 1375,372 1379,372 1384,371 1388,371 1393,370 1397,370 1402,369 1406,369 1411,368 1415,368 1420,367 1424,367 1429,366 1433,366 1438,365 1442,365 1447,364 1451,364 1456,363 1460,363 1465,362 1469,362 1474,361 1478,361 1483,360 1487,360 1492,359 1496,359 1501,358 1505,358 1510,357 1514,357 1519,356 1523,356 1528,355 1532,355 1537,354 1541,354 1546,353 1550,353 1555,352 1559,352 1564,351 1568,351 1573,350 1577,350 1582,349 1586,349 1591,348 1595,348 1600,347 1604,347 1609,346 1613,346 1618,345 1622,345 1626,344 1631,344 1635,343 1640,343 1644,342 1649,342 1653,341 1658,341 1662,340 1667,340 1671,339 1676,339 1680,338 1685,338 1689,337 1694,337 1698,336 1703,336 1707,335 1712,335 1716,334 1721,333 1725,333 1730,332 1734,332 1739,331 1743,331 1748,330 1752,330 1757,329 1761,329 1766,328 1770,328 1775,327 1779,327 1784,326 1788,326 1793,325 1797,325 1802,324 1806,324 1811,323 1815,323 1820,322 1824,322 1829,321 1833,321 1838,320 1842,320 1847,319 1851,319 1856,318 1860,318 1865,318 1869,317 1874,317 1878,316 1883,316 1887,315 1892,315 1896,314 1901,314 1905,313 1910,313 1914,312 1919,312 1923,311 1928,311 1932,310 1937,310 1941,309 1946,309 1950,308 1955,308 1959,307 1964,307 1968,306 1973,306 1977,305 1982,305 1986,304 1991,304 1995,303 2000,303 2004,302 2009,302 2013,301 2018,301 2022,300 2027,300 2031,299 2036,299 2040,298 2045,298 2049,297 2054,297 2058,296 2063,296 2067,296 2072,295 2076,295 2081,294 2085,294 2090,293 2094,293 2099,292 2103,292 2108,291 2112,291 2117,290 2121,290 2126,289 2130,289 2135,288 2139,288 2144,287 2148,287 2153,286 2157,286 2162,286 2166,285 2171,285 2175,284 2180,284 2184,283 2189,283 2193,282 2198,282 2202,281 2207,281 2211,280 2216,280 2220,279 2225,279 2229,279 2234,278 2238,278 2243,277 2247,277 2252,276 2256,276 2261,275 2265,275 2270,274 2274,274 2279,274 2283,273 2288,273 2292,272 2297,272 2301,271 2306,271 2310,270 2315,270 2319,270 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2206" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2206 74,2206 "/>
+<text x="65" y="2088" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2088 74,2088 "/>
+<text x="65" y="1970" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1970 74,1970 "/>
+<text x="65" y="1852" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1852 74,1852 "/>
+<text x="65" y="1734" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1734 74,1734 "/>
+<text x="65" y="1616" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1616 74,1616 "/>
+<text x="65" y="1497" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1497 74,1497 "/>
+<text x="65" y="1379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1379 74,1379 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2277 151,2277 156,2276 160,2276 165,2276 169,2275 174,2275 178,2275 183,2275 187,2274 192,2274 196,2274 201,2273 205,2273 210,2273 214,2272 219,2272 223,2272 228,2271 232,2271 237,2271 241,2270 246,2270 250,2270 255,2269 259,2269 264,2269 268,2268 273,2268 277,2268 282,2267 286,2267 291,2266 295,2266 300,2266 304,2265 309,2265 313,2265 318,2264 322,2264 327,2263 331,2263 336,2263 340,2262 345,2262 349,2262 354,2261 358,2261 363,2260 367,2260 372,2260 376,2259 381,2259 385,2258 390,2258 394,2257 399,2257 403,2257 408,2256 412,2256 417,2255 421,2255 426,2254 430,2254 435,2254 439,2253 444,2253 448,2252 453,2252 457,2251 462,2251 466,2250 471,2250 475,2249 480,2249 484,2249 489,2248 493,2248 498,2247 502,2247 506,2246 511,2246 515,2245 520,2245 524,2244 529,2244 533,2243 538,2243 542,2242 547,2242 551,2241 556,2240 560,2240 565,2239 569,2239 574,2238 578,2238 583,2237 587,2237 592,2236 596,2236 601,2235 605,2234 610,2234 614,2233 619,2233 623,2232 628,2232 632,2231 637,2230 641,2230 646,2229 650,2229 655,2228 659,2227 664,2227 668,2226 673,2226 677,2225 682,2224 686,2224 691,2223 695,2222 700,2222 704,2221 709,2221 713,2220 718,2219 722,2219 727,2218 731,2217 736,2217 740,2216 745,2215 749,2214 754,2214 758,2213 763,2212 767,2212 772,2211 776,2210 781,2210 785,2209 790,2208 794,2207 799,2207 803,2206 808,2205 812,2204 817,2204 821,2203 826,2202 830,2201 835,2201 839,2200 844,2199 848,2198 853,2197 857,2197 862,2196 866,2195 871,2194 875,2193 880,2193 884,2192 889,2191 893,2190 898,2189 902,2188 907,2188 911,2187 916,2186 920,2185 925,2184 929,2183 934,2182 938,2181 943,2180 947,2180 952,2179 956,2178 961,2177 965,2176 970,2175 974,2174 979,2173 983,2172 988,2171 992,2170 997,2169 1001,2168 1006,2167 1010,2166 1015,2165 1019,2164 1024,2163 1028,2162 1033,2161 1037,2160 1042,2159 1046,2158 1051,2157 1055,2156 1060,2155 1064,2154 1069,2153 1073,2152 1078,2151 1082,2150 1087,2148 1091,2147 1096,2146 1100,2145 1105,2144 1109,2143 1114,2142 1118,2141 1123,2139 1127,2138 1132,2137 1136,2136 1141,2135 1145,2134 1150,2132 1154,2131 1159,2130 1163,2129 1168,2127 1172,2126 1177,2125 1181,2124 1186,2122 1190,2121 1195,2120 1199,2119 1204,2117 1208,2116 1213,2115 1217,2113 1222,2112 1226,2111 1231,2109 1235,2108 1240,2107 1244,2105 1249,2104 1253,2103 1258,2101 1262,2100 1267,2098 1271,2097 1276,2096 1280,2094 1285,2093 1289,2091 1294,2090 1298,2088 1303,2087 1307,2085 1312,2084 1316,2082 1321,2081 1325,2079 1330,2078 1334,2076 1339,2075 1343,2073 1348,2071 1352,2070 1357,2068 1361,2067 1366,2065 1370,2063 1375,2062 1379,2060 1384,2058 1388,2057 1393,2055 1397,2053 1402,2052 1406,2050 1411,2048 1415,2046 1420,2045 1424,2043 1429,2041 1433,2039 1438,2038 1442,2036 1447,2034 1451,2032 1456,2030 1460,2028 1465,2027 1469,2025 1474,2023 1478,2021 1483,2019 1487,2017 1492,2015 1496,2013 1501,2011 1505,2009 1510,2007 1514,2005 1519,2003 1523,2001 1528,1999 1532,1997 1537,1995 1541,1993 1546,1991 1550,1989 1555,1987 1559,1985 1564,1983 1568,1980 1573,1978 1577,1976 1582,1974 1586,1972 1591,1969 1595,1967 1600,1965 1604,1963 1609,1960 1613,1958 1618,1956 1622,1953 1626,1951 1631,1949 1635,1946 1640,1944 1644,1942 1649,1939 1653,1937 1658,1934 1662,1932 1667,1929 1671,1927 1676,1924 1680,1922 1685,1919 1689,1917 1694,1914 1698,1912 1703,1909 1707,1907 1712,1904 1716,1901 1721,1899 1725,1896 1730,1893 1734,1891 1739,1888 1743,1885 1748,1882 1752,1880 1757,1877 1761,1874 1766,1871 1770,1868 1775,1865 1779,1862 1784,1860 1788,1857 1793,1854 1797,1851 1802,1848 1806,1845 1811,1842 1815,1839 1820,1836 1824,1833 1829,1830 1833,1826 1838,1823 1842,1820 1847,1817 1851,1814 1856,1811 1860,1807 1865,1804 1869,1801 1874,1797 1878,1794 1883,1791 1887,1787 1892,1784 1896,1781 1901,1777 1905,1774 1910,1770 1914,1767 1919,1763 1923,1760 1928,1756 1932,1753 1937,1749 1941,1746 1946,1742 1950,1738 1955,1735 1959,1731 1964,1727 1968,1723 1973,1720 1977,1716 1982,1712 1986,1708 1991,1704 1995,1700 2000,1696 2004,1692 2009,1688 2013,1684 2018,1680 2022,1676 2027,1672 2031,1668 2036,1664 2040,1660 2045,1656 2049,1652 2054,1647 2058,1643 2063,1639 2067,1634 2072,1630 2076,1626 2081,1621 2085,1617 2090,1613 2094,1608 2099,1604 2103,1599 2108,1594 2112,1590 2117,1585 2121,1581 2126,1576 2130,1571 2135,1566 2139,1562 2144,1557 2148,1552 2153,1547 2157,1542 2162,1537 2166,1532 2171,1528 2175,1522 2180,1517 2184,1512 2189,1507 2193,1502 2198,1497 2202,1492 2207,1487 2211,1481 2216,1476 2220,1471 2225,1465 2229,1460 2234,1454 2238,1449 2243,1443 2247,1438 2252,1432 2256,1427 2261,1421 2265,1415 2270,1410 2274,1404 2279,1398 2283,1392 2288,1386 2292,1381 2297,1375 2301,1369 2306,1363 2310,1357 2315,1351 2319,1344 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2152 394,1832 399,1832 403,1832 408,1832 412,1832 417,1832 421,1832 426,1832 430,1832 435,1832 439,1832 444,1832 448,1832 453,1832 457,1832 462,1832 466,1832 471,1832 475,1832 480,1832 484,1832 489,1832 493,1832 498,1832 502,1832 507,1832 511,1832 516,1832 520,1832 525,1832 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_10% annual fee growth_0.000200.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_10% annual fee growth_0.000200.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+10% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,956 88,947 93,939 97,931 102,923 106,914 111,906 115,899 120,891 124,883 129,876 133,869 138,861 142,854 147,847 151,840 156,833 160,827 165,820 169,813 174,807 178,801 183,794 187,788 192,782 196,776 201,770 205,765 210,759 214,753 219,748 223,742 228,737 232,732 237,727 241,722 246,716 250,712 255,707 259,702 264,697 268,692 273,688 277,683 282,679 286,674 291,670 295,666 300,662 304,658 309,653 313,649 318,645 322,642 327,638 331,634 336,630 340,627 345,623 349,620 354,616 358,613 363,609 367,606 372,603 376,599 381,596 385,593 390,590 394,587 399,584 403,581 408,578 412,575 417,572 421,570 426,567 430,564 435,562 439,559 444,556 448,554 453,551 457,549 462,547 466,544 471,542 475,539 480,537 484,535 489,533 493,531 498,528 502,526 506,524 511,522 515,520 520,518 524,516 529,514 533,512 538,511 542,509 547,507 551,505 556,503 560,502 565,500 569,498 574,497 578,495 583,494 587,492 592,490 596,489 601,487 605,486 610,484 614,483 619,482 623,480 628,479 632,477 637,476 641,475 646,474 650,472 655,471 659,470 664,469 668,467 673,466 677,465 682,464 686,463 691,462 695,461 700,460 704,459 709,458 713,456 718,455 722,455 727,454 731,453 736,452 740,451 745,450 749,449 754,448 758,447 763,446 767,445 772,445 776,444 781,443 785,442 790,441 794,441 799,440 803,439 808,438 812,438 817,437 821,436 826,436 830,435 835,434 839,434 844,433 848,432 853,432 857,431 862,430 866,430 871,429 875,429 880,428 884,428 889,427 893,427 898,426 902,425 907,425 911,424 916,424 920,423 925,423 929,422 934,422 938,421 943,421 947,420 952,420 956,419 961,419 965,418 970,418 974,417 979,417 983,416 988,416 992,415 997,415 1001,414 1006,414 1010,413 1015,413 1019,412 1024,412 1028,411 1033,411 1037,410 1042,410 1046,409 1051,409 1055,408 1060,408 1064,407 1069,407 1073,406 1078,406 1082,405 1087,405 1091,404 1096,404 1100,403 1105,403 1109,402 1114,402 1118,401 1123,401 1127,400 1132,400 1136,399 1141,399 1145,398 1150,398 1154,397 1159,397 1163,396 1168,396 1172,395 1177,395 1181,394 1186,394 1190,393 1195,393 1199,392 1204,392 1208,391 1213,391 1217,390 1222,390 1226,389 1231,389 1235,388 1240,388 1244,387 1249,387 1253,386 1258,386 1262,385 1267,385 1271,384 1276,384 1280,383 1285,383 1289,382 1294,382 1298,381 1303,381 1307,380 1312,380 1316,379 1321,379 1325,378 1330,378 1334,377 1339,377 1343,376 1348,376 1352,375 1357,375 1361,374 1366,374 1370,373 1375,373 1379,372 1384,372 1388,371 1393,371 1397,370 1402,370 1406,369 1411,369 1415,368 1420,368 1424,367 1429,367 1433,366 1438,366 1442,365 1447,365 1451,364 1456,364 1460,363 1465,363 1469,362 1474,362 1478,361 1483,360 1487,360 1492,359 1496,359 1501,358 1505,358 1510,357 1514,357 1519,356 1523,356 1528,355 1532,355 1537,354 1541,354 1546,353 1550,353 1555,352 1559,352 1564,351 1568,351 1573,350 1577,350 1582,349 1586,349 1591,348 1595,348 1600,347 1604,347 1609,346 1613,346 1618,345 1622,345 1626,344 1631,344 1635,343 1640,343 1644,342 1649,342 1653,341 1658,341 1662,340 1667,340 1671,339 1676,339 1680,338 1685,338 1689,337 1694,337 1698,336 1703,336 1707,335 1712,335 1716,334 1721,334 1725,333 1730,333 1734,332 1739,332 1743,331 1748,331 1752,330 1757,330 1761,329 1766,329 1770,328 1775,328 1779,327 1784,327 1788,326 1793,326 1797,325 1802,325 1806,324 1811,324 1815,323 1820,323 1824,322 1829,322 1833,321 1838,321 1842,320 1847,320 1851,319 1856,319 1860,318 1865,318 1869,317 1874,317 1878,316 1883,316 1887,315 1892,315 1896,314 1901,314 1905,313 1910,313 1914,312 1919,312 1923,311 1928,311 1932,310 1937,310 1941,309 1946,309 1950,308 1955,308 1959,307 1964,307 1968,306 1973,306 1977,305 1982,305 1986,304 1991,304 1995,303 2000,303 2004,302 2009,302 2013,301 2018,301 2022,301 2027,300 2031,300 2036,299 2040,299 2045,298 2049,298 2054,297 2058,297 2063,296 2067,296 2072,295 2076,295 2081,294 2085,294 2090,293 2094,293 2099,292 2103,292 2108,291 2112,291 2117,290 2121,290 2126,289 2130,289 2135,289 2139,288 2144,288 2148,287 2153,287 2157,286 2162,286 2166,285 2171,285 2175,284 2180,284 2184,283 2189,283 2193,282 2198,282 2202,282 2207,281 2211,281 2216,280 2220,280 2225,279 2229,279 2234,278 2238,278 2243,277 2247,277 2252,276 2256,276 2261,276 2265,275 2270,275 2274,274 2279,274 2283,273 2288,273 2292,272 2297,272 2301,272 2306,271 2310,271 2315,270 2319,270 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2206" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2206 74,2206 "/>
+<text x="65" y="2088" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2088 74,2088 "/>
+<text x="65" y="1970" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1970 74,1970 "/>
+<text x="65" y="1852" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1852 74,1852 "/>
+<text x="65" y="1734" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1734 74,1734 "/>
+<text x="65" y="1616" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1616 74,1616 "/>
+<text x="65" y="1497" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1497 74,1497 "/>
+<text x="65" y="1379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1379 74,1379 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2277 151,2277 156,2276 160,2276 165,2276 169,2275 174,2275 178,2275 183,2275 187,2274 192,2274 196,2274 201,2273 205,2273 210,2273 214,2272 219,2272 223,2272 228,2271 232,2271 237,2271 241,2270 246,2270 250,2270 255,2269 259,2269 264,2269 268,2268 273,2268 277,2268 282,2267 286,2267 291,2266 295,2266 300,2266 304,2265 309,2265 313,2265 318,2264 322,2264 327,2263 331,2263 336,2263 340,2262 345,2262 349,2262 354,2261 358,2261 363,2260 367,2260 372,2260 376,2259 381,2259 385,2258 390,2258 394,2257 399,2257 403,2257 408,2256 412,2256 417,2255 421,2255 426,2254 430,2254 435,2254 439,2253 444,2253 448,2252 453,2252 457,2251 462,2251 466,2250 471,2250 475,2249 480,2249 484,2249 489,2248 493,2248 498,2247 502,2247 506,2246 511,2246 515,2245 520,2245 524,2244 529,2244 533,2243 538,2243 542,2242 547,2242 551,2241 556,2240 560,2240 565,2239 569,2239 574,2238 578,2238 583,2237 587,2237 592,2236 596,2236 601,2235 605,2234 610,2234 614,2233 619,2233 623,2232 628,2232 632,2231 637,2230 641,2230 646,2229 650,2229 655,2228 659,2227 664,2227 668,2226 673,2226 677,2225 682,2224 686,2224 691,2223 695,2222 700,2222 704,2221 709,2221 713,2220 718,2219 722,2219 727,2218 731,2217 736,2217 740,2216 745,2215 749,2214 754,2214 758,2213 763,2212 767,2212 772,2211 776,2210 781,2210 785,2209 790,2208 794,2207 799,2207 803,2206 808,2205 812,2204 817,2204 821,2203 826,2202 830,2201 835,2201 839,2200 844,2199 848,2198 853,2197 857,2197 862,2196 866,2195 871,2194 875,2193 880,2193 884,2192 889,2191 893,2190 898,2189 902,2188 907,2188 911,2187 916,2186 920,2185 925,2184 929,2183 934,2182 938,2181 943,2180 947,2180 952,2179 956,2178 961,2177 965,2176 970,2175 974,2174 979,2173 983,2172 988,2171 992,2170 997,2169 1001,2168 1006,2167 1010,2166 1015,2165 1019,2164 1024,2163 1028,2162 1033,2161 1037,2160 1042,2159 1046,2158 1051,2157 1055,2156 1060,2155 1064,2154 1069,2153 1073,2152 1078,2151 1082,2150 1087,2148 1091,2147 1096,2146 1100,2145 1105,2144 1109,2143 1114,2142 1118,2141 1123,2139 1127,2138 1132,2137 1136,2136 1141,2135 1145,2134 1150,2132 1154,2131 1159,2130 1163,2129 1168,2127 1172,2126 1177,2125 1181,2124 1186,2122 1190,2121 1195,2120 1199,2119 1204,2117 1208,2116 1213,2115 1217,2113 1222,2112 1226,2111 1231,2109 1235,2108 1240,2107 1244,2105 1249,2104 1253,2103 1258,2101 1262,2100 1267,2098 1271,2097 1276,2096 1280,2094 1285,2093 1289,2091 1294,2090 1298,2088 1303,2087 1307,2085 1312,2084 1316,2082 1321,2081 1325,2079 1330,2078 1334,2076 1339,2075 1343,2073 1348,2071 1352,2070 1357,2068 1361,2067 1366,2065 1370,2063 1375,2062 1379,2060 1384,2058 1388,2057 1393,2055 1397,2053 1402,2052 1406,2050 1411,2048 1415,2046 1420,2045 1424,2043 1429,2041 1433,2039 1438,2038 1442,2036 1447,2034 1451,2032 1456,2030 1460,2028 1465,2027 1469,2025 1474,2023 1478,2021 1483,2019 1487,2017 1492,2015 1496,2013 1501,2011 1505,2009 1510,2007 1514,2005 1519,2003 1523,2001 1528,1999 1532,1997 1537,1995 1541,1993 1546,1991 1550,1989 1555,1987 1559,1985 1564,1983 1568,1980 1573,1978 1577,1976 1582,1974 1586,1972 1591,1969 1595,1967 1600,1965 1604,1963 1609,1960 1613,1958 1618,1956 1622,1953 1626,1951 1631,1949 1635,1946 1640,1944 1644,1942 1649,1939 1653,1937 1658,1934 1662,1932 1667,1929 1671,1927 1676,1924 1680,1922 1685,1919 1689,1917 1694,1914 1698,1912 1703,1909 1707,1907 1712,1904 1716,1901 1721,1899 1725,1896 1730,1893 1734,1891 1739,1888 1743,1885 1748,1882 1752,1880 1757,1877 1761,1874 1766,1871 1770,1868 1775,1865 1779,1862 1784,1860 1788,1857 1793,1854 1797,1851 1802,1848 1806,1845 1811,1842 1815,1839 1820,1836 1824,1833 1829,1830 1833,1826 1838,1823 1842,1820 1847,1817 1851,1814 1856,1811 1860,1807 1865,1804 1869,1801 1874,1797 1878,1794 1883,1791 1887,1787 1892,1784 1896,1781 1901,1777 1905,1774 1910,1770 1914,1767 1919,1763 1923,1760 1928,1756 1932,1753 1937,1749 1941,1746 1946,1742 1950,1738 1955,1735 1959,1731 1964,1727 1968,1723 1973,1720 1977,1716 1982,1712 1986,1708 1991,1704 1995,1700 2000,1696 2004,1692 2009,1688 2013,1684 2018,1680 2022,1676 2027,1672 2031,1668 2036,1664 2040,1660 2045,1656 2049,1652 2054,1647 2058,1643 2063,1639 2067,1634 2072,1630 2076,1626 2081,1621 2085,1617 2090,1613 2094,1608 2099,1604 2103,1599 2108,1594 2112,1590 2117,1585 2121,1581 2126,1576 2130,1571 2135,1566 2139,1562 2144,1557 2148,1552 2153,1547 2157,1542 2162,1537 2166,1532 2171,1528 2175,1522 2180,1517 2184,1512 2189,1507 2193,1502 2198,1497 2202,1492 2207,1487 2211,1481 2216,1476 2220,1471 2225,1465 2229,1460 2234,1454 2238,1449 2243,1443 2247,1438 2252,1432 2256,1427 2261,1421 2265,1415 2270,1410 2274,1404 2279,1398 2283,1392 2288,1386 2292,1381 2297,1375 2301,1369 2306,1363 2310,1357 2315,1351 2319,1344 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2274 318,1971 322,1832 327,1832 331,1832 336,1832 340,1832 345,1832 349,1832 354,1832 358,1832 363,1832 367,1832 372,1832 376,1832 381,1832 385,1832 390,1832 394,1832 399,1832 403,1832 408,1832 412,1832 417,1832 421,1832 426,1832 430,1832 435,1832 439,1832 444,1832 448,1832 453,1832 457,1832 462,1832 466,1832 471,1832 475,1832 480,1832 484,1832 489,1832 493,1832 498,1832 502,1832 507,1832 511,1832 516,1832 520,1832 525,1832 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_10% annual fee growth_0.000300.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_10% annual fee growth_0.000300.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+10% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,956 88,947 93,939 97,931 102,923 106,914 111,906 115,899 120,891 124,883 129,876 133,869 138,861 142,854 147,847 151,840 156,833 160,827 165,820 169,813 174,807 178,801 183,794 187,788 192,782 196,776 201,770 205,765 210,759 214,753 219,748 223,742 228,737 232,732 237,727 241,722 246,717 250,712 255,707 259,702 264,697 268,693 273,688 277,683 282,679 286,675 291,670 295,666 300,662 304,658 309,654 313,650 318,646 322,642 327,638 331,634 336,631 340,627 345,623 349,620 354,616 358,613 363,609 367,606 372,603 376,600 381,596 385,593 390,590 394,587 399,584 403,581 408,578 412,575 417,573 421,570 426,567 430,564 435,562 439,559 444,557 448,554 453,552 457,549 462,547 466,544 471,542 475,540 480,537 484,535 489,533 493,531 498,529 502,527 506,525 511,522 515,520 520,518 524,517 529,515 533,513 538,511 542,509 547,507 551,505 556,504 560,502 565,500 569,499 574,497 578,495 583,494 587,492 592,491 596,489 601,488 605,486 610,485 614,483 619,482 623,480 628,479 632,478 637,476 641,475 646,474 650,473 655,471 659,470 664,469 668,468 673,466 677,465 682,464 686,463 691,462 695,461 700,460 704,459 709,458 713,457 718,456 722,455 727,454 731,453 736,452 740,451 745,450 749,449 754,448 758,447 763,447 767,446 772,445 776,444 781,443 785,442 790,442 794,441 799,440 803,439 808,439 812,438 817,437 821,437 826,436 830,435 835,434 839,434 844,433 848,433 853,432 857,431 862,431 866,430 871,430 875,429 880,428 884,428 889,427 893,427 898,426 902,426 907,425 911,425 916,424 920,424 925,423 929,423 934,422 938,422 943,421 947,421 952,420 956,420 961,419 965,419 970,418 974,418 979,417 983,417 988,416 992,416 997,415 1001,415 1006,414 1010,414 1015,413 1019,413 1024,412 1028,412 1033,411 1037,411 1042,410 1046,410 1051,409 1055,409 1060,408 1064,408 1069,407 1073,407 1078,406 1082,406 1087,405 1091,405 1096,404 1100,404 1105,403 1109,403 1114,402 1118,402 1123,401 1127,401 1132,400 1136,400 1141,399 1145,399 1150,398 1154,398 1159,397 1163,397 1168,396 1172,396 1177,395 1181,395 1186,394 1190,394 1195,393 1199,393 1204,392 1208,392 1213,391 1217,391 1222,390 1226,390 1231,389 1235,389 1240,388 1244,388 1249,387 1253,387 1258,386 1262,386 1267,385 1271,385 1276,384 1280,384 1285,383 1289,383 1294,382 1298,381 1303,381 1307,380 1312,380 1316,379 1321,379 1325,378 1330,378 1334,377 1339,377 1343,376 1348,376 1352,375 1357,375 1361,374 1366,374 1370,373 1375,373 1379,372 1384,372 1388,371 1393,371 1397,370 1402,370 1406,369 1411,369 1415,368 1420,368 1424,367 1429,367 1433,366 1438,366 1442,365 1447,365 1451,364 1456,364 1460,363 1465,363 1469,362 1474,362 1478,361 1483,361 1487,360 1492,360 1496,359 1501,359 1505,358 1510,358 1514,357 1519,357 1523,356 1528,356 1532,355 1537,355 1541,354 1546,354 1550,353 1555,353 1559,352 1564,352 1568,351 1573,351 1577,350 1582,350 1586,349 1591,349 1595,348 1600,348 1604,347 1609,347 1613,346 1618,346 1622,345 1626,344 1631,344 1635,343 1640,343 1644,342 1649,342 1653,341 1658,341 1662,340 1667,340 1671,339 1676,339 1680,338 1685,338 1689,337 1694,337 1698,336 1703,336 1707,335 1712,335 1716,334 1721,334 1725,333 1730,333 1734,332 1739,332 1743,331 1748,331 1752,330 1757,330 1761,329 1766,329 1770,328 1775,328 1779,327 1784,327 1788,326 1793,326 1797,325 1802,325 1806,324 1811,324 1815,323 1820,323 1824,322 1829,322 1833,321 1838,321 1842,320 1847,320 1851,319 1856,319 1860,318 1865,318 1869,317 1874,317 1878,316 1883,316 1887,315 1892,315 1896,314 1901,314 1905,313 1910,313 1914,312 1919,312 1923,311 1928,311 1932,311 1937,310 1941,310 1946,309 1950,309 1955,308 1959,308 1964,307 1968,307 1973,306 1977,306 1982,305 1986,305 1991,304 1995,304 2000,303 2004,303 2009,302 2013,302 2018,301 2022,301 2027,300 2031,300 2036,299 2040,299 2045,298 2049,298 2054,297 2058,297 2063,296 2067,296 2072,295 2076,295 2081,294 2085,294 2090,294 2094,293 2099,293 2103,292 2108,292 2112,291 2117,291 2121,290 2126,290 2130,289 2135,289 2139,288 2144,288 2148,287 2153,287 2157,286 2162,286 2166,285 2171,285 2175,285 2180,284 2184,284 2189,283 2193,283 2198,282 2202,282 2207,281 2211,281 2216,280 2220,280 2225,279 2229,279 2234,279 2238,278 2243,278 2247,277 2252,277 2256,276 2261,276 2265,275 2270,275 2274,274 2279,274 2283,274 2288,273 2292,273 2297,272 2301,272 2306,271 2310,271 2315,270 2319,270 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2206" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2206 74,2206 "/>
+<text x="65" y="2088" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2088 74,2088 "/>
+<text x="65" y="1970" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1970 74,1970 "/>
+<text x="65" y="1852" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1852 74,1852 "/>
+<text x="65" y="1734" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1734 74,1734 "/>
+<text x="65" y="1616" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1616 74,1616 "/>
+<text x="65" y="1497" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1497 74,1497 "/>
+<text x="65" y="1379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1379 74,1379 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2277 151,2277 156,2276 160,2276 165,2276 169,2275 174,2275 178,2275 183,2275 187,2274 192,2274 196,2274 201,2273 205,2273 210,2273 214,2272 219,2272 223,2272 228,2271 232,2271 237,2271 241,2270 246,2270 250,2270 255,2269 259,2269 264,2269 268,2268 273,2268 277,2268 282,2267 286,2267 291,2266 295,2266 300,2266 304,2265 309,2265 313,2265 318,2264 322,2264 327,2263 331,2263 336,2263 340,2262 345,2262 349,2262 354,2261 358,2261 363,2260 367,2260 372,2260 376,2259 381,2259 385,2258 390,2258 394,2257 399,2257 403,2257 408,2256 412,2256 417,2255 421,2255 426,2254 430,2254 435,2254 439,2253 444,2253 448,2252 453,2252 457,2251 462,2251 466,2250 471,2250 475,2249 480,2249 484,2249 489,2248 493,2248 498,2247 502,2247 506,2246 511,2246 515,2245 520,2245 524,2244 529,2244 533,2243 538,2243 542,2242 547,2242 551,2241 556,2240 560,2240 565,2239 569,2239 574,2238 578,2238 583,2237 587,2237 592,2236 596,2236 601,2235 605,2234 610,2234 614,2233 619,2233 623,2232 628,2232 632,2231 637,2230 641,2230 646,2229 650,2229 655,2228 659,2227 664,2227 668,2226 673,2226 677,2225 682,2224 686,2224 691,2223 695,2222 700,2222 704,2221 709,2221 713,2220 718,2219 722,2219 727,2218 731,2217 736,2217 740,2216 745,2215 749,2214 754,2214 758,2213 763,2212 767,2212 772,2211 776,2210 781,2210 785,2209 790,2208 794,2207 799,2207 803,2206 808,2205 812,2204 817,2204 821,2203 826,2202 830,2201 835,2201 839,2200 844,2199 848,2198 853,2197 857,2197 862,2196 866,2195 871,2194 875,2193 880,2193 884,2192 889,2191 893,2190 898,2189 902,2188 907,2188 911,2187 916,2186 920,2185 925,2184 929,2183 934,2182 938,2181 943,2180 947,2180 952,2179 956,2178 961,2177 965,2176 970,2175 974,2174 979,2173 983,2172 988,2171 992,2170 997,2169 1001,2168 1006,2167 1010,2166 1015,2165 1019,2164 1024,2163 1028,2162 1033,2161 1037,2160 1042,2159 1046,2158 1051,2157 1055,2156 1060,2155 1064,2154 1069,2153 1073,2152 1078,2151 1082,2150 1087,2148 1091,2147 1096,2146 1100,2145 1105,2144 1109,2143 1114,2142 1118,2141 1123,2139 1127,2138 1132,2137 1136,2136 1141,2135 1145,2134 1150,2132 1154,2131 1159,2130 1163,2129 1168,2127 1172,2126 1177,2125 1181,2124 1186,2122 1190,2121 1195,2120 1199,2119 1204,2117 1208,2116 1213,2115 1217,2113 1222,2112 1226,2111 1231,2109 1235,2108 1240,2107 1244,2105 1249,2104 1253,2103 1258,2101 1262,2100 1267,2098 1271,2097 1276,2096 1280,2094 1285,2093 1289,2091 1294,2090 1298,2088 1303,2087 1307,2085 1312,2084 1316,2082 1321,2081 1325,2079 1330,2078 1334,2076 1339,2075 1343,2073 1348,2071 1352,2070 1357,2068 1361,2067 1366,2065 1370,2063 1375,2062 1379,2060 1384,2058 1388,2057 1393,2055 1397,2053 1402,2052 1406,2050 1411,2048 1415,2046 1420,2045 1424,2043 1429,2041 1433,2039 1438,2038 1442,2036 1447,2034 1451,2032 1456,2030 1460,2028 1465,2027 1469,2025 1474,2023 1478,2021 1483,2019 1487,2017 1492,2015 1496,2013 1501,2011 1505,2009 1510,2007 1514,2005 1519,2003 1523,2001 1528,1999 1532,1997 1537,1995 1541,1993 1546,1991 1550,1989 1555,1987 1559,1985 1564,1983 1568,1980 1573,1978 1577,1976 1582,1974 1586,1972 1591,1969 1595,1967 1600,1965 1604,1963 1609,1960 1613,1958 1618,1956 1622,1953 1626,1951 1631,1949 1635,1946 1640,1944 1644,1942 1649,1939 1653,1937 1658,1934 1662,1932 1667,1929 1671,1927 1676,1924 1680,1922 1685,1919 1689,1917 1694,1914 1698,1912 1703,1909 1707,1907 1712,1904 1716,1901 1721,1899 1725,1896 1730,1893 1734,1891 1739,1888 1743,1885 1748,1882 1752,1880 1757,1877 1761,1874 1766,1871 1770,1868 1775,1865 1779,1862 1784,1860 1788,1857 1793,1854 1797,1851 1802,1848 1806,1845 1811,1842 1815,1839 1820,1836 1824,1833 1829,1830 1833,1826 1838,1823 1842,1820 1847,1817 1851,1814 1856,1811 1860,1807 1865,1804 1869,1801 1874,1797 1878,1794 1883,1791 1887,1787 1892,1784 1896,1781 1901,1777 1905,1774 1910,1770 1914,1767 1919,1763 1923,1760 1928,1756 1932,1753 1937,1749 1941,1746 1946,1742 1950,1738 1955,1735 1959,1731 1964,1727 1968,1723 1973,1720 1977,1716 1982,1712 1986,1708 1991,1704 1995,1700 2000,1696 2004,1692 2009,1688 2013,1684 2018,1680 2022,1676 2027,1672 2031,1668 2036,1664 2040,1660 2045,1656 2049,1652 2054,1647 2058,1643 2063,1639 2067,1634 2072,1630 2076,1626 2081,1621 2085,1617 2090,1613 2094,1608 2099,1604 2103,1599 2108,1594 2112,1590 2117,1585 2121,1581 2126,1576 2130,1571 2135,1566 2139,1562 2144,1557 2148,1552 2153,1547 2157,1542 2162,1537 2166,1532 2171,1528 2175,1522 2180,1517 2184,1512 2189,1507 2193,1502 2198,1497 2202,1492 2207,1487 2211,1481 2216,1476 2220,1471 2225,1465 2229,1460 2234,1454 2238,1449 2243,1443 2247,1438 2252,1432 2256,1427 2261,1421 2265,1415 2270,1410 2274,1404 2279,1398 2283,1392 2288,1386 2292,1381 2297,1375 2301,1369 2306,1363 2310,1357 2315,1351 2319,1344 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2018 223,1832 228,1832 232,1832 237,1832 241,1832 246,1832 250,1832 255,1832 259,1832 264,1832 268,1832 273,1832 277,1832 282,1832 286,1832 291,1832 295,1832 300,1832 304,1832 309,1832 313,1832 318,1832 322,1832 327,1832 331,1832 336,1832 340,1832 345,1832 349,1832 354,1832 358,1832 363,1832 367,1832 372,1832 376,1832 381,1832 385,1832 390,1832 394,1832 399,1832 403,1832 408,1832 412,1832 417,1832 421,1832 426,1832 430,1832 435,1832 439,1832 444,1832 448,1832 453,1832 457,1832 462,1832 466,1832 471,1832 475,1832 480,1832 484,1832 489,1832 493,1832 498,1832 502,1832 507,1832 511,1832 516,1832 520,1832 525,1832 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_25% annual fee growth_0.000100.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_25% annual fee growth_0.000100.svg
@@ -1,0 +1,661 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+25% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,956 88,947 93,939 97,931 102,923 106,914 111,906 115,899 120,891 124,883 129,876 133,869 138,861 142,854 147,847 151,840 156,833 160,827 165,820 169,813 174,807 178,801 183,794 187,788 192,782 196,776 201,770 205,765 210,759 214,753 219,748 223,742 228,737 232,732 237,727 241,722 246,716 250,712 255,707 259,702 264,697 268,692 273,688 277,683 282,679 286,674 291,670 295,666 300,662 304,657 309,653 313,649 318,645 322,642 327,638 331,634 336,630 340,627 345,623 349,619 354,616 358,612 363,609 367,606 372,602 376,599 381,596 385,593 390,590 394,587 399,584 403,581 408,578 412,575 417,572 421,569 426,567 430,564 435,561 439,559 444,556 448,554 453,551 457,549 462,546 466,544 471,541 475,539 480,537 484,535 489,532 493,530 498,528 502,526 506,524 511,522 515,520 520,518 524,516 529,514 533,512 538,510 542,508 547,506 551,505 556,503 560,501 565,499 569,498 574,496 578,495 583,493 587,491 592,490 596,488 601,487 605,485 610,484 614,482 619,481 623,480 628,478 632,477 637,475 641,474 646,473 650,472 655,470 659,469 664,468 668,467 673,466 677,464 682,463 686,462 691,461 695,460 700,459 704,458 709,457 713,456 718,455 722,454 727,453 731,452 736,451 740,450 745,449 749,448 754,447 758,446 763,445 767,445 772,444 776,443 781,442 785,441 790,441 794,440 799,439 803,438 808,438 812,437 817,436 821,435 826,435 830,434 835,433 839,433 844,432 848,431 853,431 857,430 862,430 866,429 871,428 875,428 880,427 884,427 889,426 893,426 898,425 902,425 907,424 911,424 916,423 920,423 925,422 929,422 934,421 938,421 943,420 947,420 952,419 956,419 961,418 965,418 970,417 974,417 979,416 983,416 988,415 992,415 997,414 1001,414 1006,413 1010,413 1015,412 1019,412 1024,411 1028,411 1033,410 1037,410 1042,409 1046,409 1051,408 1055,408 1060,407 1064,407 1069,406 1073,406 1078,405 1082,405 1087,404 1091,404 1096,403 1100,403 1105,402 1109,402 1114,401 1118,401 1123,401 1127,400 1132,400 1136,399 1141,399 1145,398 1150,398 1154,397 1159,397 1163,396 1168,396 1172,395 1177,395 1181,394 1186,394 1190,393 1195,393 1199,392 1204,392 1208,391 1213,391 1217,391 1222,390 1226,390 1231,389 1235,389 1240,388 1244,388 1249,387 1253,387 1258,386 1262,386 1267,385 1271,385 1276,385 1280,384 1285,384 1289,383 1294,383 1298,382 1303,382 1307,381 1312,381 1316,380 1321,380 1325,380 1330,379 1334,379 1339,378 1343,378 1348,377 1352,377 1357,377 1361,376 1366,376 1370,375 1375,375 1379,374 1384,374 1388,374 1393,373 1397,373 1402,372 1406,372 1411,371 1415,371 1420,371 1424,370 1429,370 1433,369 1438,369 1442,369 1447,368 1451,368 1456,367 1460,367 1465,367 1469,366 1474,366 1478,365 1483,365 1487,365 1492,364 1496,364 1501,364 1505,363 1510,363 1514,362 1519,362 1523,362 1528,361 1532,361 1537,361 1541,360 1546,360 1550,360 1555,359 1559,359 1564,359 1568,358 1573,358 1577,358 1582,357 1586,357 1591,357 1595,356 1600,356 1604,356 1609,356 1613,355 1618,355 1622,355 1626,354 1631,354 1635,354 1640,354 1644,353 1649,353 1653,353 1658,353 1662,352 1667,352 1671,352 1676,352 1680,351 1685,351 1689,351 1694,351 1698,350 1703,350 1707,350 1712,350 1716,350 1721,350 1725,349 1730,349 1734,349 1739,349 1743,349 1748,349 1752,348 1757,348 1761,348 1766,348 1770,348 1775,348 1779,348 1784,348 1788,348 1793,347 1797,347 1802,347 1806,347 1811,347 1815,347 1820,347 1824,347 1829,347 1833,347 1838,347 1842,347 1847,347 1851,347 1856,347 1860,347 1865,347 1869,347 1874,347 1878,348 1883,348 1887,348 1892,348 1896,348 1901,348 1905,348 1910,348 1914,349 1919,349 1923,349 1928,349 1932,349 1937,349 1941,350 1946,350 1950,350 1955,350 1959,351 1964,351 1968,351 1973,352 1977,352 1982,352 1986,353 1991,353 1995,353 2000,354 2004,354 2009,355 2013,355 2018,356 2022,356 2027,357 2031,357 2036,358 2040,358 2045,359 2049,359 2054,360 2058,361 2063,361 2067,362 2072,362 2076,363 2081,364 2085,365 2090,365 2094,366 2099,367 2103,368 2108,368 2112,369 2117,370 2121,371 2126,372 2130,373 2135,374 2139,375 2144,376 2148,377 2153,378 2157,379 2162,380 2166,381 2171,382 2175,383 2180,385 2184,386 2189,387 2193,388 2198,390 2202,391 2207,392 2211,394 2216,395 2220,397 2225,398 2229,400 2234,401 2238,403 2243,404 2247,406 2252,408 2256,409 2261,411 2265,413 2270,415 2274,417 2279,418 2283,420 2288,422 2292,424 2297,426 2301,428 2306,431 2310,433 2315,435 2319,437 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2164" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2164 74,2164 "/>
+<text x="65" y="2003" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2003 74,2003 "/>
+<text x="65" y="1842" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1842 74,1842 "/>
+<text x="65" y="1682" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1682 74,1682 "/>
+<text x="65" y="1521" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1521 74,1521 "/>
+<text x="65" y="1360" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1360 74,1360 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2324 151,2324 156,2324 160,2324 165,2324 169,2324 174,2324 178,2324 183,2324 187,2324 192,2324 196,2324 201,2324 205,2324 210,2324 214,2323 219,2323 223,2323 228,2323 232,2323 237,2323 241,2323 246,2323 250,2323 255,2323 259,2323 264,2323 268,2323 273,2323 277,2323 282,2323 286,2323 291,2323 295,2323 300,2323 304,2323 309,2323 313,2323 318,2323 322,2323 327,2323 331,2323 336,2323 340,2323 345,2323 349,2323 354,2323 358,2323 363,2323 367,2323 372,2323 376,2323 381,2323 385,2323 390,2323 394,2323 399,2323 403,2323 408,2323 412,2323 417,2323 421,2323 426,2322 430,2322 435,2322 439,2322 444,2322 448,2322 453,2322 457,2322 462,2322 466,2322 471,2322 475,2322 480,2322 484,2322 489,2322 493,2322 498,2322 502,2322 506,2322 511,2322 515,2322 520,2322 524,2322 529,2322 533,2322 538,2322 542,2322 547,2321 551,2321 556,2321 560,2321 565,2321 569,2321 574,2321 578,2321 583,2321 587,2321 592,2321 596,2321 601,2321 605,2321 610,2321 614,2321 619,2321 623,2321 628,2321 632,2321 637,2320 641,2320 646,2320 650,2320 655,2320 659,2320 664,2320 668,2320 673,2320 677,2320 682,2320 686,2320 691,2320 695,2320 700,2320 704,2319 709,2319 713,2319 718,2319 722,2319 727,2319 731,2319 736,2319 740,2319 745,2319 749,2319 754,2319 758,2319 763,2318 767,2318 772,2318 776,2318 781,2318 785,2318 790,2318 794,2318 799,2318 803,2318 808,2317 812,2317 817,2317 821,2317 826,2317 830,2317 835,2317 839,2317 844,2317 848,2316 853,2316 857,2316 862,2316 866,2316 871,2316 875,2316 880,2316 884,2315 889,2315 893,2315 898,2315 902,2315 907,2315 911,2315 916,2315 920,2314 925,2314 929,2314 934,2314 938,2314 943,2314 947,2313 952,2313 956,2313 961,2313 965,2313 970,2313 974,2312 979,2312 983,2312 988,2312 992,2312 997,2311 1001,2311 1006,2311 1010,2311 1015,2311 1019,2310 1024,2310 1028,2310 1033,2310 1037,2310 1042,2309 1046,2309 1051,2309 1055,2309 1060,2309 1064,2308 1069,2308 1073,2308 1078,2308 1082,2307 1087,2307 1091,2307 1096,2307 1100,2306 1105,2306 1109,2306 1114,2305 1118,2305 1123,2305 1127,2305 1132,2304 1136,2304 1141,2304 1145,2303 1150,2303 1154,2303 1159,2302 1163,2302 1168,2302 1172,2301 1177,2301 1181,2301 1186,2300 1190,2300 1195,2300 1199,2299 1204,2299 1208,2299 1213,2298 1217,2298 1222,2297 1226,2297 1231,2297 1235,2296 1240,2296 1244,2295 1249,2295 1253,2294 1258,2294 1262,2294 1267,2293 1271,2293 1276,2292 1280,2292 1285,2291 1289,2291 1294,2290 1298,2290 1303,2289 1307,2289 1312,2288 1316,2288 1321,2287 1325,2287 1330,2286 1334,2285 1339,2285 1343,2284 1348,2284 1352,2283 1357,2282 1361,2282 1366,2281 1370,2281 1375,2280 1379,2279 1384,2279 1388,2278 1393,2277 1397,2276 1402,2276 1406,2275 1411,2274 1415,2274 1420,2273 1424,2272 1429,2271 1433,2270 1438,2270 1442,2269 1447,2268 1451,2267 1456,2266 1460,2266 1465,2265 1469,2264 1474,2263 1478,2262 1483,2261 1487,2260 1492,2259 1496,2258 1501,2257 1505,2256 1510,2255 1514,2254 1519,2253 1523,2252 1528,2251 1532,2250 1537,2249 1541,2248 1546,2247 1550,2245 1555,2244 1559,2243 1564,2242 1568,2241 1573,2239 1577,2238 1582,2237 1586,2236 1591,2234 1595,2233 1600,2232 1604,2230 1609,2229 1613,2227 1618,2226 1622,2224 1626,2223 1631,2222 1635,2220 1640,2218 1644,2217 1649,2215 1653,2214 1658,2212 1662,2210 1667,2209 1671,2207 1676,2205 1680,2203 1685,2202 1689,2200 1694,2198 1698,2196 1703,2194 1707,2192 1712,2190 1716,2188 1721,2186 1725,2184 1730,2182 1734,2180 1739,2178 1743,2176 1748,2174 1752,2171 1757,2169 1761,2167 1766,2165 1770,2162 1775,2160 1779,2157 1784,2155 1788,2152 1793,2150 1797,2147 1802,2145 1806,2142 1811,2139 1815,2137 1820,2134 1824,2131 1829,2128 1833,2125 1838,2122 1842,2119 1847,2116 1851,2113 1856,2110 1860,2107 1865,2104 1869,2100 1874,2097 1878,2094 1883,2090 1887,2087 1892,2083 1896,2080 1901,2076 1905,2072 1910,2069 1914,2065 1919,2061 1923,2057 1928,2053 1932,2049 1937,2045 1941,2041 1946,2037 1950,2033 1955,2028 1959,2024 1964,2019 1968,2015 1973,2010 1977,2006 1982,2001 1986,1996 1991,1991 1995,1986 2000,1981 2004,1976 2009,1971 2013,1966 2018,1961 2022,1955 2027,1950 2031,1944 2036,1939 2040,1933 2045,1927 2049,1921 2054,1915 2058,1909 2063,1903 2067,1897 2072,1891 2076,1884 2081,1878 2085,1871 2090,1864 2094,1858 2099,1851 2103,1844 2108,1837 2112,1829 2117,1822 2121,1815 2126,1807 2130,1800 2135,1792 2139,1784 2144,1776 2148,1768 2153,1760 2157,1751 2162,1743 2166,1734 2171,1725 2175,1717 2180,1708 2184,1698 2189,1689 2193,1680 2198,1670 2202,1661 2207,1651 2211,1641 2216,1631 2220,1620 2225,1610 2229,1600 2234,1589 2238,1578 2243,1567 2247,1556 2252,1544 2256,1533 2261,1521 2265,1509 2270,1497 2274,1485 2279,1473 2283,1460 2288,1447 2292,1434 2297,1421 2301,1408 2306,1394 2310,1380 2315,1366 2319,1352 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2144 394,1832 399,1832 403,1832 408,1832 412,1832 417,1832 421,1832 426,1832 430,1832 435,1832 439,1832 444,1832 448,1832 453,1832 457,1832 462,1832 466,1832 471,1832 475,1832 480,1832 484,1832 489,1832 493,1832 498,1832 502,1832 507,1832 511,1832 516,1832 520,1832 525,1832 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_25% annual fee growth_0.000300.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_25% annual fee growth_0.000300.svg
@@ -1,0 +1,661 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+25% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,956 88,947 93,939 97,931 102,923 106,914 111,906 115,899 120,891 124,883 129,876 133,869 138,861 142,854 147,847 151,840 156,833 160,827 165,820 169,813 174,807 178,801 183,794 187,788 192,782 196,776 201,770 205,765 210,759 214,753 219,748 223,742 228,737 232,732 237,727 241,722 246,716 250,712 255,707 259,702 264,697 268,692 273,688 277,683 282,679 286,674 291,670 295,666 300,662 304,658 309,653 313,649 318,646 322,642 327,638 331,634 336,630 340,627 345,623 349,620 354,616 358,613 363,609 367,606 372,603 376,599 381,596 385,593 390,590 394,587 399,584 403,581 408,578 412,575 417,572 421,570 426,567 430,564 435,561 439,559 444,556 448,554 453,551 457,549 462,546 466,544 471,542 475,539 480,537 484,535 489,532 493,530 498,528 502,526 506,524 511,522 515,520 520,518 524,516 529,514 533,512 538,510 542,508 547,507 551,505 556,503 560,501 565,500 569,498 574,496 578,495 583,493 587,491 592,490 596,488 601,487 605,485 610,484 614,483 619,481 623,480 628,478 632,477 637,476 641,474 646,473 650,472 655,471 659,469 664,468 668,467 673,466 677,465 682,463 686,462 691,461 695,460 700,459 704,458 709,457 713,456 718,455 722,454 727,453 731,452 736,451 740,450 745,449 749,448 754,447 758,446 763,446 767,445 772,444 776,443 781,442 785,441 790,441 794,440 799,439 803,438 808,438 812,437 817,436 821,436 826,435 830,434 835,434 839,433 844,432 848,432 853,431 857,430 862,430 866,429 871,429 875,428 880,427 884,427 889,426 893,426 898,425 902,425 907,424 911,424 916,423 920,423 925,422 929,422 934,421 938,421 943,420 947,420 952,419 956,419 961,418 965,418 970,417 974,417 979,416 983,416 988,415 992,415 997,414 1001,414 1006,413 1010,413 1015,412 1019,412 1024,411 1028,411 1033,410 1037,410 1042,409 1046,409 1051,408 1055,408 1060,407 1064,407 1069,406 1073,406 1078,406 1082,405 1087,405 1091,404 1096,404 1100,403 1105,403 1109,402 1114,402 1118,401 1123,401 1127,400 1132,400 1136,399 1141,399 1145,398 1150,398 1154,397 1159,397 1163,396 1168,396 1172,395 1177,395 1181,394 1186,394 1190,394 1195,393 1199,393 1204,392 1208,392 1213,391 1217,391 1222,390 1226,390 1231,389 1235,389 1240,388 1244,388 1249,387 1253,387 1258,387 1262,386 1267,386 1271,385 1276,385 1280,384 1285,384 1289,383 1294,383 1298,382 1303,382 1307,382 1312,381 1316,381 1321,380 1325,380 1330,379 1334,379 1339,378 1343,378 1348,378 1352,377 1357,377 1361,376 1366,376 1370,375 1375,375 1379,375 1384,374 1388,374 1393,373 1397,373 1402,372 1406,372 1411,372 1415,371 1420,371 1424,370 1429,370 1433,370 1438,369 1442,369 1447,368 1451,368 1456,368 1460,367 1465,367 1469,366 1474,366 1478,366 1483,365 1487,365 1492,364 1496,364 1501,364 1505,363 1510,363 1514,363 1519,362 1523,362 1528,362 1532,361 1537,361 1541,360 1546,360 1550,360 1555,359 1559,359 1564,359 1568,358 1573,358 1577,358 1582,358 1586,357 1591,357 1595,357 1600,356 1604,356 1609,356 1613,355 1618,355 1622,355 1626,355 1631,354 1635,354 1640,354 1644,353 1649,353 1653,353 1658,353 1662,352 1667,352 1671,352 1676,352 1680,351 1685,351 1689,351 1694,351 1698,351 1703,350 1707,350 1712,350 1716,350 1721,350 1725,350 1730,349 1734,349 1739,349 1743,349 1748,349 1752,349 1757,348 1761,348 1766,348 1770,348 1775,348 1779,348 1784,348 1788,348 1793,348 1797,348 1802,347 1806,347 1811,347 1815,347 1820,347 1824,347 1829,347 1833,347 1838,347 1842,347 1847,347 1851,347 1856,347 1860,347 1865,347 1869,348 1874,348 1878,348 1883,348 1887,348 1892,348 1896,348 1901,348 1905,348 1910,348 1914,349 1919,349 1923,349 1928,349 1932,349 1937,350 1941,350 1946,350 1950,350 1955,351 1959,351 1964,351 1968,352 1973,352 1977,352 1982,352 1986,353 1991,353 1995,354 2000,354 2004,354 2009,355 2013,355 2018,356 2022,356 2027,357 2031,357 2036,358 2040,358 2045,359 2049,359 2054,360 2058,361 2063,361 2067,362 2072,363 2076,363 2081,364 2085,365 2090,365 2094,366 2099,367 2103,368 2108,369 2112,369 2117,370 2121,371 2126,372 2130,373 2135,374 2139,375 2144,376 2148,377 2153,378 2157,379 2162,380 2166,381 2171,382 2175,384 2180,385 2184,386 2189,387 2193,389 2198,390 2202,391 2207,393 2211,394 2216,395 2220,397 2225,398 2229,400 2234,401 2238,403 2243,404 2247,406 2252,408 2256,410 2261,411 2265,413 2270,415 2274,417 2279,419 2283,420 2288,422 2292,424 2297,426 2301,429 2306,431 2310,433 2315,435 2319,437 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2164" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2164 74,2164 "/>
+<text x="65" y="2003" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2003 74,2003 "/>
+<text x="65" y="1842" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1842 74,1842 "/>
+<text x="65" y="1682" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1682 74,1682 "/>
+<text x="65" y="1521" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1521 74,1521 "/>
+<text x="65" y="1360" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1360 74,1360 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2324 151,2324 156,2324 160,2324 165,2324 169,2324 174,2324 178,2324 183,2324 187,2324 192,2324 196,2324 201,2324 205,2324 210,2324 214,2323 219,2323 223,2323 228,2323 232,2323 237,2323 241,2323 246,2323 250,2323 255,2323 259,2323 264,2323 268,2323 273,2323 277,2323 282,2323 286,2323 291,2323 295,2323 300,2323 304,2323 309,2323 313,2323 318,2323 322,2323 327,2323 331,2323 336,2323 340,2323 345,2323 349,2323 354,2323 358,2323 363,2323 367,2323 372,2323 376,2323 381,2323 385,2323 390,2323 394,2323 399,2323 403,2323 408,2323 412,2323 417,2323 421,2323 426,2322 430,2322 435,2322 439,2322 444,2322 448,2322 453,2322 457,2322 462,2322 466,2322 471,2322 475,2322 480,2322 484,2322 489,2322 493,2322 498,2322 502,2322 506,2322 511,2322 515,2322 520,2322 524,2322 529,2322 533,2322 538,2322 542,2322 547,2321 551,2321 556,2321 560,2321 565,2321 569,2321 574,2321 578,2321 583,2321 587,2321 592,2321 596,2321 601,2321 605,2321 610,2321 614,2321 619,2321 623,2321 628,2321 632,2321 637,2320 641,2320 646,2320 650,2320 655,2320 659,2320 664,2320 668,2320 673,2320 677,2320 682,2320 686,2320 691,2320 695,2320 700,2320 704,2319 709,2319 713,2319 718,2319 722,2319 727,2319 731,2319 736,2319 740,2319 745,2319 749,2319 754,2319 758,2319 763,2318 767,2318 772,2318 776,2318 781,2318 785,2318 790,2318 794,2318 799,2318 803,2318 808,2317 812,2317 817,2317 821,2317 826,2317 830,2317 835,2317 839,2317 844,2317 848,2316 853,2316 857,2316 862,2316 866,2316 871,2316 875,2316 880,2316 884,2315 889,2315 893,2315 898,2315 902,2315 907,2315 911,2315 916,2315 920,2314 925,2314 929,2314 934,2314 938,2314 943,2314 947,2313 952,2313 956,2313 961,2313 965,2313 970,2313 974,2312 979,2312 983,2312 988,2312 992,2312 997,2311 1001,2311 1006,2311 1010,2311 1015,2311 1019,2310 1024,2310 1028,2310 1033,2310 1037,2310 1042,2309 1046,2309 1051,2309 1055,2309 1060,2309 1064,2308 1069,2308 1073,2308 1078,2308 1082,2307 1087,2307 1091,2307 1096,2307 1100,2306 1105,2306 1109,2306 1114,2305 1118,2305 1123,2305 1127,2305 1132,2304 1136,2304 1141,2304 1145,2303 1150,2303 1154,2303 1159,2302 1163,2302 1168,2302 1172,2301 1177,2301 1181,2301 1186,2300 1190,2300 1195,2300 1199,2299 1204,2299 1208,2299 1213,2298 1217,2298 1222,2297 1226,2297 1231,2297 1235,2296 1240,2296 1244,2295 1249,2295 1253,2294 1258,2294 1262,2294 1267,2293 1271,2293 1276,2292 1280,2292 1285,2291 1289,2291 1294,2290 1298,2290 1303,2289 1307,2289 1312,2288 1316,2288 1321,2287 1325,2287 1330,2286 1334,2285 1339,2285 1343,2284 1348,2284 1352,2283 1357,2282 1361,2282 1366,2281 1370,2281 1375,2280 1379,2279 1384,2279 1388,2278 1393,2277 1397,2276 1402,2276 1406,2275 1411,2274 1415,2274 1420,2273 1424,2272 1429,2271 1433,2270 1438,2270 1442,2269 1447,2268 1451,2267 1456,2266 1460,2266 1465,2265 1469,2264 1474,2263 1478,2262 1483,2261 1487,2260 1492,2259 1496,2258 1501,2257 1505,2256 1510,2255 1514,2254 1519,2253 1523,2252 1528,2251 1532,2250 1537,2249 1541,2248 1546,2247 1550,2245 1555,2244 1559,2243 1564,2242 1568,2241 1573,2239 1577,2238 1582,2237 1586,2236 1591,2234 1595,2233 1600,2232 1604,2230 1609,2229 1613,2227 1618,2226 1622,2224 1626,2223 1631,2222 1635,2220 1640,2218 1644,2217 1649,2215 1653,2214 1658,2212 1662,2210 1667,2209 1671,2207 1676,2205 1680,2203 1685,2202 1689,2200 1694,2198 1698,2196 1703,2194 1707,2192 1712,2190 1716,2188 1721,2186 1725,2184 1730,2182 1734,2180 1739,2178 1743,2176 1748,2174 1752,2171 1757,2169 1761,2167 1766,2165 1770,2162 1775,2160 1779,2157 1784,2155 1788,2152 1793,2150 1797,2147 1802,2145 1806,2142 1811,2139 1815,2137 1820,2134 1824,2131 1829,2128 1833,2125 1838,2122 1842,2119 1847,2116 1851,2113 1856,2110 1860,2107 1865,2104 1869,2100 1874,2097 1878,2094 1883,2090 1887,2087 1892,2083 1896,2080 1901,2076 1905,2072 1910,2069 1914,2065 1919,2061 1923,2057 1928,2053 1932,2049 1937,2045 1941,2041 1946,2037 1950,2033 1955,2028 1959,2024 1964,2019 1968,2015 1973,2010 1977,2006 1982,2001 1986,1996 1991,1991 1995,1986 2000,1981 2004,1976 2009,1971 2013,1966 2018,1961 2022,1955 2027,1950 2031,1944 2036,1939 2040,1933 2045,1927 2049,1921 2054,1915 2058,1909 2063,1903 2067,1897 2072,1891 2076,1884 2081,1878 2085,1871 2090,1864 2094,1858 2099,1851 2103,1844 2108,1837 2112,1829 2117,1822 2121,1815 2126,1807 2130,1800 2135,1792 2139,1784 2144,1776 2148,1768 2153,1760 2157,1751 2162,1743 2166,1734 2171,1725 2175,1717 2180,1708 2184,1698 2189,1689 2193,1680 2198,1670 2202,1661 2207,1651 2211,1641 2216,1631 2220,1620 2225,1610 2229,1600 2234,1589 2238,1578 2243,1567 2247,1556 2252,1544 2256,1533 2261,1521 2265,1509 2270,1497 2274,1485 2279,1473 2283,1460 2288,1447 2292,1434 2297,1421 2301,1408 2306,1394 2310,1380 2315,1366 2319,1352 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2001 223,1832 228,1832 232,1832 237,1832 241,1832 246,1832 250,1832 255,1832 259,1832 264,1832 268,1832 273,1832 277,1832 282,1832 286,1832 291,1832 295,1832 300,1832 304,1832 309,1832 313,1832 318,1832 322,1832 327,1832 331,1832 336,1832 340,1832 345,1832 349,1832 354,1832 358,1832 363,1832 367,1832 372,1832 376,1832 381,1832 385,1832 390,1832 394,1832 399,1832 403,1832 408,1832 412,1832 417,1832 421,1832 426,1832 430,1832 435,1832 439,1832 444,1832 448,1832 453,1832 457,1832 462,1832 466,1832 471,1832 475,1832 480,1832 484,1832 489,1832 493,1832 498,1832 502,1832 507,1832 511,1832 516,1832 520,1832 525,1832 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Slower growth, tapering fees_0.000100.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Slower growth, tapering fees_0.000100.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Slower growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,956 88,947 93,939 97,931 102,923 106,914 111,907 115,899 120,891 124,883 129,876 133,869 138,861 142,854 147,847 151,840 156,834 160,827 165,820 169,814 174,807 178,801 183,795 187,789 192,783 196,777 201,771 205,765 210,760 214,754 219,749 223,743 228,738 232,733 237,728 241,723 246,718 250,713 255,708 259,703 264,698 268,694 273,689 277,685 282,680 286,676 291,672 295,668 300,663 304,659 309,655 313,651 318,648 322,644 327,640 331,636 336,633 340,629 345,625 349,622 354,619 358,615 363,612 367,609 372,605 376,602 381,599 385,596 390,593 394,590 399,587 403,584 408,582 412,580 417,578 421,576 426,573 430,571 435,570 439,568 444,566 448,564 453,562 457,560 462,559 466,557 471,555 475,554 480,552 484,551 489,549 493,548 498,546 502,545 506,544 511,542 515,541 520,540 524,539 529,537 533,536 538,535 542,534 547,533 551,532 556,531 560,530 565,529 569,528 574,528 578,527 583,526 587,525 592,524 596,524 601,523 605,522 610,522 614,521 619,520 623,520 628,519 632,519 637,518 641,518 646,517 650,517 655,517 659,516 664,516 668,515 673,515 677,515 682,515 686,514 691,514 695,514 700,514 704,513 709,513 713,513 718,513 722,513 727,513 731,513 736,513 740,513 745,513 749,513 754,513 758,513 763,513 767,513 772,513 776,513 781,513 785,513 790,514 794,514 799,514 803,514 808,514 812,514 817,515 821,515 826,515 830,516 835,516 839,516 844,516 848,517 853,517 857,517 862,518 866,518 871,519 875,519 880,519 884,520 889,520 893,521 898,521 902,522 907,522 911,523 916,523 920,524 925,524 929,525 934,525 938,526 943,526 947,527 952,528 956,528 961,529 965,529 970,530 974,530 979,531 983,531 988,532 992,533 997,533 1001,534 1006,534 1010,535 1015,535 1019,536 1024,537 1028,537 1033,538 1037,538 1042,539 1046,540 1051,540 1055,541 1060,541 1064,542 1069,543 1073,543 1078,544 1082,544 1087,545 1091,546 1096,546 1100,547 1105,548 1109,548 1114,549 1118,549 1123,550 1127,550 1132,551 1136,551 1141,551 1145,552 1150,552 1154,552 1159,552 1163,553 1168,553 1172,553 1177,553 1181,553 1186,553 1190,554 1195,554 1199,554 1204,554 1208,554 1213,554 1217,554 1222,554 1226,554 1231,554 1235,554 1240,554 1244,554 1249,554 1253,555 1258,555 1262,555 1267,555 1271,555 1276,555 1280,555 1285,555 1289,555 1294,555 1298,555 1303,555 1307,555 1312,555 1316,555 1321,555 1325,555 1330,555 1334,555 1339,555 1343,555 1348,555 1352,555 1357,555 1361,555 1366,555 1370,555 1375,555 1379,555 1384,555 1388,555 1393,555 1397,555 1402,555 1406,555 1411,555 1415,555 1420,555 1424,555 1429,555 1433,555 1438,555 1442,555 1447,555 1451,555 1456,555 1460,555 1465,555 1469,555 1474,555 1478,555 1483,555 1487,555 1492,555 1496,555 1501,555 1505,555 1510,555 1514,555 1519,555 1523,555 1528,555 1532,555 1537,555 1541,555 1546,555 1550,555 1555,555 1559,555 1564,555 1568,555 1573,555 1577,555 1582,555 1586,555 1591,555 1595,555 1600,555 1604,555 1609,555 1613,555 1618,555 1622,555 1626,555 1631,555 1635,555 1640,555 1644,555 1649,555 1653,555 1658,555 1662,555 1667,555 1671,555 1676,555 1680,555 1685,555 1689,555 1694,555 1698,555 1703,555 1707,555 1712,555 1716,555 1721,555 1725,555 1730,555 1734,555 1739,555 1743,555 1748,555 1752,555 1757,555 1761,555 1766,555 1770,555 1775,555 1779,555 1784,555 1788,555 1793,555 1797,555 1802,555 1806,555 1811,555 1815,555 1820,555 1824,555 1829,555 1833,555 1838,555 1842,555 1847,555 1851,555 1856,555 1860,555 1865,555 1869,555 1874,555 1878,555 1883,555 1887,555 1892,555 1896,555 1901,555 1905,555 1910,555 1914,555 1919,555 1923,555 1928,555 1932,555 1937,555 1941,555 1946,555 1950,555 1955,555 1959,555 1964,555 1968,555 1973,555 1977,555 1982,555 1986,555 1991,555 1995,555 2000,555 2004,555 2009,555 2013,555 2018,555 2022,555 2027,555 2031,555 2036,555 2040,555 2045,555 2049,555 2054,555 2058,555 2063,555 2067,555 2072,555 2076,555 2081,555 2085,555 2090,555 2094,555 2099,555 2103,555 2108,555 2112,555 2117,555 2121,555 2126,555 2130,555 2135,555 2139,555 2144,555 2148,555 2153,555 2157,555 2162,555 2166,555 2171,555 2175,555 2180,555 2184,555 2189,555 2193,555 2198,555 2202,555 2207,555 2211,555 2216,555 2220,555 2225,555 2229,555 2234,555 2238,555 2243,555 2247,555 2252,555 2256,555 2261,555 2265,555 2270,555 2274,555 2279,555 2283,555 2288,555 2292,555 2297,555 2301,555 2306,555 2310,555 2315,555 2319,555 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2208" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2208 74,2208 "/>
+<text x="65" y="2092" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2092 74,2092 "/>
+<text x="65" y="1975" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1975 74,1975 "/>
+<text x="65" y="1859" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1859 74,1859 "/>
+<text x="65" y="1743" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1743 74,1743 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1510" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1510 74,1510 "/>
+<text x="65" y="1394" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1394 74,1394 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2207 115,2201 120,2195 124,2190 129,2184 133,2178 138,2173 142,2167 147,2162 151,2157 156,2151 160,2146 165,2141 169,2136 174,2131 178,2127 183,2122 187,2117 192,2113 196,2109 201,2105 205,2101 210,2097 214,2093 219,2089 223,2086 228,2082 232,2079 237,2075 241,2072 246,2069 250,2066 255,2063 259,2060 264,2057 268,2055 273,2052 277,2050 282,2047 286,2045 291,2042 295,2040 300,2038 304,2035 309,2033 313,2031 318,2029 322,2027 327,2025 331,2023 336,2021 340,2019 345,2017 349,2015 354,2013 358,2011 363,2009 367,2008 372,2006 376,2004 381,2002 385,2001 390,1999 394,1997 399,1996 403,1994 408,1992 412,1990 417,1989 421,1987 426,1986 430,1984 435,1982 439,1981 444,1979 448,1977 453,1976 457,1974 462,1973 466,1971 471,1970 475,1968 480,1966 484,1965 489,1963 493,1962 498,1960 502,1959 506,1957 511,1955 515,1954 520,1952 524,1951 529,1949 533,1948 538,1946 542,1945 547,1943 551,1941 556,1940 560,1938 565,1937 569,1935 574,1934 578,1932 583,1931 587,1929 592,1928 596,1926 601,1925 605,1923 610,1921 614,1920 619,1918 623,1917 628,1915 632,1914 637,1912 641,1911 646,1909 650,1908 655,1906 659,1905 664,1903 668,1901 673,1900 677,1898 682,1897 686,1895 691,1894 695,1892 700,1891 704,1889 709,1888 713,1886 718,1885 722,1883 727,1882 731,1880 736,1879 740,1877 745,1875 749,1874 754,1872 758,1871 763,1869 767,1868 772,1866 776,1865 781,1863 785,1862 790,1860 794,1859 799,1857 803,1856 808,1854 812,1853 817,1851 821,1849 826,1848 830,1846 835,1845 839,1843 844,1842 848,1840 853,1839 857,1837 862,1836 866,1834 871,1833 875,1831 880,1830 884,1828 889,1826 893,1825 898,1823 902,1822 907,1820 911,1819 916,1817 920,1816 925,1814 929,1813 934,1811 938,1810 943,1808 947,1807 952,1805 956,1804 961,1802 965,1800 970,1799 974,1797 979,1796 983,1794 988,1793 992,1791 997,1790 1001,1788 1006,1787 1010,1785 1015,1784 1019,1782 1024,1781 1028,1779 1033,1778 1037,1776 1042,1774 1046,1773 1051,1771 1055,1770 1060,1768 1064,1767 1069,1765 1073,1764 1078,1762 1082,1761 1087,1759 1091,1758 1096,1756 1100,1755 1105,1753 1109,1752 1114,1750 1118,1748 1123,1747 1127,1745 1132,1744 1136,1742 1141,1741 1145,1739 1150,1738 1154,1736 1159,1735 1163,1733 1168,1732 1172,1730 1177,1729 1181,1727 1186,1726 1190,1724 1195,1722 1199,1721 1204,1719 1208,1718 1213,1716 1217,1715 1222,1713 1226,1712 1231,1710 1235,1709 1240,1707 1244,1706 1249,1704 1253,1703 1258,1701 1262,1700 1267,1698 1271,1696 1276,1695 1280,1693 1285,1692 1289,1690 1294,1689 1298,1687 1303,1686 1307,1684 1312,1683 1316,1681 1321,1680 1325,1678 1330,1677 1334,1675 1339,1673 1343,1672 1348,1670 1352,1669 1357,1667 1361,1666 1366,1664 1370,1663 1375,1661 1379,1660 1384,1658 1388,1657 1393,1655 1397,1654 1402,1652 1406,1651 1411,1649 1415,1647 1420,1646 1424,1644 1429,1643 1433,1641 1438,1640 1442,1638 1447,1637 1451,1635 1456,1634 1460,1632 1465,1631 1469,1629 1474,1628 1478,1626 1483,1625 1487,1623 1492,1621 1496,1620 1501,1618 1505,1617 1510,1615 1514,1614 1519,1612 1523,1611 1528,1609 1532,1608 1537,1606 1541,1605 1546,1603 1550,1602 1555,1600 1559,1599 1564,1597 1568,1595 1573,1594 1577,1592 1582,1591 1586,1589 1591,1588 1595,1586 1600,1585 1604,1583 1609,1582 1613,1580 1618,1579 1622,1577 1626,1576 1631,1574 1635,1573 1640,1571 1644,1569 1649,1568 1653,1566 1658,1565 1662,1563 1667,1562 1671,1560 1676,1559 1680,1557 1685,1556 1689,1554 1694,1553 1698,1551 1703,1550 1707,1548 1712,1547 1716,1545 1721,1543 1725,1542 1730,1540 1734,1539 1739,1537 1743,1536 1748,1534 1752,1533 1757,1531 1761,1530 1766,1528 1770,1527 1775,1525 1779,1524 1784,1522 1788,1521 1793,1519 1797,1517 1802,1516 1806,1514 1811,1513 1815,1511 1820,1510 1824,1508 1829,1507 1833,1505 1838,1504 1842,1502 1847,1501 1851,1499 1856,1498 1860,1496 1865,1494 1869,1493 1874,1491 1878,1490 1883,1488 1887,1487 1892,1485 1896,1484 1901,1482 1905,1481 1910,1479 1914,1478 1919,1476 1923,1475 1928,1473 1932,1472 1937,1470 1941,1468 1946,1467 1950,1465 1955,1464 1959,1462 1964,1461 1968,1459 1973,1458 1977,1456 1982,1455 1986,1453 1991,1452 1995,1450 2000,1449 2004,1447 2009,1446 2013,1444 2018,1442 2022,1441 2027,1439 2031,1438 2036,1436 2040,1435 2045,1433 2049,1432 2054,1430 2058,1429 2063,1427 2067,1426 2072,1424 2076,1423 2081,1421 2085,1420 2090,1418 2094,1416 2099,1415 2103,1413 2108,1412 2112,1410 2117,1409 2121,1407 2126,1406 2130,1404 2135,1403 2139,1401 2144,1400 2148,1398 2153,1397 2157,1395 2162,1394 2166,1392 2171,1390 2175,1389 2180,1387 2184,1386 2189,1384 2193,1383 2198,1381 2202,1380 2207,1378 2211,1377 2216,1375 2220,1374 2225,1372 2229,1371 2234,1369 2238,1368 2243,1366 2247,1364 2252,1363 2256,1361 2261,1360 2265,1358 2270,1357 2274,1355 2279,1354 2283,1352 2288,1351 2292,1349 2297,1348 2301,1346 2306,1345 2310,1343 2315,1341 2319,1340 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2272 399,2152 403,2021 408,1904 412,1832 417,1832 421,1832 426,1832 430,1832 435,1832 439,1832 444,1832 448,1832 453,1832 457,1832 462,1832 466,1832 471,1832 475,1832 480,1832 484,1832 489,1832 493,1832 498,1832 502,1832 507,1832 511,1832 516,1832 520,1832 525,1832 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1836 1110,1859 1114,1880 1119,1899 1123,1914 1128,1931 1132,1945 1137,1959 1141,1972 1146,1984 1150,1994 1155,2004 1159,2013 1164,2021 1168,2029 1173,2036 1177,2043 1182,2049 1186,2054 1191,2057 1195,2061 1200,2066 1204,2070 1209,2074 1213,2077 1218,2081 1222,2084 1227,2087 1231,2089 1236,2091 1240,2094 1245,2096 1249,2098 1254,2100 1258,2100 1263,2101 1267,2103 1272,2104 1276,2105 1281,2107 1285,2108 1290,2109 1294,2110 1299,2111 1303,2112 1308,2113 1312,2114 1317,2115 1321,2116 1326,2115 1330,2116 1335,2116 1339,2117 1344,2117 1348,2118 1353,2119 1357,2120 1362,2121 1366,2121 1371,2121 1375,2122 1380,2122 1384,2123 1389,2123 1393,2124 1398,2122 1402,2124 1407,2124 1411,2125 1416,2125 1420,2126 1425,2126 1429,2127 1434,2127 1438,2127 1443,2128 1447,2128 1452,2129 1456,2129 1461,2130 1465,2129 1470,2129 1474,2129 1479,2129 1483,2130 1488,2130 1492,2131 1497,2131 1501,2132 1506,2132 1510,2132 1515,2133 1519,2133 1524,2134 1528,2134 1533,2133 1537,2133 1542,2133 1546,2134 1551,2134 1555,2135 1560,2135 1564,2135 1569,2136 1573,2136 1578,2137 1582,2137 1587,2137 1591,2138 1596,2138 1600,2137 1605,2137 1609,2137 1614,2138 1618,2138 1623,2139 1627,2139 1632,2139 1636,2140 1641,2140 1645,2140 1650,2141 1654,2141 1659,2142 1663,2142 1668,2142 1672,2141 1677,2141 1681,2142 1686,2142 1690,2142 1695,2143 1699,2143 1704,2143 1708,2144 1713,2144 1717,2145 1722,2145 1726,2145 1731,2146 1735,2146 1740,2145 1744,2145 1749,2145 1753,2145 1758,2146 1762,2146 1767,2147 1771,2147 1776,2147 1780,2147 1785,2148 1789,2148 1794,2148 1798,2149 1803,2149 1807,2148 1812,2148 1816,2149 1821,2149 1825,2149 1830,2150 1834,2150 1839,2150 1843,2151 1848,2151 1852,2151 1857,2152 1861,2152 1866,2152 1870,2152 1875,2152 1879,2151 1884,2152 1888,2152 1893,2152 1897,2153 1902,2153 1906,2153 1911,2154 1915,2154 1920,2154 1924,2154 1929,2155 1933,2155 1938,2156 1942,2156 1947,2154 1951,2155 1956,2155 1960,2155 1965,2156 1969,2156 1974,2156 1978,2157 1983,2157 1987,2157 1992,2157 1996,2158 2001,2158 2005,2159 2010,2159 2014,2157 2019,2157 2023,2158 2028,2158 2032,2158 2037,2159 2041,2159 2046,2159 2050,2160 2055,2160 2059,2160 2064,2160 2068,2161 2073,2161 2077,2162 2082,2160 2086,2160 2091,2160 2095,2161 2100,2161 2104,2161 2109,2162 2113,2162 2118,2162 2122,2162 2127,2163 2131,2163 2136,2163 2140,2164 2145,2164 2149,2163 2154,2163 2158,2163 2163,2164 2167,2163 2172,2164 2176,2164 2181,2164 2185,2165 2190,2165 2194,2165 2199,2165 2203,2165 2208,2166 2212,2166 2217,2166 2221,2165 2226,2165 2230,2165 2235,2166 2239,2166 2244,2166 2248,2167 2253,2167 2257,2167 2262,2167 2266,2168 2271,2168 2275,2168 2280,2168 2284,2169 2289,2167 2293,2167 2298,2168 2302,2168 2307,2168 2311,2169 2316,2169 2320,2169 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Slower growth, tapering fees_0.000200.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Slower growth, tapering fees_0.000200.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Slower growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,956 88,947 93,939 97,931 102,923 106,914 111,907 115,899 120,891 124,883 129,876 133,869 138,861 142,854 147,847 151,840 156,834 160,827 165,820 169,814 174,807 178,801 183,795 187,789 192,783 196,777 201,771 205,765 210,760 214,754 219,749 223,743 228,738 232,733 237,728 241,723 246,718 250,713 255,708 259,703 264,698 268,694 273,689 277,685 282,680 286,676 291,672 295,668 300,663 304,659 309,655 313,651 318,648 322,644 327,640 331,637 336,633 340,630 345,627 349,624 354,621 358,618 363,615 367,613 372,610 376,608 381,605 385,603 390,600 394,598 399,595 403,593 408,591 412,589 417,587 421,584 426,582 430,580 435,578 439,577 444,575 448,573 453,571 457,569 462,568 466,566 471,564 475,563 480,561 484,560 489,558 493,557 498,555 502,554 506,553 511,551 515,550 520,549 524,548 529,546 533,545 538,544 542,543 547,542 551,541 556,540 560,539 565,538 569,537 574,536 578,536 583,535 587,534 592,533 596,533 601,532 605,531 610,531 614,530 619,529 623,529 628,528 632,528 637,527 641,527 646,526 650,526 655,525 659,525 664,525 668,524 673,524 677,524 682,523 686,523 691,523 695,523 700,523 704,522 709,522 713,522 718,522 722,522 727,522 731,522 736,522 740,522 745,522 749,522 754,522 758,522 763,522 767,522 772,522 776,522 781,522 785,522 790,522 794,523 799,523 803,523 808,523 812,523 817,524 821,524 826,524 830,524 835,525 839,525 844,525 848,526 853,526 857,526 862,527 866,527 871,528 875,528 880,528 884,529 889,529 893,530 898,530 902,531 907,531 911,532 916,532 920,533 925,533 929,534 934,534 938,535 943,535 947,536 952,536 956,537 961,538 965,538 970,539 974,539 979,540 983,540 988,541 992,541 997,542 1001,543 1006,543 1010,544 1015,544 1019,544 1024,545 1028,545 1033,546 1037,546 1042,546 1046,547 1051,547 1055,547 1060,548 1064,548 1069,548 1073,549 1078,549 1082,549 1087,549 1091,550 1096,550 1100,550 1105,550 1109,550 1114,551 1118,551 1123,551 1127,551 1132,551 1136,551 1141,552 1145,552 1150,552 1154,552 1159,552 1163,552 1168,552 1172,552 1177,553 1181,553 1186,553 1190,553 1195,553 1199,553 1204,553 1208,553 1213,553 1217,553 1222,553 1226,553 1231,554 1235,554 1240,554 1244,554 1249,554 1253,554 1258,554 1262,554 1267,554 1271,554 1276,554 1280,554 1285,554 1289,554 1294,554 1298,554 1303,554 1307,554 1312,554 1316,554 1321,554 1325,554 1330,554 1334,554 1339,554 1343,554 1348,554 1352,555 1357,555 1361,555 1366,555 1370,555 1375,555 1379,555 1384,555 1388,555 1393,555 1397,555 1402,555 1406,555 1411,555 1415,555 1420,555 1424,555 1429,555 1433,555 1438,555 1442,555 1447,555 1451,555 1456,555 1460,555 1465,555 1469,555 1474,555 1478,555 1483,555 1487,555 1492,555 1496,555 1501,555 1505,555 1510,555 1514,555 1519,555 1523,555 1528,555 1532,555 1537,555 1541,555 1546,555 1550,555 1555,555 1559,555 1564,555 1568,555 1573,555 1577,555 1582,555 1586,555 1591,555 1595,555 1600,555 1604,555 1609,555 1613,555 1618,555 1622,555 1626,555 1631,555 1635,555 1640,555 1644,555 1649,555 1653,555 1658,555 1662,555 1667,555 1671,555 1676,555 1680,555 1685,555 1689,555 1694,555 1698,555 1703,555 1707,555 1712,555 1716,555 1721,555 1725,555 1730,555 1734,555 1739,555 1743,555 1748,555 1752,555 1757,555 1761,555 1766,555 1770,555 1775,555 1779,555 1784,555 1788,555 1793,555 1797,555 1802,555 1806,555 1811,555 1815,555 1820,555 1824,555 1829,555 1833,555 1838,555 1842,555 1847,555 1851,555 1856,555 1860,555 1865,555 1869,555 1874,555 1878,555 1883,555 1887,555 1892,555 1896,555 1901,555 1905,555 1910,555 1914,555 1919,555 1923,555 1928,555 1932,555 1937,555 1941,555 1946,555 1950,555 1955,555 1959,555 1964,555 1968,555 1973,555 1977,555 1982,555 1986,555 1991,555 1995,555 2000,555 2004,555 2009,555 2013,555 2018,555 2022,555 2027,555 2031,555 2036,555 2040,555 2045,555 2049,555 2054,555 2058,555 2063,555 2067,555 2072,555 2076,555 2081,555 2085,555 2090,555 2094,555 2099,555 2103,555 2108,555 2112,555 2117,555 2121,555 2126,555 2130,555 2135,555 2139,555 2144,555 2148,555 2153,555 2157,555 2162,555 2166,555 2171,555 2175,555 2180,555 2184,555 2189,555 2193,555 2198,555 2202,555 2207,555 2211,555 2216,555 2220,555 2225,555 2229,555 2234,555 2238,555 2243,555 2247,555 2252,555 2256,555 2261,555 2265,555 2270,555 2274,555 2279,555 2283,555 2288,555 2292,555 2297,555 2301,555 2306,555 2310,555 2315,555 2319,555 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2208" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2208 74,2208 "/>
+<text x="65" y="2092" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2092 74,2092 "/>
+<text x="65" y="1975" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1975 74,1975 "/>
+<text x="65" y="1859" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1859 74,1859 "/>
+<text x="65" y="1743" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1743 74,1743 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1510" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1510 74,1510 "/>
+<text x="65" y="1394" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1394 74,1394 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2207 115,2201 120,2195 124,2190 129,2184 133,2178 138,2173 142,2167 147,2162 151,2157 156,2151 160,2146 165,2141 169,2136 174,2131 178,2127 183,2122 187,2117 192,2113 196,2109 201,2105 205,2101 210,2097 214,2093 219,2089 223,2086 228,2082 232,2079 237,2075 241,2072 246,2069 250,2066 255,2063 259,2060 264,2057 268,2055 273,2052 277,2050 282,2047 286,2045 291,2042 295,2040 300,2038 304,2035 309,2033 313,2031 318,2029 322,2027 327,2025 331,2023 336,2021 340,2019 345,2017 349,2015 354,2013 358,2011 363,2009 367,2008 372,2006 376,2004 381,2002 385,2001 390,1999 394,1997 399,1996 403,1994 408,1992 412,1990 417,1989 421,1987 426,1986 430,1984 435,1982 439,1981 444,1979 448,1977 453,1976 457,1974 462,1973 466,1971 471,1970 475,1968 480,1966 484,1965 489,1963 493,1962 498,1960 502,1959 506,1957 511,1955 515,1954 520,1952 524,1951 529,1949 533,1948 538,1946 542,1945 547,1943 551,1941 556,1940 560,1938 565,1937 569,1935 574,1934 578,1932 583,1931 587,1929 592,1928 596,1926 601,1925 605,1923 610,1921 614,1920 619,1918 623,1917 628,1915 632,1914 637,1912 641,1911 646,1909 650,1908 655,1906 659,1905 664,1903 668,1901 673,1900 677,1898 682,1897 686,1895 691,1894 695,1892 700,1891 704,1889 709,1888 713,1886 718,1885 722,1883 727,1882 731,1880 736,1879 740,1877 745,1875 749,1874 754,1872 758,1871 763,1869 767,1868 772,1866 776,1865 781,1863 785,1862 790,1860 794,1859 799,1857 803,1856 808,1854 812,1853 817,1851 821,1849 826,1848 830,1846 835,1845 839,1843 844,1842 848,1840 853,1839 857,1837 862,1836 866,1834 871,1833 875,1831 880,1830 884,1828 889,1826 893,1825 898,1823 902,1822 907,1820 911,1819 916,1817 920,1816 925,1814 929,1813 934,1811 938,1810 943,1808 947,1807 952,1805 956,1804 961,1802 965,1800 970,1799 974,1797 979,1796 983,1794 988,1793 992,1791 997,1790 1001,1788 1006,1787 1010,1785 1015,1784 1019,1782 1024,1781 1028,1779 1033,1778 1037,1776 1042,1774 1046,1773 1051,1771 1055,1770 1060,1768 1064,1767 1069,1765 1073,1764 1078,1762 1082,1761 1087,1759 1091,1758 1096,1756 1100,1755 1105,1753 1109,1752 1114,1750 1118,1748 1123,1747 1127,1745 1132,1744 1136,1742 1141,1741 1145,1739 1150,1738 1154,1736 1159,1735 1163,1733 1168,1732 1172,1730 1177,1729 1181,1727 1186,1726 1190,1724 1195,1722 1199,1721 1204,1719 1208,1718 1213,1716 1217,1715 1222,1713 1226,1712 1231,1710 1235,1709 1240,1707 1244,1706 1249,1704 1253,1703 1258,1701 1262,1700 1267,1698 1271,1696 1276,1695 1280,1693 1285,1692 1289,1690 1294,1689 1298,1687 1303,1686 1307,1684 1312,1683 1316,1681 1321,1680 1325,1678 1330,1677 1334,1675 1339,1673 1343,1672 1348,1670 1352,1669 1357,1667 1361,1666 1366,1664 1370,1663 1375,1661 1379,1660 1384,1658 1388,1657 1393,1655 1397,1654 1402,1652 1406,1651 1411,1649 1415,1647 1420,1646 1424,1644 1429,1643 1433,1641 1438,1640 1442,1638 1447,1637 1451,1635 1456,1634 1460,1632 1465,1631 1469,1629 1474,1628 1478,1626 1483,1625 1487,1623 1492,1621 1496,1620 1501,1618 1505,1617 1510,1615 1514,1614 1519,1612 1523,1611 1528,1609 1532,1608 1537,1606 1541,1605 1546,1603 1550,1602 1555,1600 1559,1599 1564,1597 1568,1595 1573,1594 1577,1592 1582,1591 1586,1589 1591,1588 1595,1586 1600,1585 1604,1583 1609,1582 1613,1580 1618,1579 1622,1577 1626,1576 1631,1574 1635,1573 1640,1571 1644,1569 1649,1568 1653,1566 1658,1565 1662,1563 1667,1562 1671,1560 1676,1559 1680,1557 1685,1556 1689,1554 1694,1553 1698,1551 1703,1550 1707,1548 1712,1547 1716,1545 1721,1543 1725,1542 1730,1540 1734,1539 1739,1537 1743,1536 1748,1534 1752,1533 1757,1531 1761,1530 1766,1528 1770,1527 1775,1525 1779,1524 1784,1522 1788,1521 1793,1519 1797,1517 1802,1516 1806,1514 1811,1513 1815,1511 1820,1510 1824,1508 1829,1507 1833,1505 1838,1504 1842,1502 1847,1501 1851,1499 1856,1498 1860,1496 1865,1494 1869,1493 1874,1491 1878,1490 1883,1488 1887,1487 1892,1485 1896,1484 1901,1482 1905,1481 1910,1479 1914,1478 1919,1476 1923,1475 1928,1473 1932,1472 1937,1470 1941,1468 1946,1467 1950,1465 1955,1464 1959,1462 1964,1461 1968,1459 1973,1458 1977,1456 1982,1455 1986,1453 1991,1452 1995,1450 2000,1449 2004,1447 2009,1446 2013,1444 2018,1442 2022,1441 2027,1439 2031,1438 2036,1436 2040,1435 2045,1433 2049,1432 2054,1430 2058,1429 2063,1427 2067,1426 2072,1424 2076,1423 2081,1421 2085,1420 2090,1418 2094,1416 2099,1415 2103,1413 2108,1412 2112,1410 2117,1409 2121,1407 2126,1406 2130,1404 2135,1403 2139,1401 2144,1400 2148,1398 2153,1397 2157,1395 2162,1394 2166,1392 2171,1390 2175,1389 2180,1387 2184,1386 2189,1384 2193,1383 2198,1381 2202,1380 2207,1378 2211,1377 2216,1375 2220,1374 2225,1372 2229,1371 2234,1369 2238,1368 2243,1366 2247,1364 2252,1363 2256,1361 2261,1360 2265,1358 2270,1357 2274,1355 2279,1354 2283,1352 2288,1351 2292,1349 2297,1348 2301,1346 2306,1345 2310,1343 2315,1341 2319,1340 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2231 327,2154 331,2082 336,2016 340,1954 345,1897 349,1844 354,1832 358,1832 363,1832 367,1832 372,1832 376,1832 381,1832 385,1832 390,1832 394,1832 399,1832 403,1832 408,1832 412,1832 417,1832 421,1832 426,1832 430,1832 435,1832 439,1832 444,1832 448,1832 453,1832 457,1832 462,1832 466,1832 471,1832 475,1832 480,1832 484,1832 489,1832 493,1832 498,1832 502,1832 507,1832 511,1832 516,1832 520,1832 525,1832 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1842 1002,1854 1006,1864 1011,1875 1015,1885 1020,1895 1024,1904 1029,1913 1033,1922 1038,1930 1042,1938 1047,1945 1051,1950 1056,1957 1060,1963 1065,1970 1069,1976 1074,1982 1078,1987 1083,1993 1087,1998 1092,2003 1096,2008 1101,2012 1105,2017 1110,2021 1114,2025 1119,2029 1123,2031 1128,2034 1132,2038 1137,2041 1141,2045 1146,2048 1150,2051 1155,2054 1159,2056 1164,2059 1168,2062 1173,2064 1177,2066 1182,2069 1186,2071 1191,2071 1195,2073 1200,2075 1204,2077 1209,2079 1213,2081 1218,2083 1222,2085 1227,2086 1231,2088 1236,2090 1240,2091 1245,2092 1249,2094 1254,2095 1258,2094 1263,2095 1267,2097 1272,2098 1276,2100 1281,2101 1285,2101 1290,2103 1294,2104 1299,2105 1303,2106 1308,2107 1312,2108 1317,2109 1321,2110 1326,2109 1330,2110 1335,2111 1339,2111 1344,2112 1348,2113 1353,2114 1357,2114 1362,2116 1366,2116 1371,2117 1375,2118 1380,2118 1384,2119 1389,2120 1393,2120 1398,2119 1402,2120 1407,2120 1411,2121 1416,2122 1420,2122 1425,2123 1429,2124 1434,2124 1438,2125 1443,2125 1447,2126 1452,2126 1456,2127 1461,2127 1465,2126 1470,2126 1474,2127 1479,2128 1483,2128 1488,2129 1492,2129 1497,2130 1501,2130 1506,2131 1510,2131 1515,2132 1519,2132 1524,2133 1528,2133 1533,2132 1537,2132 1542,2132 1546,2133 1551,2134 1555,2134 1560,2135 1564,2135 1569,2135 1573,2136 1578,2136 1582,2137 1587,2137 1591,2137 1596,2138 1600,2136 1605,2137 1609,2137 1614,2137 1618,2138 1623,2138 1627,2139 1632,2139 1636,2140 1641,2140 1645,2140 1650,2141 1654,2141 1659,2142 1663,2142 1668,2142 1672,2141 1677,2141 1681,2142 1686,2142 1690,2142 1695,2143 1699,2143 1704,2143 1708,2144 1713,2144 1717,2145 1722,2145 1726,2145 1731,2146 1735,2146 1740,2145 1744,2145 1749,2145 1753,2145 1758,2146 1762,2146 1767,2147 1771,2147 1776,2147 1780,2148 1785,2148 1789,2148 1794,2149 1798,2149 1803,2149 1807,2148 1812,2148 1816,2149 1821,2149 1825,2149 1830,2150 1834,2150 1839,2150 1843,2151 1848,2151 1852,2151 1857,2152 1861,2152 1866,2152 1870,2153 1875,2151 1879,2151 1884,2152 1888,2152 1893,2152 1897,2153 1902,2153 1906,2153 1911,2154 1915,2154 1920,2154 1924,2155 1929,2155 1933,2155 1938,2155 1942,2156 1947,2155 1951,2155 1956,2155 1960,2155 1965,2155 1969,2156 1974,2156 1978,2156 1983,2157 1987,2157 1992,2157 1996,2158 2001,2158 2005,2158 2010,2158 2014,2157 2019,2157 2023,2158 2028,2158 2032,2158 2037,2158 2041,2159 2046,2159 2050,2159 2055,2160 2059,2160 2064,2160 2068,2160 2073,2161 2077,2161 2082,2160 2086,2160 2091,2160 2095,2161 2100,2161 2104,2161 2109,2161 2113,2162 2118,2162 2122,2162 2127,2162 2131,2163 2136,2163 2140,2163 2145,2164 2149,2162 2154,2162 2158,2163 2163,2163 2167,2163 2172,2164 2176,2164 2181,2164 2185,2164 2190,2165 2194,2165 2199,2165 2203,2165 2208,2166 2212,2166 2217,2166 2221,2165 2226,2165 2230,2165 2235,2166 2239,2166 2244,2166 2248,2166 2253,2167 2257,2167 2262,2167 2266,2167 2271,2168 2275,2168 2280,2168 2284,2168 2289,2167 2293,2168 2298,2168 2302,2169 2307,2168 2311,2169 2316,2169 2320,2169 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Slower growth, tapering fees_0.000300.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Slower growth, tapering fees_0.000300.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Slower growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,956 88,947 93,939 97,931 102,923 106,914 111,907 115,899 120,891 124,883 129,876 133,869 138,861 142,854 147,847 151,840 156,834 160,827 165,820 169,814 174,807 178,801 183,795 187,789 192,783 196,777 201,771 205,765 210,760 214,754 219,749 223,743 228,738 232,733 237,728 241,723 246,719 250,714 255,710 259,706 264,701 268,697 273,693 277,689 282,685 286,682 291,678 295,674 300,670 304,667 309,663 313,660 318,657 322,653 327,650 331,647 336,644 340,641 345,638 349,635 354,632 358,629 363,627 367,624 372,621 376,619 381,616 385,614 390,611 394,609 399,607 403,604 408,602 412,600 417,598 421,596 426,594 430,592 435,590 439,588 444,586 448,584 453,582 457,580 462,579 466,577 471,575 475,574 480,572 484,571 489,569 493,568 498,566 502,565 506,564 511,562 515,561 520,560 524,559 529,558 533,556 538,555 542,554 547,553 551,552 556,551 560,550 565,549 569,548 574,548 578,547 583,546 587,545 592,544 596,544 601,543 605,542 610,542 614,541 619,540 623,540 628,539 632,539 637,538 641,538 646,537 650,537 655,537 659,536 664,536 668,535 673,535 677,535 682,535 686,534 691,534 695,534 700,534 704,534 709,533 713,533 718,533 722,533 727,533 731,533 736,533 740,533 745,533 749,533 754,533 758,533 763,533 767,533 772,533 776,533 781,533 785,533 790,534 794,534 799,534 803,534 808,534 812,535 817,535 821,535 826,535 830,536 835,536 839,536 844,537 848,537 853,537 857,538 862,538 866,538 871,539 875,539 880,540 884,540 889,540 893,541 898,541 902,542 907,542 911,542 916,543 920,543 925,543 929,544 934,544 938,544 943,545 947,545 952,545 956,545 961,546 965,546 970,546 974,546 979,547 983,547 988,547 992,547 997,548 1001,548 1006,548 1010,548 1015,548 1019,549 1024,549 1028,549 1033,549 1037,549 1042,549 1046,550 1051,550 1055,550 1060,550 1064,550 1069,550 1073,550 1078,550 1082,551 1087,551 1091,551 1096,551 1100,551 1105,551 1109,551 1114,551 1118,551 1123,552 1127,552 1132,552 1136,552 1141,552 1145,552 1150,552 1154,552 1159,552 1163,552 1168,552 1172,552 1177,553 1181,553 1186,553 1190,553 1195,553 1199,553 1204,553 1208,553 1213,553 1217,553 1222,553 1226,553 1231,553 1235,553 1240,553 1244,553 1249,553 1253,553 1258,554 1262,554 1267,554 1271,554 1276,554 1280,554 1285,554 1289,554 1294,554 1298,554 1303,554 1307,554 1312,554 1316,554 1321,554 1325,554 1330,554 1334,554 1339,554 1343,554 1348,554 1352,554 1357,554 1361,554 1366,554 1370,554 1375,554 1379,554 1384,554 1388,554 1393,554 1397,554 1402,554 1406,554 1411,554 1415,554 1420,554 1424,554 1429,554 1433,554 1438,555 1442,555 1447,555 1451,555 1456,555 1460,555 1465,555 1469,555 1474,555 1478,555 1483,555 1487,555 1492,555 1496,555 1501,555 1505,555 1510,555 1514,555 1519,555 1523,555 1528,555 1532,555 1537,555 1541,555 1546,555 1550,555 1555,555 1559,555 1564,555 1568,555 1573,555 1577,555 1582,555 1586,555 1591,555 1595,555 1600,555 1604,555 1609,555 1613,555 1618,555 1622,555 1626,555 1631,555 1635,555 1640,555 1644,555 1649,555 1653,555 1658,555 1662,555 1667,555 1671,555 1676,555 1680,555 1685,555 1689,555 1694,555 1698,555 1703,555 1707,555 1712,555 1716,555 1721,555 1725,555 1730,555 1734,555 1739,555 1743,555 1748,555 1752,555 1757,555 1761,555 1766,555 1770,555 1775,555 1779,555 1784,555 1788,555 1793,555 1797,555 1802,555 1806,555 1811,555 1815,555 1820,555 1824,555 1829,555 1833,555 1838,555 1842,555 1847,555 1851,555 1856,555 1860,555 1865,555 1869,555 1874,555 1878,555 1883,555 1887,555 1892,555 1896,555 1901,555 1905,555 1910,555 1914,555 1919,555 1923,555 1928,555 1932,555 1937,555 1941,555 1946,555 1950,555 1955,555 1959,555 1964,555 1968,555 1973,555 1977,555 1982,555 1986,555 1991,555 1995,555 2000,555 2004,555 2009,555 2013,555 2018,555 2022,555 2027,555 2031,555 2036,555 2040,555 2045,555 2049,555 2054,555 2058,555 2063,555 2067,555 2072,555 2076,555 2081,555 2085,555 2090,555 2094,555 2099,555 2103,555 2108,555 2112,555 2117,555 2121,555 2126,555 2130,555 2135,555 2139,555 2144,555 2148,555 2153,555 2157,555 2162,555 2166,555 2171,555 2175,555 2180,555 2184,555 2189,555 2193,555 2198,555 2202,555 2207,555 2211,555 2216,555 2220,555 2225,555 2229,555 2234,555 2238,555 2243,555 2247,555 2252,555 2256,555 2261,555 2265,555 2270,555 2274,555 2279,555 2283,555 2288,555 2292,555 2297,555 2301,555 2306,555 2310,555 2315,555 2319,555 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2208" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2208 74,2208 "/>
+<text x="65" y="2092" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2092 74,2092 "/>
+<text x="65" y="1975" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1975 74,1975 "/>
+<text x="65" y="1859" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1859 74,1859 "/>
+<text x="65" y="1743" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1743 74,1743 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1510" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1510 74,1510 "/>
+<text x="65" y="1394" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1394 74,1394 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2207 115,2201 120,2195 124,2190 129,2184 133,2178 138,2173 142,2167 147,2162 151,2157 156,2151 160,2146 165,2141 169,2136 174,2131 178,2127 183,2122 187,2117 192,2113 196,2109 201,2105 205,2101 210,2097 214,2093 219,2089 223,2086 228,2082 232,2079 237,2075 241,2072 246,2069 250,2066 255,2063 259,2060 264,2057 268,2055 273,2052 277,2050 282,2047 286,2045 291,2042 295,2040 300,2038 304,2035 309,2033 313,2031 318,2029 322,2027 327,2025 331,2023 336,2021 340,2019 345,2017 349,2015 354,2013 358,2011 363,2009 367,2008 372,2006 376,2004 381,2002 385,2001 390,1999 394,1997 399,1996 403,1994 408,1992 412,1990 417,1989 421,1987 426,1986 430,1984 435,1982 439,1981 444,1979 448,1977 453,1976 457,1974 462,1973 466,1971 471,1970 475,1968 480,1966 484,1965 489,1963 493,1962 498,1960 502,1959 506,1957 511,1955 515,1954 520,1952 524,1951 529,1949 533,1948 538,1946 542,1945 547,1943 551,1941 556,1940 560,1938 565,1937 569,1935 574,1934 578,1932 583,1931 587,1929 592,1928 596,1926 601,1925 605,1923 610,1921 614,1920 619,1918 623,1917 628,1915 632,1914 637,1912 641,1911 646,1909 650,1908 655,1906 659,1905 664,1903 668,1901 673,1900 677,1898 682,1897 686,1895 691,1894 695,1892 700,1891 704,1889 709,1888 713,1886 718,1885 722,1883 727,1882 731,1880 736,1879 740,1877 745,1875 749,1874 754,1872 758,1871 763,1869 767,1868 772,1866 776,1865 781,1863 785,1862 790,1860 794,1859 799,1857 803,1856 808,1854 812,1853 817,1851 821,1849 826,1848 830,1846 835,1845 839,1843 844,1842 848,1840 853,1839 857,1837 862,1836 866,1834 871,1833 875,1831 880,1830 884,1828 889,1826 893,1825 898,1823 902,1822 907,1820 911,1819 916,1817 920,1816 925,1814 929,1813 934,1811 938,1810 943,1808 947,1807 952,1805 956,1804 961,1802 965,1800 970,1799 974,1797 979,1796 983,1794 988,1793 992,1791 997,1790 1001,1788 1006,1787 1010,1785 1015,1784 1019,1782 1024,1781 1028,1779 1033,1778 1037,1776 1042,1774 1046,1773 1051,1771 1055,1770 1060,1768 1064,1767 1069,1765 1073,1764 1078,1762 1082,1761 1087,1759 1091,1758 1096,1756 1100,1755 1105,1753 1109,1752 1114,1750 1118,1748 1123,1747 1127,1745 1132,1744 1136,1742 1141,1741 1145,1739 1150,1738 1154,1736 1159,1735 1163,1733 1168,1732 1172,1730 1177,1729 1181,1727 1186,1726 1190,1724 1195,1722 1199,1721 1204,1719 1208,1718 1213,1716 1217,1715 1222,1713 1226,1712 1231,1710 1235,1709 1240,1707 1244,1706 1249,1704 1253,1703 1258,1701 1262,1700 1267,1698 1271,1696 1276,1695 1280,1693 1285,1692 1289,1690 1294,1689 1298,1687 1303,1686 1307,1684 1312,1683 1316,1681 1321,1680 1325,1678 1330,1677 1334,1675 1339,1673 1343,1672 1348,1670 1352,1669 1357,1667 1361,1666 1366,1664 1370,1663 1375,1661 1379,1660 1384,1658 1388,1657 1393,1655 1397,1654 1402,1652 1406,1651 1411,1649 1415,1647 1420,1646 1424,1644 1429,1643 1433,1641 1438,1640 1442,1638 1447,1637 1451,1635 1456,1634 1460,1632 1465,1631 1469,1629 1474,1628 1478,1626 1483,1625 1487,1623 1492,1621 1496,1620 1501,1618 1505,1617 1510,1615 1514,1614 1519,1612 1523,1611 1528,1609 1532,1608 1537,1606 1541,1605 1546,1603 1550,1602 1555,1600 1559,1599 1564,1597 1568,1595 1573,1594 1577,1592 1582,1591 1586,1589 1591,1588 1595,1586 1600,1585 1604,1583 1609,1582 1613,1580 1618,1579 1622,1577 1626,1576 1631,1574 1635,1573 1640,1571 1644,1569 1649,1568 1653,1566 1658,1565 1662,1563 1667,1562 1671,1560 1676,1559 1680,1557 1685,1556 1689,1554 1694,1553 1698,1551 1703,1550 1707,1548 1712,1547 1716,1545 1721,1543 1725,1542 1730,1540 1734,1539 1739,1537 1743,1536 1748,1534 1752,1533 1757,1531 1761,1530 1766,1528 1770,1527 1775,1525 1779,1524 1784,1522 1788,1521 1793,1519 1797,1517 1802,1516 1806,1514 1811,1513 1815,1511 1820,1510 1824,1508 1829,1507 1833,1505 1838,1504 1842,1502 1847,1501 1851,1499 1856,1498 1860,1496 1865,1494 1869,1493 1874,1491 1878,1490 1883,1488 1887,1487 1892,1485 1896,1484 1901,1482 1905,1481 1910,1479 1914,1478 1919,1476 1923,1475 1928,1473 1932,1472 1937,1470 1941,1468 1946,1467 1950,1465 1955,1464 1959,1462 1964,1461 1968,1459 1973,1458 1977,1456 1982,1455 1986,1453 1991,1452 1995,1450 2000,1449 2004,1447 2009,1446 2013,1444 2018,1442 2022,1441 2027,1439 2031,1438 2036,1436 2040,1435 2045,1433 2049,1432 2054,1430 2058,1429 2063,1427 2067,1426 2072,1424 2076,1423 2081,1421 2085,1420 2090,1418 2094,1416 2099,1415 2103,1413 2108,1412 2112,1410 2117,1409 2121,1407 2126,1406 2130,1404 2135,1403 2139,1401 2144,1400 2148,1398 2153,1397 2157,1395 2162,1394 2166,1392 2171,1390 2175,1389 2180,1387 2184,1386 2189,1384 2193,1383 2198,1381 2202,1380 2207,1378 2211,1377 2216,1375 2220,1374 2225,1372 2229,1371 2234,1369 2238,1368 2243,1366 2247,1364 2252,1363 2256,1361 2261,1360 2265,1358 2270,1357 2274,1355 2279,1354 2283,1352 2288,1351 2292,1349 2297,1348 2301,1346 2306,1345 2310,1343 2315,1341 2319,1340 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2217 228,2154 232,2096 237,2041 241,1990 246,1944 250,1900 255,1859 259,1832 264,1832 268,1832 273,1832 277,1832 282,1832 286,1832 291,1832 295,1832 300,1832 304,1832 309,1832 313,1832 318,1832 322,1832 327,1832 331,1832 336,1832 340,1832 345,1832 349,1832 354,1832 358,1832 363,1832 367,1832 372,1832 376,1832 381,1832 385,1832 390,1832 394,1832 399,1832 403,1832 408,1832 412,1832 417,1832 421,1832 426,1832 430,1832 435,1832 439,1832 444,1832 448,1832 453,1832 457,1832 462,1832 466,1832 471,1832 475,1832 480,1832 484,1832 489,1832 493,1832 498,1832 502,1832 507,1832 511,1832 516,1832 520,1832 525,1832 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1842 889,1853 894,1864 898,1875 903,1885 907,1895 912,1905 916,1913 921,1919 925,1924 930,1930 934,1935 939,1940 943,1945 948,1950 952,1955 957,1959 961,1964 966,1968 970,1972 975,1976 979,1981 984,1982 988,1986 993,1990 997,1994 1002,1997 1006,2001 1011,2004 1015,2007 1020,2010 1024,2013 1029,2016 1033,2019 1038,2022 1042,2025 1047,2028 1051,2028 1056,2031 1060,2033 1065,2036 1069,2038 1074,2040 1078,2043 1083,2045 1087,2047 1092,2049 1096,2052 1101,2054 1105,2055 1110,2058 1114,2059 1119,2061 1123,2060 1128,2063 1132,2064 1137,2066 1141,2067 1146,2069 1150,2071 1155,2072 1159,2074 1164,2075 1168,2077 1173,2078 1177,2080 1182,2081 1186,2083 1191,2082 1195,2083 1200,2085 1204,2085 1209,2087 1213,2088 1218,2089 1222,2091 1227,2092 1231,2092 1236,2094 1240,2094 1245,2096 1249,2097 1254,2098 1258,2097 1263,2098 1267,2099 1272,2100 1276,2101 1281,2102 1285,2102 1290,2103 1294,2104 1299,2105 1303,2106 1308,2107 1312,2107 1317,2108 1321,2109 1326,2108 1330,2109 1335,2110 1339,2110 1344,2111 1348,2112 1353,2113 1357,2114 1362,2114 1366,2115 1371,2115 1375,2116 1380,2117 1384,2118 1389,2118 1393,2119 1398,2117 1402,2118 1407,2119 1411,2119 1416,2120 1420,2121 1425,2121 1429,2122 1434,2122 1438,2123 1443,2124 1447,2124 1452,2125 1456,2125 1461,2126 1465,2124 1470,2125 1474,2126 1479,2126 1483,2126 1488,2127 1492,2128 1497,2128 1501,2129 1506,2129 1510,2130 1515,2130 1519,2131 1524,2131 1528,2132 1533,2131 1537,2131 1542,2131 1546,2132 1551,2132 1555,2133 1560,2133 1564,2134 1569,2134 1573,2135 1578,2135 1582,2136 1587,2136 1591,2136 1596,2137 1600,2135 1605,2136 1609,2136 1614,2136 1618,2137 1623,2137 1627,2138 1632,2138 1636,2139 1641,2139 1645,2139 1650,2140 1654,2140 1659,2141 1663,2141 1668,2142 1672,2140 1677,2141 1681,2141 1686,2141 1690,2142 1695,2142 1699,2143 1704,2143 1708,2143 1713,2143 1717,2144 1722,2144 1726,2145 1731,2145 1735,2146 1740,2144 1744,2144 1749,2145 1753,2145 1758,2146 1762,2146 1767,2146 1771,2147 1776,2147 1780,2147 1785,2148 1789,2148 1794,2148 1798,2149 1803,2149 1807,2148 1812,2148 1816,2148 1821,2149 1825,2149 1830,2149 1834,2150 1839,2150 1843,2151 1848,2151 1852,2151 1857,2152 1861,2152 1866,2152 1870,2152 1875,2151 1879,2151 1884,2152 1888,2152 1893,2152 1897,2153 1902,2153 1906,2153 1911,2154 1915,2154 1920,2154 1924,2155 1929,2155 1933,2155 1938,2155 1942,2156 1947,2154 1951,2155 1956,2155 1960,2155 1965,2155 1969,2156 1974,2156 1978,2156 1983,2157 1987,2157 1992,2157 1996,2158 2001,2158 2005,2158 2010,2158 2014,2157 2019,2158 2023,2158 2028,2158 2032,2158 2037,2159 2041,2159 2046,2159 2050,2159 2055,2160 2059,2160 2064,2160 2068,2160 2073,2161 2077,2161 2082,2160 2086,2160 2091,2160 2095,2160 2100,2161 2104,2161 2109,2161 2113,2162 2118,2162 2122,2162 2127,2163 2131,2163 2136,2163 2140,2163 2145,2164 2149,2162 2154,2163 2158,2163 2163,2163 2167,2163 2172,2164 2176,2164 2181,2164 2185,2164 2190,2165 2194,2165 2199,2165 2203,2166 2208,2166 2212,2166 2217,2166 2221,2165 2226,2165 2230,2166 2235,2166 2239,2166 2244,2166 2248,2166 2253,2167 2257,2167 2262,2167 2266,2168 2271,2168 2275,2168 2280,2168 2284,2168 2289,2167 2293,2167 2298,2168 2302,2168 2307,2168 2311,2168 2316,2169 2320,2169 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Strong growth, tapering fees_0.000100.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Strong growth, tapering fees_0.000100.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Strong growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,956 88,947 93,939 97,931 102,923 106,914 111,906 115,899 120,891 124,883 129,876 133,869 138,861 142,854 147,847 151,840 156,834 160,827 165,821 169,814 174,808 178,802 183,796 187,790 192,784 196,778 201,772 205,767 210,761 214,756 219,751 223,745 228,740 232,735 237,730 241,725 246,720 250,716 255,711 259,706 264,702 268,697 273,693 277,689 282,684 286,680 291,676 295,672 300,668 304,664 309,660 313,657 318,653 322,649 327,646 331,642 336,639 340,635 345,632 349,628 354,625 358,622 363,619 367,616 372,613 376,610 381,607 385,604 390,601 394,598 399,596 403,593 408,590 412,588 417,585 421,583 426,580 430,578 435,576 439,575 444,573 448,572 453,570 457,569 462,568 466,567 471,566 475,565 480,564 484,563 489,563 493,562 498,562 502,561 506,561 511,560 515,560 520,559 524,559 529,559 533,558 538,558 542,558 547,558 551,557 556,557 560,557 565,557 569,557 574,557 578,556 583,556 587,556 592,556 596,556 601,556 605,556 610,556 614,556 619,556 623,556 628,556 632,556 637,555 641,555 646,555 650,555 655,555 659,555 664,555 668,555 673,555 677,555 682,555 686,555 691,555 695,555 700,555 704,555 709,555 713,555 718,555 722,555 727,555 731,555 736,555 740,555 745,555 749,555 754,555 758,555 763,555 767,555 772,555 776,555 781,555 785,555 790,555 794,555 799,555 803,555 808,555 812,555 817,555 821,555 826,555 830,555 835,555 839,555 844,555 848,555 853,555 857,555 862,555 866,555 871,555 875,555 880,555 884,555 889,555 893,555 898,555 902,555 907,555 911,555 916,555 920,555 925,555 929,555 934,555 938,555 943,555 947,555 952,555 956,555 961,555 965,555 970,555 974,555 979,555 983,555 988,555 992,555 997,555 1001,555 1006,555 1010,555 1015,555 1019,555 1024,555 1028,555 1033,555 1037,555 1042,555 1046,555 1051,555 1055,555 1060,555 1064,555 1069,555 1073,555 1078,555 1082,555 1087,555 1091,555 1096,555 1100,555 1105,555 1109,555 1114,555 1118,555 1123,555 1127,555 1132,555 1136,555 1141,555 1145,555 1150,555 1154,555 1159,555 1163,555 1168,555 1172,555 1177,555 1181,555 1186,555 1190,555 1195,555 1199,555 1204,555 1208,555 1213,555 1217,555 1222,555 1226,555 1231,555 1235,555 1240,555 1244,555 1249,555 1253,555 1258,555 1262,555 1267,555 1271,555 1276,555 1280,555 1285,555 1289,555 1294,555 1298,555 1303,555 1307,555 1312,555 1316,555 1321,555 1325,555 1330,555 1334,555 1339,555 1343,555 1348,555 1352,555 1357,555 1361,555 1366,555 1370,555 1375,555 1379,555 1384,555 1388,555 1393,555 1397,555 1402,555 1406,555 1411,555 1415,555 1420,555 1424,555 1429,555 1433,555 1438,555 1442,555 1447,555 1451,555 1456,555 1460,555 1465,555 1469,555 1474,555 1478,555 1483,555 1487,555 1492,555 1496,555 1501,555 1505,555 1510,555 1514,555 1519,555 1523,555 1528,555 1532,555 1537,555 1541,555 1546,555 1550,555 1555,555 1559,555 1564,555 1568,555 1573,555 1577,555 1582,555 1586,555 1591,555 1595,555 1600,555 1604,555 1609,555 1613,555 1618,555 1622,555 1626,555 1631,555 1635,555 1640,555 1644,555 1649,555 1653,555 1658,555 1662,555 1667,555 1671,555 1676,555 1680,555 1685,555 1689,555 1694,555 1698,555 1703,555 1707,555 1712,555 1716,555 1721,555 1725,555 1730,555 1734,555 1739,555 1743,555 1748,555 1752,555 1757,555 1761,555 1766,555 1770,555 1775,555 1779,555 1784,555 1788,555 1793,555 1797,555 1802,555 1806,555 1811,555 1815,555 1820,555 1824,555 1829,555 1833,555 1838,555 1842,555 1847,555 1851,555 1856,555 1860,555 1865,555 1869,555 1874,555 1878,555 1883,555 1887,555 1892,555 1896,555 1901,555 1905,555 1910,555 1914,555 1919,555 1923,555 1928,555 1932,555 1937,555 1941,555 1946,555 1950,555 1955,555 1959,555 1964,555 1968,555 1973,555 1977,555 1982,555 1986,555 1991,555 1995,555 2000,555 2004,555 2009,555 2013,555 2018,555 2022,555 2027,555 2031,555 2036,555 2040,555 2045,555 2049,555 2054,555 2058,555 2063,555 2067,555 2072,555 2076,555 2081,555 2085,555 2090,555 2094,555 2099,555 2103,555 2108,555 2112,555 2117,555 2121,555 2126,555 2130,555 2135,555 2139,555 2144,555 2148,555 2153,555 2157,555 2162,555 2166,555 2171,555 2175,555 2180,555 2184,555 2189,555 2193,555 2198,555 2202,555 2207,555 2211,555 2216,555 2220,555 2225,555 2229,555 2234,555 2238,555 2243,555 2247,555 2252,555 2256,555 2261,555 2265,555 2270,555 2274,555 2279,555 2283,555 2288,555 2292,555 2297,555 2301,555 2306,555 2310,555 2315,555 2319,555 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2204" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2204 74,2204 "/>
+<text x="65" y="2084" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2084 74,2084 "/>
+<text x="65" y="1963" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1963 74,1963 "/>
+<text x="65" y="1843" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1843 74,1843 "/>
+<text x="65" y="1722" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1722 74,1722 "/>
+<text x="65" y="1602" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1602 74,1602 "/>
+<text x="65" y="1481" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1481 74,1481 "/>
+<text x="65" y="1361" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1361 74,1361 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2016 151,2004 156,1992 160,1981 165,1970 169,1958 174,1947 178,1936 183,1925 187,1915 192,1905 196,1895 201,1885 205,1875 210,1866 214,1857 219,1848 223,1840 228,1832 232,1824 237,1817 241,1810 246,1803 250,1796 255,1790 259,1784 264,1778 268,1773 273,1767 277,1762 282,1758 286,1753 291,1749 295,1745 300,1741 304,1737 309,1733 313,1730 318,1727 322,1724 327,1721 331,1718 336,1715 340,1713 345,1710 349,1708 354,1706 358,1703 363,1701 367,1699 372,1697 376,1696 381,1694 385,1692 390,1690 394,1689 399,1687 403,1686 408,1684 412,1683 417,1682 421,1680 426,1679 430,1678 435,1677 439,1676 444,1674 448,1673 453,1672 457,1671 462,1670 466,1669 471,1668 475,1667 480,1666 484,1665 489,1664 493,1663 498,1662 502,1661 506,1660 511,1659 515,1658 520,1657 524,1657 529,1656 533,1655 538,1654 542,1653 547,1652 551,1651 556,1650 560,1650 565,1649 569,1648 574,1647 578,1646 583,1645 587,1645 592,1644 596,1643 601,1642 605,1641 610,1641 614,1640 619,1639 623,1638 628,1637 632,1636 637,1636 641,1635 646,1634 650,1633 655,1632 659,1632 664,1631 668,1630 673,1629 677,1628 682,1628 686,1627 691,1626 695,1625 700,1624 704,1624 709,1623 713,1622 718,1621 722,1620 727,1620 731,1619 736,1618 740,1617 745,1616 749,1616 754,1615 758,1614 763,1613 767,1612 772,1612 776,1611 781,1610 785,1609 790,1609 794,1608 799,1607 803,1606 808,1605 812,1605 817,1604 821,1603 826,1602 830,1601 835,1601 839,1600 844,1599 848,1598 853,1597 857,1597 862,1596 866,1595 871,1594 875,1593 880,1593 884,1592 889,1591 893,1590 898,1589 902,1589 907,1588 911,1587 916,1586 920,1586 925,1585 929,1584 934,1583 938,1582 943,1582 947,1581 952,1580 956,1579 961,1578 965,1578 970,1577 974,1576 979,1575 983,1574 988,1574 992,1573 997,1572 1001,1571 1006,1570 1010,1570 1015,1569 1019,1568 1024,1567 1028,1567 1033,1566 1037,1565 1042,1564 1046,1563 1051,1563 1055,1562 1060,1561 1064,1560 1069,1559 1073,1559 1078,1558 1082,1557 1087,1556 1091,1555 1096,1555 1100,1554 1105,1553 1109,1552 1114,1551 1118,1551 1123,1550 1127,1549 1132,1548 1136,1548 1141,1547 1145,1546 1150,1545 1154,1544 1159,1544 1163,1543 1168,1542 1172,1541 1177,1540 1181,1540 1186,1539 1190,1538 1195,1537 1199,1536 1204,1536 1208,1535 1213,1534 1217,1533 1222,1532 1226,1532 1231,1531 1235,1530 1240,1529 1244,1529 1249,1528 1253,1527 1258,1526 1262,1525 1267,1525 1271,1524 1276,1523 1280,1522 1285,1521 1289,1521 1294,1520 1298,1519 1303,1518 1307,1517 1312,1517 1316,1516 1321,1515 1325,1514 1330,1513 1334,1513 1339,1512 1343,1511 1348,1510 1352,1510 1357,1509 1361,1508 1366,1507 1370,1506 1375,1506 1379,1505 1384,1504 1388,1503 1393,1502 1397,1502 1402,1501 1406,1500 1411,1499 1415,1498 1420,1498 1424,1497 1429,1496 1433,1495 1438,1494 1442,1494 1447,1493 1451,1492 1456,1491 1460,1491 1465,1490 1469,1489 1474,1488 1478,1487 1483,1487 1487,1486 1492,1485 1496,1484 1501,1483 1505,1483 1510,1482 1514,1481 1519,1480 1523,1479 1528,1479 1532,1478 1537,1477 1541,1476 1546,1475 1550,1475 1555,1474 1559,1473 1564,1472 1568,1471 1573,1471 1577,1470 1582,1469 1586,1468 1591,1468 1595,1467 1600,1466 1604,1465 1609,1464 1613,1464 1618,1463 1622,1462 1626,1461 1631,1460 1635,1460 1640,1459 1644,1458 1649,1457 1653,1456 1658,1456 1662,1455 1667,1454 1671,1453 1676,1452 1680,1452 1685,1451 1689,1450 1694,1449 1698,1449 1703,1448 1707,1447 1712,1446 1716,1445 1721,1445 1725,1444 1730,1443 1734,1442 1739,1441 1743,1441 1748,1440 1752,1439 1757,1438 1761,1437 1766,1437 1770,1436 1775,1435 1779,1434 1784,1433 1788,1433 1793,1432 1797,1431 1802,1430 1806,1430 1811,1429 1815,1428 1820,1427 1824,1426 1829,1426 1833,1425 1838,1424 1842,1423 1847,1422 1851,1422 1856,1421 1860,1420 1865,1419 1869,1418 1874,1418 1878,1417 1883,1416 1887,1415 1892,1414 1896,1414 1901,1413 1905,1412 1910,1411 1914,1411 1919,1410 1923,1409 1928,1408 1932,1407 1937,1407 1941,1406 1946,1405 1950,1404 1955,1403 1959,1403 1964,1402 1968,1401 1973,1400 1977,1399 1982,1399 1986,1398 1991,1397 1995,1396 2000,1395 2004,1395 2009,1394 2013,1393 2018,1392 2022,1392 2027,1391 2031,1390 2036,1389 2040,1388 2045,1388 2049,1387 2054,1386 2058,1385 2063,1384 2067,1384 2072,1383 2076,1382 2081,1381 2085,1380 2090,1380 2094,1379 2099,1378 2103,1377 2108,1376 2112,1376 2117,1375 2121,1374 2126,1373 2130,1373 2135,1372 2139,1371 2144,1370 2148,1369 2153,1369 2157,1368 2162,1367 2166,1366 2171,1365 2175,1365 2180,1364 2184,1363 2189,1362 2193,1361 2198,1361 2202,1360 2207,1359 2211,1358 2216,1357 2220,1357 2225,1356 2229,1355 2234,1354 2238,1354 2243,1353 2247,1352 2252,1351 2256,1350 2261,1350 2265,1349 2270,1348 2274,1347 2279,1346 2283,1346 2288,1345 2292,1344 2297,1343 2301,1342 2306,1342 2310,1341 2315,1340 2319,1339 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2272 421,2241 426,2212 430,2187 435,2165 439,2144 444,2127 448,2111 453,2097 457,2085 462,2074 466,2064 471,2056 475,2049 480,2043 484,2039 489,2035 493,2031 498,2029 502,2027 507,2025 511,2025 516,2024 520,2024 525,2025 529,2026 534,2027 538,2028 543,2030 547,2032 552,2034 556,2036 561,2039 565,2042 570,2044 574,2047 579,2050 583,2053 588,2056 592,2059 597,2063 601,2066 606,2069 610,2072 615,2076 619,2079 624,2082 628,2086 633,2089 637,2092 642,2095 646,2099 651,2102 655,2105 660,2109 664,2112 669,2115 673,2118 678,2121 682,2124 687,2127 691,2131 696,2133 700,2136 705,2139 709,2142 714,2145 718,2148 723,2151 727,2153 732,2156 736,2159 741,2161 745,2164 750,2167 754,2169 759,2171 763,2174 768,2176 772,2179 777,2181 781,2183 786,2186 790,2188 795,2190 799,2192 804,2194 808,2197 813,2199 817,2201 822,2202 826,2204 831,2206 835,2208 840,2210 844,2212 849,2213 853,2215 858,2217 862,2219 867,2221 871,2222 876,2225 880,2225 885,2227 889,2229 894,2231 898,2232 903,2234 907,2235 912,2236 916,2237 921,2237 925,2237 930,2237 934,2237 939,2237 943,2238 948,2238 952,2238 957,2238 961,2238 966,2238 970,2238 975,2238 979,2238 984,2238 988,2238 993,2238 997,2238 1002,2238 1006,2238 1011,2238 1015,2238 1020,2238 1024,2238 1029,2238 1033,2239 1038,2239 1042,2239 1047,2239 1051,2238 1056,2238 1060,2238 1065,2238 1069,2238 1074,2239 1078,2239 1083,2239 1087,2239 1092,2239 1096,2239 1101,2239 1105,2239 1110,2239 1114,2239 1119,2239 1123,2239 1128,2239 1132,2239 1137,2239 1141,2239 1146,2239 1150,2239 1155,2239 1159,2239 1164,2240 1168,2239 1173,2239 1177,2240 1182,2240 1186,2240 1191,2239 1195,2239 1200,2239 1204,2239 1209,2239 1213,2239 1218,2239 1222,2240 1227,2240 1231,2240 1236,2240 1240,2240 1245,2240 1249,2240 1254,2240 1258,2239 1263,2239 1267,2239 1272,2240 1276,2240 1281,2240 1285,2240 1290,2240 1294,2240 1299,2240 1303,2240 1308,2240 1312,2240 1317,2240 1321,2240 1326,2240 1330,2240 1335,2240 1339,2240 1344,2240 1348,2240 1353,2240 1357,2240 1362,2241 1366,2241 1371,2241 1375,2241 1380,2241 1384,2241 1389,2241 1393,2241 1398,2240 1402,2240 1407,2240 1411,2241 1416,2241 1420,2241 1425,2241 1429,2241 1434,2241 1438,2241 1443,2241 1447,2241 1452,2241 1456,2241 1461,2242 1465,2241 1470,2241 1474,2241 1479,2241 1483,2241 1488,2241 1492,2241 1497,2241 1501,2242 1506,2242 1510,2242 1515,2242 1519,2242 1524,2242 1528,2242 1533,2241 1537,2241 1542,2241 1546,2241 1551,2241 1555,2242 1560,2242 1564,2242 1569,2242 1573,2242 1578,2242 1582,2242 1587,2242 1591,2242 1596,2242 1600,2241 1605,2241 1609,2241 1614,2242 1618,2242 1623,2242 1627,2242 1632,2242 1636,2242 1641,2242 1645,2242 1650,2242 1654,2242 1659,2242 1663,2242 1668,2243 1672,2242 1677,2242 1681,2242 1686,2242 1690,2242 1695,2242 1699,2242 1704,2242 1708,2242 1713,2243 1717,2243 1722,2243 1726,2243 1731,2243 1735,2243 1740,2242 1744,2242 1749,2242 1753,2242 1758,2242 1762,2242 1767,2242 1771,2243 1776,2243 1780,2243 1785,2243 1789,2243 1794,2243 1798,2243 1803,2243 1807,2242 1812,2242 1816,2242 1821,2243 1825,2243 1830,2243 1834,2243 1839,2243 1843,2243 1848,2243 1852,2243 1857,2243 1861,2243 1866,2244 1870,2243 1875,2243 1879,2243 1884,2243 1888,2243 1893,2243 1897,2243 1902,2243 1906,2243 1911,2243 1915,2243 1920,2243 1924,2243 1929,2243 1933,2244 1938,2244 1942,2244 1947,2243 1951,2243 1956,2243 1960,2243 1965,2243 1969,2243 1974,2243 1978,2244 1983,2244 1987,2244 1992,2244 1996,2244 2001,2244 2005,2244 2010,2244 2014,2243 2019,2243 2023,2243 2028,2243 2032,2244 2037,2244 2041,2244 2046,2244 2050,2244 2055,2244 2059,2244 2064,2244 2068,2244 2073,2244 2077,2244 2082,2243 2086,2243 2091,2243 2095,2244 2100,2244 2104,2244 2109,2244 2113,2244 2118,2244 2122,2244 2127,2244 2131,2244 2136,2244 2140,2244 2145,2244 2149,2244 2154,2244 2158,2244 2163,2244 2167,2244 2172,2244 2176,2244 2181,2244 2185,2244 2190,2244 2194,2244 2199,2244 2203,2244 2208,2244 2212,2245 2217,2245 2221,2244 2226,2244 2230,2244 2235,2244 2239,2244 2244,2244 2248,2244 2253,2244 2257,2244 2262,2244 2266,2245 2271,2245 2275,2245 2280,2245 2284,2245 2289,2244 2293,2244 2298,2244 2302,2244 2307,2244 2311,2244 2316,2244 2320,2245 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Strong growth, tapering fees_0.000200.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Strong growth, tapering fees_0.000200.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Strong growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,956 88,947 93,939 97,931 102,923 106,914 111,906 115,899 120,891 124,883 129,876 133,869 138,861 142,854 147,847 151,840 156,834 160,827 165,821 169,814 174,808 178,802 183,796 187,790 192,784 196,778 201,772 205,767 210,761 214,756 219,751 223,745 228,740 232,735 237,730 241,725 246,720 250,716 255,711 259,706 264,702 268,697 273,693 277,689 282,684 286,680 291,676 295,672 300,668 304,664 309,660 313,657 318,653 322,649 327,646 331,642 336,639 340,635 345,632 349,629 354,626 358,623 363,620 367,617 372,615 376,612 381,610 385,608 390,605 394,603 399,601 403,599 408,598 412,596 417,594 421,593 426,591 430,590 435,588 439,587 444,585 448,584 453,583 457,582 462,581 466,580 471,579 475,578 480,577 484,576 489,575 493,574 498,573 502,573 506,572 511,571 515,571 520,570 524,569 529,569 533,568 538,568 542,567 547,567 551,566 556,566 560,565 565,565 569,564 574,564 578,564 583,563 587,563 592,563 596,562 601,562 605,562 610,561 614,561 619,561 623,561 628,560 632,560 637,560 641,560 646,560 650,559 655,559 659,559 664,559 668,559 673,559 677,558 682,558 686,558 691,558 695,558 700,558 704,558 709,558 713,557 718,557 722,557 727,557 731,557 736,557 740,557 745,557 749,557 754,557 758,557 763,557 767,556 772,556 776,556 781,556 785,556 790,556 794,556 799,556 803,556 808,556 812,556 817,556 821,556 826,556 830,556 835,556 839,556 844,556 848,556 853,556 857,556 862,556 866,556 871,556 875,556 880,556 884,555 889,555 893,555 898,555 902,555 907,555 911,555 916,555 920,555 925,555 929,555 934,555 938,555 943,555 947,555 952,555 956,555 961,555 965,555 970,555 974,555 979,555 983,555 988,555 992,555 997,555 1001,555 1006,555 1010,555 1015,555 1019,555 1024,555 1028,555 1033,555 1037,555 1042,555 1046,555 1051,555 1055,555 1060,555 1064,555 1069,555 1073,555 1078,555 1082,555 1087,555 1091,555 1096,555 1100,555 1105,555 1109,555 1114,555 1118,555 1123,555 1127,555 1132,555 1136,555 1141,555 1145,555 1150,555 1154,555 1159,555 1163,555 1168,555 1172,555 1177,555 1181,555 1186,555 1190,555 1195,555 1199,555 1204,555 1208,555 1213,555 1217,555 1222,555 1226,555 1231,555 1235,555 1240,555 1244,555 1249,555 1253,555 1258,555 1262,555 1267,555 1271,555 1276,555 1280,555 1285,555 1289,555 1294,555 1298,555 1303,555 1307,555 1312,555 1316,555 1321,555 1325,555 1330,555 1334,555 1339,555 1343,555 1348,555 1352,555 1357,555 1361,555 1366,555 1370,555 1375,555 1379,555 1384,555 1388,555 1393,555 1397,555 1402,555 1406,555 1411,555 1415,555 1420,555 1424,555 1429,555 1433,555 1438,555 1442,555 1447,555 1451,555 1456,555 1460,555 1465,555 1469,555 1474,555 1478,555 1483,555 1487,555 1492,555 1496,555 1501,555 1505,555 1510,555 1514,555 1519,555 1523,555 1528,555 1532,555 1537,555 1541,555 1546,555 1550,555 1555,555 1559,555 1564,555 1568,555 1573,555 1577,555 1582,555 1586,555 1591,555 1595,555 1600,555 1604,555 1609,555 1613,555 1618,555 1622,555 1626,555 1631,555 1635,555 1640,555 1644,555 1649,555 1653,555 1658,555 1662,555 1667,555 1671,555 1676,555 1680,555 1685,555 1689,555 1694,555 1698,555 1703,555 1707,555 1712,555 1716,555 1721,555 1725,555 1730,555 1734,555 1739,555 1743,555 1748,555 1752,555 1757,555 1761,555 1766,555 1770,555 1775,555 1779,555 1784,555 1788,555 1793,555 1797,555 1802,555 1806,555 1811,555 1815,555 1820,555 1824,555 1829,555 1833,555 1838,555 1842,555 1847,555 1851,555 1856,555 1860,555 1865,555 1869,555 1874,555 1878,555 1883,555 1887,555 1892,555 1896,555 1901,555 1905,555 1910,555 1914,555 1919,555 1923,555 1928,555 1932,555 1937,555 1941,555 1946,555 1950,555 1955,555 1959,555 1964,555 1968,555 1973,555 1977,555 1982,555 1986,555 1991,555 1995,555 2000,555 2004,555 2009,555 2013,555 2018,555 2022,555 2027,555 2031,555 2036,555 2040,555 2045,555 2049,555 2054,555 2058,555 2063,555 2067,555 2072,555 2076,555 2081,555 2085,555 2090,555 2094,555 2099,555 2103,555 2108,555 2112,555 2117,555 2121,555 2126,555 2130,555 2135,555 2139,555 2144,555 2148,555 2153,555 2157,555 2162,555 2166,555 2171,555 2175,555 2180,555 2184,555 2189,555 2193,555 2198,555 2202,555 2207,555 2211,555 2216,555 2220,555 2225,555 2229,555 2234,555 2238,555 2243,555 2247,555 2252,555 2256,555 2261,555 2265,555 2270,555 2274,555 2279,555 2283,555 2288,555 2292,555 2297,555 2301,555 2306,555 2310,555 2315,555 2319,555 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2204" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2204 74,2204 "/>
+<text x="65" y="2084" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2084 74,2084 "/>
+<text x="65" y="1963" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1963 74,1963 "/>
+<text x="65" y="1843" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1843 74,1843 "/>
+<text x="65" y="1722" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1722 74,1722 "/>
+<text x="65" y="1602" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1602 74,1602 "/>
+<text x="65" y="1481" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1481 74,1481 "/>
+<text x="65" y="1361" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1361 74,1361 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2016 151,2004 156,1992 160,1981 165,1970 169,1958 174,1947 178,1936 183,1925 187,1915 192,1905 196,1895 201,1885 205,1875 210,1866 214,1857 219,1848 223,1840 228,1832 232,1824 237,1817 241,1810 246,1803 250,1796 255,1790 259,1784 264,1778 268,1773 273,1767 277,1762 282,1758 286,1753 291,1749 295,1745 300,1741 304,1737 309,1733 313,1730 318,1727 322,1724 327,1721 331,1718 336,1715 340,1713 345,1710 349,1708 354,1706 358,1703 363,1701 367,1699 372,1697 376,1696 381,1694 385,1692 390,1690 394,1689 399,1687 403,1686 408,1684 412,1683 417,1682 421,1680 426,1679 430,1678 435,1677 439,1676 444,1674 448,1673 453,1672 457,1671 462,1670 466,1669 471,1668 475,1667 480,1666 484,1665 489,1664 493,1663 498,1662 502,1661 506,1660 511,1659 515,1658 520,1657 524,1657 529,1656 533,1655 538,1654 542,1653 547,1652 551,1651 556,1650 560,1650 565,1649 569,1648 574,1647 578,1646 583,1645 587,1645 592,1644 596,1643 601,1642 605,1641 610,1641 614,1640 619,1639 623,1638 628,1637 632,1636 637,1636 641,1635 646,1634 650,1633 655,1632 659,1632 664,1631 668,1630 673,1629 677,1628 682,1628 686,1627 691,1626 695,1625 700,1624 704,1624 709,1623 713,1622 718,1621 722,1620 727,1620 731,1619 736,1618 740,1617 745,1616 749,1616 754,1615 758,1614 763,1613 767,1612 772,1612 776,1611 781,1610 785,1609 790,1609 794,1608 799,1607 803,1606 808,1605 812,1605 817,1604 821,1603 826,1602 830,1601 835,1601 839,1600 844,1599 848,1598 853,1597 857,1597 862,1596 866,1595 871,1594 875,1593 880,1593 884,1592 889,1591 893,1590 898,1589 902,1589 907,1588 911,1587 916,1586 920,1586 925,1585 929,1584 934,1583 938,1582 943,1582 947,1581 952,1580 956,1579 961,1578 965,1578 970,1577 974,1576 979,1575 983,1574 988,1574 992,1573 997,1572 1001,1571 1006,1570 1010,1570 1015,1569 1019,1568 1024,1567 1028,1567 1033,1566 1037,1565 1042,1564 1046,1563 1051,1563 1055,1562 1060,1561 1064,1560 1069,1559 1073,1559 1078,1558 1082,1557 1087,1556 1091,1555 1096,1555 1100,1554 1105,1553 1109,1552 1114,1551 1118,1551 1123,1550 1127,1549 1132,1548 1136,1548 1141,1547 1145,1546 1150,1545 1154,1544 1159,1544 1163,1543 1168,1542 1172,1541 1177,1540 1181,1540 1186,1539 1190,1538 1195,1537 1199,1536 1204,1536 1208,1535 1213,1534 1217,1533 1222,1532 1226,1532 1231,1531 1235,1530 1240,1529 1244,1529 1249,1528 1253,1527 1258,1526 1262,1525 1267,1525 1271,1524 1276,1523 1280,1522 1285,1521 1289,1521 1294,1520 1298,1519 1303,1518 1307,1517 1312,1517 1316,1516 1321,1515 1325,1514 1330,1513 1334,1513 1339,1512 1343,1511 1348,1510 1352,1510 1357,1509 1361,1508 1366,1507 1370,1506 1375,1506 1379,1505 1384,1504 1388,1503 1393,1502 1397,1502 1402,1501 1406,1500 1411,1499 1415,1498 1420,1498 1424,1497 1429,1496 1433,1495 1438,1494 1442,1494 1447,1493 1451,1492 1456,1491 1460,1491 1465,1490 1469,1489 1474,1488 1478,1487 1483,1487 1487,1486 1492,1485 1496,1484 1501,1483 1505,1483 1510,1482 1514,1481 1519,1480 1523,1479 1528,1479 1532,1478 1537,1477 1541,1476 1546,1475 1550,1475 1555,1474 1559,1473 1564,1472 1568,1471 1573,1471 1577,1470 1582,1469 1586,1468 1591,1468 1595,1467 1600,1466 1604,1465 1609,1464 1613,1464 1618,1463 1622,1462 1626,1461 1631,1460 1635,1460 1640,1459 1644,1458 1649,1457 1653,1456 1658,1456 1662,1455 1667,1454 1671,1453 1676,1452 1680,1452 1685,1451 1689,1450 1694,1449 1698,1449 1703,1448 1707,1447 1712,1446 1716,1445 1721,1445 1725,1444 1730,1443 1734,1442 1739,1441 1743,1441 1748,1440 1752,1439 1757,1438 1761,1437 1766,1437 1770,1436 1775,1435 1779,1434 1784,1433 1788,1433 1793,1432 1797,1431 1802,1430 1806,1430 1811,1429 1815,1428 1820,1427 1824,1426 1829,1426 1833,1425 1838,1424 1842,1423 1847,1422 1851,1422 1856,1421 1860,1420 1865,1419 1869,1418 1874,1418 1878,1417 1883,1416 1887,1415 1892,1414 1896,1414 1901,1413 1905,1412 1910,1411 1914,1411 1919,1410 1923,1409 1928,1408 1932,1407 1937,1407 1941,1406 1946,1405 1950,1404 1955,1403 1959,1403 1964,1402 1968,1401 1973,1400 1977,1399 1982,1399 1986,1398 1991,1397 1995,1396 2000,1395 2004,1395 2009,1394 2013,1393 2018,1392 2022,1392 2027,1391 2031,1390 2036,1389 2040,1388 2045,1388 2049,1387 2054,1386 2058,1385 2063,1384 2067,1384 2072,1383 2076,1382 2081,1381 2085,1380 2090,1380 2094,1379 2099,1378 2103,1377 2108,1376 2112,1376 2117,1375 2121,1374 2126,1373 2130,1373 2135,1372 2139,1371 2144,1370 2148,1369 2153,1369 2157,1368 2162,1367 2166,1366 2171,1365 2175,1365 2180,1364 2184,1363 2189,1362 2193,1361 2198,1361 2202,1360 2207,1359 2211,1358 2216,1357 2220,1357 2225,1356 2229,1355 2234,1354 2238,1354 2243,1353 2247,1352 2252,1351 2256,1350 2261,1350 2265,1349 2270,1348 2274,1347 2279,1346 2283,1346 2288,1345 2292,1344 2297,1343 2301,1342 2306,1342 2310,1341 2315,1340 2319,1339 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2272 345,2255 349,2240 354,2225 358,2211 363,2199 367,2186 372,2176 376,2165 381,2156 385,2147 390,2139 394,2131 399,2124 403,2118 408,2112 412,2106 417,2102 421,2097 426,2093 430,2089 435,2086 439,2083 444,2081 448,2078 453,2076 457,2075 462,2073 466,2072 471,2071 475,2071 480,2070 484,2070 489,2070 493,2070 498,2070 502,2071 507,2071 511,2072 516,2073 520,2074 525,2075 529,2076 534,2077 538,2079 543,2080 547,2082 552,2083 556,2085 561,2087 565,2089 570,2091 574,2092 579,2094 583,2096 588,2098 592,2101 597,2103 601,2105 606,2107 610,2109 615,2112 619,2114 624,2116 628,2118 633,2121 637,2123 642,2125 646,2127 651,2130 655,2132 660,2135 664,2136 669,2139 673,2141 678,2144 682,2146 687,2148 691,2150 696,2153 700,2155 705,2157 709,2159 714,2161 718,2164 723,2166 727,2168 732,2170 736,2172 741,2174 745,2177 750,2178 754,2180 759,2182 763,2185 768,2186 772,2188 777,2190 781,2192 786,2194 790,2196 795,2198 799,2200 804,2201 808,2203 813,2205 817,2207 822,2208 826,2210 831,2212 835,2214 840,2215 844,2217 849,2219 853,2220 858,2222 862,2223 867,2225 871,2226 876,2228 880,2229 885,2231 889,2232 894,2234 898,2235 903,2236 907,2238 912,2239 916,2240 921,2240 925,2239 930,2240 934,2240 939,2239 943,2239 948,2240 952,2239 957,2239 961,2240 966,2240 970,2239 975,2240 979,2240 984,2239 988,2239 993,2239 997,2239 1002,2239 1006,2239 1011,2239 1015,2239 1020,2239 1024,2239 1029,2239 1033,2239 1038,2240 1042,2240 1047,2239 1051,2239 1056,2239 1060,2239 1065,2239 1069,2239 1074,2239 1078,2239 1083,2239 1087,2239 1092,2239 1096,2239 1101,2239 1105,2239 1110,2239 1114,2240 1119,2240 1123,2239 1128,2239 1132,2239 1137,2239 1141,2239 1146,2239 1150,2239 1155,2239 1159,2240 1164,2240 1168,2240 1173,2240 1177,2240 1182,2240 1186,2240 1191,2239 1195,2239 1200,2239 1204,2239 1209,2239 1213,2239 1218,2239 1222,2240 1227,2240 1231,2240 1236,2240 1240,2240 1245,2240 1249,2240 1254,2240 1258,2239 1263,2240 1267,2240 1272,2240 1276,2240 1281,2240 1285,2240 1290,2240 1294,2241 1299,2240 1303,2240 1308,2240 1312,2240 1317,2241 1321,2241 1326,2240 1330,2240 1335,2240 1339,2240 1344,2240 1348,2240 1353,2240 1357,2240 1362,2241 1366,2241 1371,2241 1375,2241 1380,2241 1384,2241 1389,2241 1393,2241 1398,2240 1402,2240 1407,2241 1411,2241 1416,2241 1420,2241 1425,2241 1429,2241 1434,2241 1438,2241 1443,2241 1447,2241 1452,2241 1456,2242 1461,2241 1465,2241 1470,2241 1474,2241 1479,2241 1483,2241 1488,2241 1492,2241 1497,2241 1501,2241 1506,2241 1510,2242 1515,2242 1519,2242 1524,2242 1528,2242 1533,2241 1537,2241 1542,2241 1546,2241 1551,2241 1555,2242 1560,2242 1564,2242 1569,2242 1573,2242 1578,2242 1582,2242 1587,2242 1591,2242 1596,2242 1600,2241 1605,2241 1609,2242 1614,2242 1618,2242 1623,2242 1627,2242 1632,2242 1636,2242 1641,2242 1645,2242 1650,2242 1654,2242 1659,2242 1663,2242 1668,2242 1672,2242 1677,2242 1681,2242 1686,2242 1690,2242 1695,2242 1699,2243 1704,2242 1708,2242 1713,2242 1717,2243 1722,2243 1726,2243 1731,2243 1735,2243 1740,2242 1744,2242 1749,2242 1753,2242 1758,2243 1762,2242 1767,2242 1771,2243 1776,2243 1780,2243 1785,2243 1789,2243 1794,2243 1798,2243 1803,2243 1807,2242 1812,2242 1816,2242 1821,2243 1825,2243 1830,2243 1834,2243 1839,2243 1843,2243 1848,2243 1852,2243 1857,2243 1861,2243 1866,2244 1870,2243 1875,2243 1879,2243 1884,2243 1888,2243 1893,2243 1897,2243 1902,2243 1906,2243 1911,2243 1915,2243 1920,2243 1924,2243 1929,2243 1933,2244 1938,2244 1942,2244 1947,2243 1951,2243 1956,2243 1960,2243 1965,2243 1969,2243 1974,2243 1978,2244 1983,2243 1987,2244 1992,2244 1996,2244 2001,2244 2005,2244 2010,2244 2014,2243 2019,2243 2023,2243 2028,2243 2032,2243 2037,2243 2041,2244 2046,2244 2050,2244 2055,2244 2059,2244 2064,2244 2068,2244 2073,2244 2077,2244 2082,2243 2086,2243 2091,2244 2095,2244 2100,2244 2104,2244 2109,2244 2113,2244 2118,2244 2122,2244 2127,2244 2131,2244 2136,2244 2140,2244 2145,2244 2149,2244 2154,2244 2158,2244 2163,2244 2167,2244 2172,2244 2176,2244 2181,2244 2185,2244 2190,2244 2194,2244 2199,2244 2203,2244 2208,2244 2212,2245 2217,2245 2221,2244 2226,2244 2230,2244 2235,2244 2239,2244 2244,2244 2248,2244 2253,2244 2257,2244 2262,2244 2266,2245 2271,2245 2275,2245 2280,2245 2284,2245 2289,2244 2293,2244 2298,2244 2302,2244 2307,2244 2311,2244 2316,2244 2320,2245 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Strong growth, tapering fees_0.000300.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Strong growth, tapering fees_0.000300.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Strong growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,956 88,947 93,939 97,931 102,923 106,914 111,906 115,899 120,891 124,883 129,876 133,869 138,861 142,854 147,847 151,840 156,834 160,827 165,821 169,814 174,808 178,802 183,796 187,790 192,784 196,778 201,772 205,767 210,761 214,756 219,751 223,745 228,740 232,735 237,730 241,725 246,721 250,716 255,711 259,707 264,703 268,699 273,695 277,691 282,687 286,684 291,680 295,677 300,673 304,670 309,667 313,664 318,661 322,658 327,655 331,652 336,649 340,647 345,644 349,642 354,639 358,637 363,635 367,633 372,631 376,628 381,626 385,624 390,623 394,621 399,619 403,617 408,615 412,614 417,612 421,610 426,609 430,607 435,606 439,605 444,603 448,602 453,601 457,599 462,598 466,597 471,596 475,595 480,594 484,592 489,591 493,590 498,589 502,589 506,588 511,587 515,586 520,585 524,584 529,583 533,583 538,582 542,581 547,580 551,580 556,579 560,578 565,578 569,577 574,576 578,576 583,575 587,575 592,574 596,574 601,573 605,573 610,572 614,572 619,571 623,571 628,570 632,570 637,569 641,569 646,569 650,568 655,568 659,568 664,567 668,567 673,567 677,566 682,566 686,566 691,565 695,565 700,565 704,564 709,564 713,564 718,564 722,563 727,563 731,563 736,563 740,563 745,562 749,562 754,562 758,562 763,562 767,561 772,561 776,561 781,561 785,561 790,561 794,560 799,560 803,560 808,560 812,560 817,560 821,560 826,559 830,559 835,559 839,559 844,559 848,559 853,559 857,559 862,559 866,558 871,558 875,558 880,558 884,558 889,558 893,558 898,558 902,558 907,558 911,558 916,558 920,557 925,557 929,557 934,557 938,557 943,557 947,557 952,557 956,557 961,557 965,557 970,557 974,557 979,557 983,557 988,557 992,557 997,557 1001,556 1006,556 1010,556 1015,556 1019,556 1024,556 1028,556 1033,556 1037,556 1042,556 1046,556 1051,556 1055,556 1060,556 1064,556 1069,556 1073,556 1078,556 1082,556 1087,556 1091,556 1096,556 1100,556 1105,556 1109,556 1114,556 1118,556 1123,556 1127,556 1132,556 1136,556 1141,556 1145,556 1150,556 1154,556 1159,556 1163,556 1168,556 1172,556 1177,555 1181,555 1186,555 1190,555 1195,555 1199,555 1204,555 1208,555 1213,555 1217,555 1222,555 1226,555 1231,555 1235,555 1240,555 1244,555 1249,555 1253,555 1258,555 1262,555 1267,555 1271,555 1276,555 1280,555 1285,555 1289,555 1294,555 1298,555 1303,555 1307,555 1312,555 1316,555 1321,555 1325,555 1330,555 1334,555 1339,555 1343,555 1348,555 1352,555 1357,555 1361,555 1366,555 1370,555 1375,555 1379,555 1384,555 1388,555 1393,555 1397,555 1402,555 1406,555 1411,555 1415,555 1420,555 1424,555 1429,555 1433,555 1438,555 1442,555 1447,555 1451,555 1456,555 1460,555 1465,555 1469,555 1474,555 1478,555 1483,555 1487,555 1492,555 1496,555 1501,555 1505,555 1510,555 1514,555 1519,555 1523,555 1528,555 1532,555 1537,555 1541,555 1546,555 1550,555 1555,555 1559,555 1564,555 1568,555 1573,555 1577,555 1582,555 1586,555 1591,555 1595,555 1600,555 1604,555 1609,555 1613,555 1618,555 1622,555 1626,555 1631,555 1635,555 1640,555 1644,555 1649,555 1653,555 1658,555 1662,555 1667,555 1671,555 1676,555 1680,555 1685,555 1689,555 1694,555 1698,555 1703,555 1707,555 1712,555 1716,555 1721,555 1725,555 1730,555 1734,555 1739,555 1743,555 1748,555 1752,555 1757,555 1761,555 1766,555 1770,555 1775,555 1779,555 1784,555 1788,555 1793,555 1797,555 1802,555 1806,555 1811,555 1815,555 1820,555 1824,555 1829,555 1833,555 1838,555 1842,555 1847,555 1851,555 1856,555 1860,555 1865,555 1869,555 1874,555 1878,555 1883,555 1887,555 1892,555 1896,555 1901,555 1905,555 1910,555 1914,555 1919,555 1923,555 1928,555 1932,555 1937,555 1941,555 1946,555 1950,555 1955,555 1959,555 1964,555 1968,555 1973,555 1977,555 1982,555 1986,555 1991,555 1995,555 2000,555 2004,555 2009,555 2013,555 2018,555 2022,555 2027,555 2031,555 2036,555 2040,555 2045,555 2049,555 2054,555 2058,555 2063,555 2067,555 2072,555 2076,555 2081,555 2085,555 2090,555 2094,555 2099,555 2103,555 2108,555 2112,555 2117,555 2121,555 2126,555 2130,555 2135,555 2139,555 2144,555 2148,555 2153,555 2157,555 2162,555 2166,555 2171,555 2175,555 2180,555 2184,555 2189,555 2193,555 2198,555 2202,555 2207,555 2211,555 2216,555 2220,555 2225,555 2229,555 2234,555 2238,555 2243,555 2247,555 2252,555 2256,555 2261,555 2265,555 2270,555 2274,555 2279,555 2283,555 2288,555 2292,555 2297,555 2301,555 2306,555 2310,555 2315,555 2319,555 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2204" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2204 74,2204 "/>
+<text x="65" y="2084" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2084 74,2084 "/>
+<text x="65" y="1963" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1963 74,1963 "/>
+<text x="65" y="1843" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1843 74,1843 "/>
+<text x="65" y="1722" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1722 74,1722 "/>
+<text x="65" y="1602" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1602 74,1602 "/>
+<text x="65" y="1481" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1481 74,1481 "/>
+<text x="65" y="1361" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1361 74,1361 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2016 151,2004 156,1992 160,1981 165,1970 169,1958 174,1947 178,1936 183,1925 187,1915 192,1905 196,1895 201,1885 205,1875 210,1866 214,1857 219,1848 223,1840 228,1832 232,1824 237,1817 241,1810 246,1803 250,1796 255,1790 259,1784 264,1778 268,1773 273,1767 277,1762 282,1758 286,1753 291,1749 295,1745 300,1741 304,1737 309,1733 313,1730 318,1727 322,1724 327,1721 331,1718 336,1715 340,1713 345,1710 349,1708 354,1706 358,1703 363,1701 367,1699 372,1697 376,1696 381,1694 385,1692 390,1690 394,1689 399,1687 403,1686 408,1684 412,1683 417,1682 421,1680 426,1679 430,1678 435,1677 439,1676 444,1674 448,1673 453,1672 457,1671 462,1670 466,1669 471,1668 475,1667 480,1666 484,1665 489,1664 493,1663 498,1662 502,1661 506,1660 511,1659 515,1658 520,1657 524,1657 529,1656 533,1655 538,1654 542,1653 547,1652 551,1651 556,1650 560,1650 565,1649 569,1648 574,1647 578,1646 583,1645 587,1645 592,1644 596,1643 601,1642 605,1641 610,1641 614,1640 619,1639 623,1638 628,1637 632,1636 637,1636 641,1635 646,1634 650,1633 655,1632 659,1632 664,1631 668,1630 673,1629 677,1628 682,1628 686,1627 691,1626 695,1625 700,1624 704,1624 709,1623 713,1622 718,1621 722,1620 727,1620 731,1619 736,1618 740,1617 745,1616 749,1616 754,1615 758,1614 763,1613 767,1612 772,1612 776,1611 781,1610 785,1609 790,1609 794,1608 799,1607 803,1606 808,1605 812,1605 817,1604 821,1603 826,1602 830,1601 835,1601 839,1600 844,1599 848,1598 853,1597 857,1597 862,1596 866,1595 871,1594 875,1593 880,1593 884,1592 889,1591 893,1590 898,1589 902,1589 907,1588 911,1587 916,1586 920,1586 925,1585 929,1584 934,1583 938,1582 943,1582 947,1581 952,1580 956,1579 961,1578 965,1578 970,1577 974,1576 979,1575 983,1574 988,1574 992,1573 997,1572 1001,1571 1006,1570 1010,1570 1015,1569 1019,1568 1024,1567 1028,1567 1033,1566 1037,1565 1042,1564 1046,1563 1051,1563 1055,1562 1060,1561 1064,1560 1069,1559 1073,1559 1078,1558 1082,1557 1087,1556 1091,1555 1096,1555 1100,1554 1105,1553 1109,1552 1114,1551 1118,1551 1123,1550 1127,1549 1132,1548 1136,1548 1141,1547 1145,1546 1150,1545 1154,1544 1159,1544 1163,1543 1168,1542 1172,1541 1177,1540 1181,1540 1186,1539 1190,1538 1195,1537 1199,1536 1204,1536 1208,1535 1213,1534 1217,1533 1222,1532 1226,1532 1231,1531 1235,1530 1240,1529 1244,1529 1249,1528 1253,1527 1258,1526 1262,1525 1267,1525 1271,1524 1276,1523 1280,1522 1285,1521 1289,1521 1294,1520 1298,1519 1303,1518 1307,1517 1312,1517 1316,1516 1321,1515 1325,1514 1330,1513 1334,1513 1339,1512 1343,1511 1348,1510 1352,1510 1357,1509 1361,1508 1366,1507 1370,1506 1375,1506 1379,1505 1384,1504 1388,1503 1393,1502 1397,1502 1402,1501 1406,1500 1411,1499 1415,1498 1420,1498 1424,1497 1429,1496 1433,1495 1438,1494 1442,1494 1447,1493 1451,1492 1456,1491 1460,1491 1465,1490 1469,1489 1474,1488 1478,1487 1483,1487 1487,1486 1492,1485 1496,1484 1501,1483 1505,1483 1510,1482 1514,1481 1519,1480 1523,1479 1528,1479 1532,1478 1537,1477 1541,1476 1546,1475 1550,1475 1555,1474 1559,1473 1564,1472 1568,1471 1573,1471 1577,1470 1582,1469 1586,1468 1591,1468 1595,1467 1600,1466 1604,1465 1609,1464 1613,1464 1618,1463 1622,1462 1626,1461 1631,1460 1635,1460 1640,1459 1644,1458 1649,1457 1653,1456 1658,1456 1662,1455 1667,1454 1671,1453 1676,1452 1680,1452 1685,1451 1689,1450 1694,1449 1698,1449 1703,1448 1707,1447 1712,1446 1716,1445 1721,1445 1725,1444 1730,1443 1734,1442 1739,1441 1743,1441 1748,1440 1752,1439 1757,1438 1761,1437 1766,1437 1770,1436 1775,1435 1779,1434 1784,1433 1788,1433 1793,1432 1797,1431 1802,1430 1806,1430 1811,1429 1815,1428 1820,1427 1824,1426 1829,1426 1833,1425 1838,1424 1842,1423 1847,1422 1851,1422 1856,1421 1860,1420 1865,1419 1869,1418 1874,1418 1878,1417 1883,1416 1887,1415 1892,1414 1896,1414 1901,1413 1905,1412 1910,1411 1914,1411 1919,1410 1923,1409 1928,1408 1932,1407 1937,1407 1941,1406 1946,1405 1950,1404 1955,1403 1959,1403 1964,1402 1968,1401 1973,1400 1977,1399 1982,1399 1986,1398 1991,1397 1995,1396 2000,1395 2004,1395 2009,1394 2013,1393 2018,1392 2022,1392 2027,1391 2031,1390 2036,1389 2040,1388 2045,1388 2049,1387 2054,1386 2058,1385 2063,1384 2067,1384 2072,1383 2076,1382 2081,1381 2085,1380 2090,1380 2094,1379 2099,1378 2103,1377 2108,1376 2112,1376 2117,1375 2121,1374 2126,1373 2130,1373 2135,1372 2139,1371 2144,1370 2148,1369 2153,1369 2157,1368 2162,1367 2166,1366 2171,1365 2175,1365 2180,1364 2184,1363 2189,1362 2193,1361 2198,1361 2202,1360 2207,1359 2211,1358 2216,1357 2220,1357 2225,1356 2229,1355 2234,1354 2238,1354 2243,1353 2247,1352 2252,1351 2256,1350 2261,1350 2265,1349 2270,1348 2274,1347 2279,1346 2283,1346 2288,1345 2292,1344 2297,1343 2301,1342 2306,1342 2310,1341 2315,1340 2319,1339 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2265 241,2252 246,2239 250,2228 255,2217 259,2208 264,2198 268,2190 273,2182 277,2174 282,2168 286,2161 291,2155 295,2149 300,2144 304,2139 309,2134 313,2130 318,2126 322,2123 327,2119 331,2116 336,2113 340,2110 345,2108 349,2106 354,2104 358,2102 363,2100 367,2098 372,2097 376,2096 381,2095 385,2095 390,2094 394,2093 399,2093 403,2092 408,2092 412,2092 417,2092 421,2092 426,2092 430,2092 435,2093 439,2093 444,2094 448,2095 453,2095 457,2096 462,2097 466,2098 471,2099 475,2100 480,2101 484,2102 489,2104 493,2105 498,2106 502,2108 507,2109 511,2110 516,2112 520,2113 525,2115 529,2116 534,2118 538,2119 543,2121 547,2123 552,2124 556,2126 561,2128 565,2130 570,2131 574,2133 579,2135 583,2137 588,2139 592,2140 597,2142 601,2144 606,2145 610,2147 615,2149 619,2151 624,2152 628,2154 633,2156 637,2158 642,2160 646,2162 651,2163 655,2165 660,2167 664,2168 669,2171 673,2172 678,2174 682,2176 687,2177 691,2179 696,2181 700,2183 705,2184 709,2186 714,2188 718,2189 723,2191 727,2193 732,2195 736,2196 741,2198 745,2199 750,2201 754,2202 759,2204 763,2205 768,2207 772,2208 777,2210 781,2211 786,2213 790,2214 795,2216 799,2217 804,2219 808,2220 813,2221 817,2223 822,2224 826,2226 831,2227 835,2228 840,2230 844,2231 849,2232 853,2234 858,2235 862,2236 867,2237 871,2238 876,2240 880,2241 885,2242 889,2243 894,2244 898,2245 903,2247 907,2247 912,2249 916,2249 921,2248 925,2248 930,2248 934,2248 939,2248 943,2247 948,2247 952,2247 957,2247 961,2247 966,2247 970,2247 975,2246 979,2246 984,2245 988,2245 993,2245 997,2245 1002,2245 1006,2245 1011,2245 1015,2245 1020,2244 1024,2244 1029,2245 1033,2244 1038,2244 1042,2244 1047,2244 1051,2243 1056,2243 1060,2243 1065,2243 1069,2242 1074,2243 1078,2243 1083,2242 1087,2243 1092,2243 1096,2242 1101,2243 1105,2242 1110,2243 1114,2243 1119,2243 1123,2242 1128,2242 1132,2242 1137,2242 1141,2242 1146,2242 1150,2242 1155,2242 1159,2242 1164,2242 1168,2242 1173,2242 1177,2242 1182,2242 1186,2242 1191,2241 1195,2241 1200,2241 1204,2241 1209,2241 1213,2241 1218,2241 1222,2242 1227,2242 1231,2242 1236,2242 1240,2242 1245,2242 1249,2242 1254,2242 1258,2241 1263,2241 1267,2241 1272,2241 1276,2241 1281,2241 1285,2241 1290,2241 1294,2241 1299,2241 1303,2241 1308,2242 1312,2242 1317,2242 1321,2242 1326,2241 1330,2241 1335,2241 1339,2241 1344,2241 1348,2242 1353,2242 1357,2242 1362,2242 1366,2242 1371,2242 1375,2242 1380,2242 1384,2242 1389,2242 1393,2242 1398,2241 1402,2242 1407,2242 1411,2242 1416,2241 1420,2241 1425,2241 1429,2242 1434,2242 1438,2242 1443,2242 1447,2242 1452,2242 1456,2242 1461,2242 1465,2241 1470,2241 1474,2242 1479,2241 1483,2241 1488,2241 1492,2241 1497,2242 1501,2242 1506,2242 1510,2242 1515,2242 1519,2242 1524,2242 1528,2242 1533,2241 1537,2242 1542,2242 1546,2241 1551,2242 1555,2242 1560,2242 1564,2242 1569,2242 1573,2242 1578,2242 1582,2242 1587,2242 1591,2242 1596,2242 1600,2241 1605,2241 1609,2242 1614,2242 1618,2242 1623,2242 1627,2242 1632,2242 1636,2242 1641,2242 1645,2242 1650,2242 1654,2242 1659,2242 1663,2242 1668,2242 1672,2242 1677,2242 1681,2242 1686,2242 1690,2242 1695,2242 1699,2242 1704,2242 1708,2242 1713,2242 1717,2242 1722,2243 1726,2242 1731,2243 1735,2243 1740,2242 1744,2242 1749,2242 1753,2242 1758,2242 1762,2242 1767,2243 1771,2243 1776,2243 1780,2243 1785,2243 1789,2243 1794,2243 1798,2243 1803,2243 1807,2242 1812,2243 1816,2243 1821,2243 1825,2243 1830,2243 1834,2243 1839,2243 1843,2243 1848,2243 1852,2243 1857,2243 1861,2243 1866,2243 1870,2243 1875,2243 1879,2243 1884,2243 1888,2243 1893,2243 1897,2243 1902,2243 1906,2243 1911,2243 1915,2243 1920,2243 1924,2243 1929,2243 1933,2243 1938,2244 1942,2244 1947,2243 1951,2243 1956,2243 1960,2243 1965,2243 1969,2243 1974,2243 1978,2243 1983,2243 1987,2244 1992,2244 1996,2244 2001,2244 2005,2244 2010,2244 2014,2243 2019,2243 2023,2243 2028,2243 2032,2243 2037,2243 2041,2243 2046,2244 2050,2244 2055,2244 2059,2244 2064,2244 2068,2244 2073,2244 2077,2244 2082,2243 2086,2243 2091,2244 2095,2244 2100,2244 2104,2244 2109,2244 2113,2244 2118,2244 2122,2244 2127,2244 2131,2244 2136,2244 2140,2244 2145,2244 2149,2244 2154,2244 2158,2244 2163,2244 2167,2244 2172,2244 2176,2244 2181,2244 2185,2244 2190,2244 2194,2244 2199,2244 2203,2244 2208,2244 2212,2245 2217,2245 2221,2244 2226,2244 2230,2244 2235,2244 2239,2244 2244,2244 2248,2244 2253,2244 2257,2244 2262,2244 2266,2245 2271,2245 2275,2245 2280,2245 2284,2245 2289,2244 2293,2244 2298,2244 2302,2244 2307,2245 2311,2245 2316,2245 2320,2245 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, high frequency_0.000100.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, high frequency_0.000100.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, high frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,957 88,949 93,941 97,933 102,925 106,918 111,910 115,903 120,896 124,889 129,882 133,875 138,868 142,861 147,855 151,848 156,842 160,836 165,830 169,824 174,818 178,812 183,806 187,800 192,795 196,789 201,784 205,779 210,773 214,768 219,763 223,758 228,753 232,749 237,744 241,739 246,735 250,730 255,726 259,722 264,717 268,713 273,709 277,705 282,701 286,697 291,693 295,689 300,686 304,682 309,678 313,675 318,671 322,668 327,665 331,661 336,658 340,655 345,652 349,649 354,646 358,643 363,640 367,637 372,634 376,631 381,629 385,626 390,623 394,621 399,618 403,616 408,613 412,611 417,609 421,606 426,604 430,602 435,600 439,597 444,595 448,593 453,591 457,589 462,587 466,585 471,583 475,582 480,580 484,578 489,576 493,575 498,573 502,572 506,571 511,569 515,568 520,567 524,566 529,565 533,564 538,564 542,563 547,562 551,562 556,561 560,561 565,560 569,560 574,559 578,559 583,558 587,558 592,558 596,558 601,557 605,557 610,557 614,557 619,557 623,556 628,556 632,556 637,556 641,556 646,556 650,556 655,556 659,555 664,555 668,556 673,555 677,555 682,555 686,555 691,555 695,555 700,555 704,555 709,555 713,555 718,555 722,555 727,555 731,555 736,555 740,555 745,555 749,555 754,555 758,555 763,555 767,555 772,555 776,555 781,555 785,555 790,555 794,555 799,555 803,555 808,555 812,555 817,555 821,555 826,555 830,556 835,555 839,556 844,556 848,556 853,556 857,556 862,556 866,556 871,556 875,556 880,556 884,556 889,556 893,556 898,556 902,556 907,556 911,556 916,557 920,557 925,557 929,557 934,557 938,557 943,557 947,557 952,557 956,557 961,557 965,557 970,557 974,557 979,557 983,557 988,557 992,557 997,557 1001,557 1006,557 1010,558 1015,558 1019,558 1024,558 1028,558 1033,558 1037,558 1042,558 1046,558 1051,558 1055,558 1060,558 1064,558 1069,558 1073,558 1078,558 1082,558 1087,558 1091,558 1096,558 1100,558 1105,558 1109,558 1114,558 1118,558 1123,558 1127,558 1132,558 1136,558 1141,558 1145,558 1150,558 1154,558 1159,558 1163,558 1168,558 1172,558 1177,558 1181,558 1186,558 1190,558 1195,558 1199,558 1204,558 1208,558 1213,558 1217,558 1222,558 1226,558 1231,558 1235,558 1240,558 1244,558 1249,558 1253,558 1258,558 1262,558 1267,558 1271,558 1276,558 1280,558 1285,558 1289,558 1294,558 1298,558 1303,558 1307,558 1312,558 1316,558 1321,558 1325,558 1330,558 1334,558 1339,558 1343,558 1348,558 1352,558 1357,558 1361,558 1366,558 1370,558 1375,558 1379,558 1384,558 1388,558 1393,558 1397,558 1402,558 1406,558 1411,558 1415,558 1420,558 1424,558 1429,558 1433,558 1438,558 1442,558 1447,558 1451,558 1456,558 1460,558 1465,558 1469,558 1474,558 1478,558 1483,558 1487,558 1492,558 1496,558 1501,558 1505,558 1510,558 1514,558 1519,558 1523,558 1528,558 1532,558 1537,558 1541,558 1546,558 1550,558 1555,558 1559,558 1564,558 1568,558 1573,558 1577,558 1582,558 1586,558 1591,558 1595,558 1600,558 1604,558 1609,558 1613,558 1618,558 1622,558 1626,558 1631,558 1635,558 1640,558 1644,558 1649,558 1653,558 1658,558 1662,558 1667,558 1671,558 1676,558 1680,558 1685,558 1689,558 1694,558 1698,558 1703,558 1707,558 1712,558 1716,558 1721,558 1725,558 1730,558 1734,558 1739,558 1743,558 1748,558 1752,558 1757,558 1761,557 1766,558 1770,558 1775,557 1779,557 1784,558 1788,558 1793,557 1797,557 1802,558 1806,557 1811,557 1815,557 1820,557 1824,557 1829,557 1833,557 1838,557 1842,557 1847,557 1851,557 1856,557 1860,557 1865,557 1869,557 1874,557 1878,557 1883,557 1887,557 1892,557 1896,557 1901,557 1905,557 1910,557 1914,557 1919,557 1923,557 1928,557 1932,557 1937,557 1941,557 1946,557 1950,557 1955,557 1959,557 1964,557 1968,557 1973,557 1977,557 1982,557 1986,557 1991,557 1995,557 2000,557 2004,557 2009,557 2013,557 2018,557 2022,557 2027,557 2031,557 2036,557 2040,557 2045,557 2049,557 2054,557 2058,557 2063,557 2067,557 2072,557 2076,557 2081,557 2085,557 2090,557 2094,557 2099,557 2103,557 2108,557 2112,557 2117,557 2121,557 2126,557 2130,557 2135,557 2139,557 2144,557 2148,557 2153,557 2157,557 2162,557 2166,557 2171,557 2175,557 2180,557 2184,557 2189,557 2193,557 2198,557 2202,557 2207,557 2211,557 2216,557 2220,557 2225,557 2229,557 2234,557 2238,557 2243,557 2247,557 2252,557 2256,557 2261,557 2265,557 2270,557 2274,557 2279,557 2283,557 2288,557 2292,557 2297,557 2301,557 2306,557 2310,557 2315,557 2319,557 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2225 74,2225 "/>
+<text x="65" y="2125" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2125 74,2125 "/>
+<text x="65" y="2025" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2025 74,2025 "/>
+<text x="65" y="1925" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1925 74,1925 "/>
+<text x="65" y="1825" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1825 74,1825 "/>
+<text x="65" y="1725" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1725 74,1725 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+14M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1526" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1526 74,1526 "/>
+<text x="65" y="1426" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+18M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1426 74,1426 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1609 79,2312 84,1825 88,1338 93,2042 97,2216 102,1435 106,1609 111,2312 115,1825 120,1338 124,2042 129,2216 133,1435 138,1609 142,2312 147,1825 151,1338 156,2042 160,2216 165,1435 169,1609 174,2312 178,1825 183,1338 187,2042 192,2216 196,1435 201,1609 205,2312 210,1825 214,1338 219,2042 223,2216 228,1435 232,1609 237,2312 241,1825 246,1338 250,2042 255,2216 259,1435 264,1609 268,2312 273,1825 277,1338 282,2042 286,2216 291,1435 295,1609 300,2312 304,1825 309,1338 313,2042 318,2216 322,1435 327,1609 331,2312 336,1825 340,1338 345,2042 349,2216 354,1435 358,1609 363,2312 367,1825 372,1338 376,2042 381,2216 385,1435 390,1609 394,2312 399,1825 403,1338 408,2042 412,2216 417,1435 421,1609 426,2312 430,1825 435,1338 439,2042 444,2216 448,1435 453,1609 457,2312 462,1825 466,1338 471,2042 475,2216 480,1435 484,1609 489,2312 493,1825 498,1338 502,2042 506,2216 511,1435 515,1609 520,2312 524,1825 529,1338 533,2042 538,2216 542,1435 547,1609 551,2312 556,1825 560,1338 565,2042 569,2216 574,1435 578,1609 583,2312 587,1825 592,1338 596,2042 601,2216 605,1435 610,1609 614,2312 619,1825 623,1338 628,2042 632,2216 637,1435 641,1609 646,2312 650,1825 655,1338 659,2042 664,2216 668,1435 673,1609 677,2312 682,1825 686,1338 691,2042 695,2216 700,1435 704,1609 709,2312 713,1825 718,1338 722,2042 727,2216 731,1435 736,1609 740,2312 745,1825 749,1338 754,2042 758,2216 763,1435 767,1609 772,2312 776,1825 781,1338 785,2042 790,2216 794,1435 799,1609 803,2312 808,1825 812,1338 817,2042 821,2216 826,1435 830,1609 835,2312 839,1825 844,1338 848,2042 853,2216 857,1435 862,1609 866,2312 871,1825 875,1338 880,2042 884,2216 889,1435 893,1609 898,2312 902,1825 907,1338 911,2042 916,2216 920,1435 925,1609 929,2312 934,1825 938,1338 943,2042 947,2216 952,1435 956,1609 961,2312 965,1825 970,1338 974,2042 979,2216 983,1435 988,1609 992,2312 997,1825 1001,1338 1006,2042 1010,2216 1015,1435 1019,1609 1024,2312 1028,1825 1033,1338 1037,2042 1042,2216 1046,1435 1051,1609 1055,2312 1060,1825 1064,1338 1069,2042 1073,2216 1078,1435 1082,1609 1087,2312 1091,1825 1096,1338 1100,2042 1105,2216 1109,1435 1114,1609 1118,2312 1123,1825 1127,1338 1132,2042 1136,2216 1141,1435 1145,1609 1150,2312 1154,1825 1159,1338 1163,2042 1168,2216 1172,1435 1177,1609 1181,2312 1186,1825 1190,1338 1195,2042 1199,2216 1204,1435 1208,1609 1213,2312 1217,1825 1222,1338 1226,2042 1231,2216 1235,1435 1240,1609 1244,2312 1249,1825 1253,1338 1258,2042 1262,2216 1267,1435 1271,1609 1276,2312 1280,1825 1285,1338 1289,2042 1294,2216 1298,1435 1303,1609 1307,2312 1312,1825 1316,1338 1321,2042 1325,2216 1330,1435 1334,1609 1339,2312 1343,1825 1348,1338 1352,2042 1357,2216 1361,1435 1366,1609 1370,2312 1375,1825 1379,1338 1384,2042 1388,2216 1393,1435 1397,1609 1402,2312 1406,1825 1411,1338 1415,2042 1420,2216 1424,1435 1429,1609 1433,2312 1438,1825 1442,1338 1447,2042 1451,2216 1456,1435 1460,1609 1465,2312 1469,1825 1474,1338 1478,2042 1483,2216 1487,1435 1492,1609 1496,2312 1501,1825 1505,1338 1510,2042 1514,2216 1519,1435 1523,1609 1528,2312 1532,1825 1537,1338 1541,2042 1546,2216 1550,1435 1555,1609 1559,2312 1564,1825 1568,1338 1573,2042 1577,2216 1582,1435 1586,1609 1591,2312 1595,1825 1600,1338 1604,2042 1609,2216 1613,1435 1618,1609 1622,2312 1626,1825 1631,1338 1635,2042 1640,2216 1644,1435 1649,1609 1653,2312 1658,1825 1662,1338 1667,2042 1671,2216 1676,1435 1680,1609 1685,2312 1689,1825 1694,1338 1698,2042 1703,2216 1707,1435 1712,1609 1716,2312 1721,1825 1725,1338 1730,2042 1734,2216 1739,1435 1743,1609 1748,2312 1752,1825 1757,1338 1761,2042 1766,2216 1770,1435 1775,1609 1779,2312 1784,1825 1788,1338 1793,2042 1797,2216 1802,1435 1806,1609 1811,2312 1815,1825 1820,1338 1824,2042 1829,2216 1833,1435 1838,1609 1842,2312 1847,1825 1851,1338 1856,2042 1860,2216 1865,1435 1869,1609 1874,2312 1878,1825 1883,1338 1887,2042 1892,2216 1896,1435 1901,1609 1905,2312 1910,1825 1914,1338 1919,2042 1923,2216 1928,1435 1932,1609 1937,2312 1941,1825 1946,1338 1950,2042 1955,2216 1959,1435 1964,1609 1968,2312 1973,1825 1977,1338 1982,2042 1986,2216 1991,1435 1995,1609 2000,2312 2004,1825 2009,1338 2013,2042 2018,2216 2022,1435 2027,1609 2031,2312 2036,1825 2040,1338 2045,2042 2049,2216 2054,1435 2058,1609 2063,2312 2067,1825 2072,1338 2076,2042 2081,2216 2085,1435 2090,1609 2094,2312 2099,1825 2103,1338 2108,2042 2112,2216 2117,1435 2121,1609 2126,2312 2130,1825 2135,1338 2139,2042 2144,2216 2148,1435 2153,1609 2157,2312 2162,1825 2166,1338 2171,2042 2175,2216 2180,1435 2184,1609 2189,2312 2193,1825 2198,1338 2202,2042 2207,2216 2211,1435 2216,1609 2220,2312 2225,1825 2229,1338 2234,2042 2238,2216 2243,1435 2247,1609 2252,2312 2256,1825 2261,1338 2265,2042 2270,2216 2274,1435 2279,1609 2283,2312 2288,1825 2292,1338 2297,2042 2301,2216 2306,1435 2310,1609 2315,2312 2319,1825 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2163 493,2275 498,2276 502,2133 507,2162 511,2276 516,2274 520,1935 525,2222 529,2276 534,2010 538,2079 543,2258 547,2257 552,1832 556,2199 561,2267 565,1980 570,2047 574,2250 579,2250 583,1832 588,2191 592,2264 597,1975 601,2040 606,2250 610,2250 615,1832 619,2193 624,2265 628,1979 633,2049 637,2252 642,2253 646,1832 651,2200 655,2269 660,1988 664,2069 669,2258 673,2259 678,1859 682,2211 687,2274 691,2011 696,2091 700,2264 705,2265 709,1902 714,2221 718,2276 723,2041 727,2113 732,2266 736,2271 741,1942 745,2231 750,2276 754,2069 759,2135 763,2275 768,2276 772,1981 777,2241 781,2276 786,2096 790,2155 795,2276 799,2276 804,2022 808,2251 813,2276 817,2124 822,2177 826,2276 831,2276 835,2061 840,2261 844,2276 849,2152 853,2198 858,2276 862,2276 867,2102 871,2271 876,2276 880,2180 885,2219 889,2276 894,2276 898,2140 903,2276 907,2276 912,2207 916,2236 921,2276 925,2276 930,2166 934,2276 939,2276 943,2218 948,2243 952,2276 957,2276 961,2177 966,2276 970,2276 975,2226 979,2248 984,2276 988,2276 993,2185 997,2276 1002,2276 1006,2230 1011,2251 1015,2276 1020,2276 1024,2192 1029,2276 1033,2276 1038,2235 1042,2253 1047,2276 1051,2276 1056,2195 1060,2276 1065,2276 1069,2236 1074,2254 1078,2276 1083,2276 1087,2198 1092,2276 1096,2276 1101,2239 1105,2256 1110,2276 1114,2276 1119,2200 1123,2276 1128,2276 1132,2239 1137,2255 1141,2276 1146,2276 1150,2200 1155,2276 1159,2276 1164,2240 1168,2256 1173,2276 1177,2276 1182,2201 1186,2276 1191,2276 1195,2239 1200,2256 1204,2276 1209,2276 1213,2199 1218,2276 1222,2276 1227,2239 1231,2256 1236,2276 1240,2276 1245,2199 1249,2276 1254,2276 1258,2237 1263,2255 1267,2276 1272,2276 1276,2197 1281,2276 1285,2276 1290,2237 1294,2255 1299,2276 1303,2276 1308,2197 1312,2276 1317,2276 1321,2237 1326,2253 1330,2276 1335,2276 1339,2194 1344,2276 1348,2276 1353,2235 1357,2253 1362,2276 1366,2276 1371,2193 1375,2276 1380,2276 1384,2234 1389,2252 1393,2276 1398,2276 1402,2191 1407,2276 1411,2276 1416,2232 1420,2251 1425,2276 1429,2276 1434,2189 1438,2276 1443,2276 1447,2231 1452,2250 1456,2276 1461,2276 1465,2186 1470,2276 1474,2276 1479,2229 1483,2249 1488,2276 1492,2276 1497,2185 1501,2276 1506,2276 1510,2228 1515,2248 1519,2276 1524,2276 1528,2184 1533,2276 1537,2276 1542,2226 1546,2247 1551,2276 1555,2276 1560,2181 1564,2276 1569,2276 1573,2225 1578,2246 1582,2276 1587,2276 1591,2179 1596,2276 1600,2276 1605,2222 1609,2244 1614,2276 1618,2276 1623,2176 1627,2276 1632,2276 1636,2221 1641,2244 1645,2276 1650,2276 1654,2175 1659,2276 1663,2276 1668,2220 1672,2242 1677,2276 1681,2276 1686,2171 1690,2276 1695,2276 1699,2218 1704,2242 1708,2276 1713,2276 1717,2170 1722,2276 1726,2276 1731,2217 1735,2241 1740,2276 1744,2276 1749,2166 1753,2276 1758,2276 1762,2214 1767,2239 1771,2276 1776,2276 1780,2165 1785,2276 1789,2276 1794,2213 1798,2239 1803,2276 1807,2276 1812,2162 1816,2276 1821,2276 1825,2211 1830,2237 1834,2276 1839,2276 1843,2160 1848,2276 1852,2276 1857,2210 1861,2236 1866,2276 1870,2276 1875,2157 1879,2276 1884,2276 1888,2207 1893,2234 1897,2276 1902,2276 1906,2155 1911,2276 1915,2276 1920,2206 1924,2234 1929,2276 1933,2276 1938,2154 1942,2276 1947,2276 1951,2204 1956,2232 1960,2276 1965,2276 1969,2150 1974,2276 1978,2276 1983,2202 1987,2231 1992,2276 1996,2276 2001,2149 2005,2276 2010,2276 2014,2200 2019,2229 2023,2276 2028,2276 2032,2145 2037,2276 2041,2276 2046,2198 2050,2229 2055,2276 2059,2276 2064,2143 2068,2276 2073,2276 2077,2198 2082,2227 2086,2276 2091,2276 2095,2140 2100,2276 2104,2276 2109,2195 2113,2226 2118,2276 2122,2276 2127,2138 2131,2276 2136,2276 2140,2194 2145,2226 2149,2276 2154,2276 2158,2135 2163,2276 2167,2276 2172,2191 2176,2223 2181,2276 2185,2276 2190,2133 2194,2276 2199,2276 2203,2190 2208,2223 2212,2276 2217,2276 2221,2129 2226,2276 2230,2276 2235,2187 2239,2221 2244,2276 2248,2276 2253,2128 2257,2276 2262,2276 2266,2186 2271,2221 2275,2276 2280,2276 2284,2127 2289,2275 2293,2276 2298,2184 2302,2218 2307,2276 2311,2276 2316,2123 2320,2275 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, high frequency_0.000200.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, high frequency_0.000200.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, high frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,957 88,949 93,941 97,933 102,925 106,918 111,910 115,903 120,896 124,889 129,882 133,875 138,868 142,861 147,855 151,848 156,842 160,836 165,830 169,824 174,818 178,812 183,806 187,800 192,795 196,789 201,784 205,779 210,773 214,768 219,763 223,758 228,753 232,749 237,744 241,739 246,735 250,730 255,726 259,722 264,717 268,713 273,709 277,705 282,701 286,697 291,693 295,689 300,686 304,682 309,678 313,675 318,671 322,668 327,665 331,661 336,658 340,655 345,652 349,649 354,646 358,643 363,640 367,637 372,634 376,631 381,629 385,626 390,623 394,621 399,618 403,616 408,614 412,611 417,609 421,607 426,605 430,603 435,601 439,599 444,598 448,596 453,594 457,592 462,591 466,589 471,588 475,587 480,585 484,584 489,583 493,582 498,580 502,579 506,578 511,577 515,576 520,575 524,575 529,574 533,573 538,572 542,571 547,571 551,570 556,569 560,569 565,568 569,568 574,567 578,566 583,566 587,566 592,565 596,565 601,564 605,564 610,563 614,563 619,563 623,562 628,562 632,562 637,561 641,561 646,561 650,560 655,560 659,560 664,560 668,559 673,559 677,559 682,559 686,559 691,558 695,558 700,558 704,558 709,558 713,558 718,558 722,557 727,557 731,557 736,557 740,557 745,557 749,557 754,557 758,557 763,557 767,557 772,556 776,557 781,556 785,556 790,556 794,556 799,556 803,556 808,556 812,556 817,556 821,556 826,556 830,556 835,556 839,557 844,557 848,557 853,557 857,557 862,557 866,557 871,557 875,557 880,557 884,557 889,557 893,557 898,557 902,557 907,557 911,557 916,558 920,558 925,558 929,558 934,558 938,558 943,558 947,558 952,558 956,558 961,558 965,558 970,558 974,558 979,558 983,559 988,559 992,559 997,559 1001,559 1006,559 1010,559 1015,559 1019,559 1024,559 1028,559 1033,559 1037,559 1042,559 1046,559 1051,559 1055,559 1060,559 1064,559 1069,559 1073,559 1078,560 1082,560 1087,560 1091,560 1096,560 1100,560 1105,560 1109,560 1114,560 1118,560 1123,560 1127,560 1132,560 1136,560 1141,560 1145,560 1150,560 1154,560 1159,560 1163,560 1168,560 1172,560 1177,560 1181,560 1186,560 1190,560 1195,560 1199,560 1204,560 1208,560 1213,560 1217,560 1222,560 1226,560 1231,560 1235,560 1240,560 1244,560 1249,560 1253,560 1258,560 1262,560 1267,561 1271,560 1276,560 1280,561 1285,561 1289,561 1294,561 1298,561 1303,561 1307,561 1312,561 1316,561 1321,561 1325,561 1330,561 1334,561 1339,561 1343,561 1348,561 1352,561 1357,561 1361,561 1366,561 1370,561 1375,561 1379,561 1384,561 1388,561 1393,561 1397,561 1402,561 1406,561 1411,561 1415,561 1420,561 1424,561 1429,561 1433,561 1438,561 1442,561 1447,561 1451,561 1456,561 1460,561 1465,561 1469,561 1474,561 1478,561 1483,561 1487,561 1492,561 1496,561 1501,561 1505,561 1510,561 1514,561 1519,561 1523,561 1528,561 1532,561 1537,561 1541,561 1546,561 1550,561 1555,561 1559,561 1564,561 1568,561 1573,561 1577,561 1582,561 1586,561 1591,561 1595,561 1600,561 1604,561 1609,561 1613,561 1618,561 1622,561 1626,561 1631,561 1635,561 1640,561 1644,561 1649,560 1653,560 1658,561 1662,560 1667,560 1671,560 1676,561 1680,560 1685,560 1689,560 1694,560 1698,560 1703,560 1707,560 1712,560 1716,560 1721,560 1725,560 1730,560 1734,560 1739,560 1743,560 1748,560 1752,560 1757,560 1761,560 1766,560 1770,560 1775,560 1779,560 1784,560 1788,560 1793,560 1797,560 1802,560 1806,560 1811,560 1815,560 1820,560 1824,560 1829,560 1833,560 1838,560 1842,560 1847,560 1851,560 1856,560 1860,560 1865,560 1869,560 1874,560 1878,560 1883,560 1887,560 1892,560 1896,560 1901,560 1905,560 1910,560 1914,560 1919,560 1923,560 1928,560 1932,560 1937,560 1941,560 1946,560 1950,560 1955,560 1959,560 1964,560 1968,560 1973,560 1977,560 1982,560 1986,560 1991,560 1995,560 2000,560 2004,560 2009,560 2013,560 2018,560 2022,560 2027,560 2031,560 2036,560 2040,560 2045,560 2049,560 2054,560 2058,560 2063,560 2067,560 2072,560 2076,560 2081,560 2085,560 2090,560 2094,559 2099,560 2103,559 2108,559 2112,559 2117,559 2121,559 2126,559 2130,559 2135,559 2139,559 2144,559 2148,559 2153,559 2157,559 2162,559 2166,559 2171,559 2175,559 2180,559 2184,559 2189,559 2193,559 2198,559 2202,559 2207,559 2211,559 2216,559 2220,559 2225,559 2229,559 2234,559 2238,559 2243,559 2247,559 2252,559 2256,559 2261,559 2265,559 2270,559 2274,559 2279,559 2283,559 2288,559 2292,559 2297,559 2301,559 2306,559 2310,559 2315,559 2319,559 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2225 74,2225 "/>
+<text x="65" y="2125" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2125 74,2125 "/>
+<text x="65" y="2025" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2025 74,2025 "/>
+<text x="65" y="1925" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1925 74,1925 "/>
+<text x="65" y="1825" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1825 74,1825 "/>
+<text x="65" y="1725" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1725 74,1725 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+14M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1526" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1526 74,1526 "/>
+<text x="65" y="1426" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+18M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1426 74,1426 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1609 79,2312 84,1825 88,1338 93,2042 97,2216 102,1435 106,1609 111,2312 115,1825 120,1338 124,2042 129,2216 133,1435 138,1609 142,2312 147,1825 151,1338 156,2042 160,2216 165,1435 169,1609 174,2312 178,1825 183,1338 187,2042 192,2216 196,1435 201,1609 205,2312 210,1825 214,1338 219,2042 223,2216 228,1435 232,1609 237,2312 241,1825 246,1338 250,2042 255,2216 259,1435 264,1609 268,2312 273,1825 277,1338 282,2042 286,2216 291,1435 295,1609 300,2312 304,1825 309,1338 313,2042 318,2216 322,1435 327,1609 331,2312 336,1825 340,1338 345,2042 349,2216 354,1435 358,1609 363,2312 367,1825 372,1338 376,2042 381,2216 385,1435 390,1609 394,2312 399,1825 403,1338 408,2042 412,2216 417,1435 421,1609 426,2312 430,1825 435,1338 439,2042 444,2216 448,1435 453,1609 457,2312 462,1825 466,1338 471,2042 475,2216 480,1435 484,1609 489,2312 493,1825 498,1338 502,2042 506,2216 511,1435 515,1609 520,2312 524,1825 529,1338 533,2042 538,2216 542,1435 547,1609 551,2312 556,1825 560,1338 565,2042 569,2216 574,1435 578,1609 583,2312 587,1825 592,1338 596,2042 601,2216 605,1435 610,1609 614,2312 619,1825 623,1338 628,2042 632,2216 637,1435 641,1609 646,2312 650,1825 655,1338 659,2042 664,2216 668,1435 673,1609 677,2312 682,1825 686,1338 691,2042 695,2216 700,1435 704,1609 709,2312 713,1825 718,1338 722,2042 727,2216 731,1435 736,1609 740,2312 745,1825 749,1338 754,2042 758,2216 763,1435 767,1609 772,2312 776,1825 781,1338 785,2042 790,2216 794,1435 799,1609 803,2312 808,1825 812,1338 817,2042 821,2216 826,1435 830,1609 835,2312 839,1825 844,1338 848,2042 853,2216 857,1435 862,1609 866,2312 871,1825 875,1338 880,2042 884,2216 889,1435 893,1609 898,2312 902,1825 907,1338 911,2042 916,2216 920,1435 925,1609 929,2312 934,1825 938,1338 943,2042 947,2216 952,1435 956,1609 961,2312 965,1825 970,1338 974,2042 979,2216 983,1435 988,1609 992,2312 997,1825 1001,1338 1006,2042 1010,2216 1015,1435 1019,1609 1024,2312 1028,1825 1033,1338 1037,2042 1042,2216 1046,1435 1051,1609 1055,2312 1060,1825 1064,1338 1069,2042 1073,2216 1078,1435 1082,1609 1087,2312 1091,1825 1096,1338 1100,2042 1105,2216 1109,1435 1114,1609 1118,2312 1123,1825 1127,1338 1132,2042 1136,2216 1141,1435 1145,1609 1150,2312 1154,1825 1159,1338 1163,2042 1168,2216 1172,1435 1177,1609 1181,2312 1186,1825 1190,1338 1195,2042 1199,2216 1204,1435 1208,1609 1213,2312 1217,1825 1222,1338 1226,2042 1231,2216 1235,1435 1240,1609 1244,2312 1249,1825 1253,1338 1258,2042 1262,2216 1267,1435 1271,1609 1276,2312 1280,1825 1285,1338 1289,2042 1294,2216 1298,1435 1303,1609 1307,2312 1312,1825 1316,1338 1321,2042 1325,2216 1330,1435 1334,1609 1339,2312 1343,1825 1348,1338 1352,2042 1357,2216 1361,1435 1366,1609 1370,2312 1375,1825 1379,1338 1384,2042 1388,2216 1393,1435 1397,1609 1402,2312 1406,1825 1411,1338 1415,2042 1420,2216 1424,1435 1429,1609 1433,2312 1438,1825 1442,1338 1447,2042 1451,2216 1456,1435 1460,1609 1465,2312 1469,1825 1474,1338 1478,2042 1483,2216 1487,1435 1492,1609 1496,2312 1501,1825 1505,1338 1510,2042 1514,2216 1519,1435 1523,1609 1528,2312 1532,1825 1537,1338 1541,2042 1546,2216 1550,1435 1555,1609 1559,2312 1564,1825 1568,1338 1573,2042 1577,2216 1582,1435 1586,1609 1591,2312 1595,1825 1600,1338 1604,2042 1609,2216 1613,1435 1618,1609 1622,2312 1626,1825 1631,1338 1635,2042 1640,2216 1644,1435 1649,1609 1653,2312 1658,1825 1662,1338 1667,2042 1671,2216 1676,1435 1680,1609 1685,2312 1689,1825 1694,1338 1698,2042 1703,2216 1707,1435 1712,1609 1716,2312 1721,1825 1725,1338 1730,2042 1734,2216 1739,1435 1743,1609 1748,2312 1752,1825 1757,1338 1761,2042 1766,2216 1770,1435 1775,1609 1779,2312 1784,1825 1788,1338 1793,2042 1797,2216 1802,1435 1806,1609 1811,2312 1815,1825 1820,1338 1824,2042 1829,2216 1833,1435 1838,1609 1842,2312 1847,1825 1851,1338 1856,2042 1860,2216 1865,1435 1869,1609 1874,2312 1878,1825 1883,1338 1887,2042 1892,2216 1896,1435 1901,1609 1905,2312 1910,1825 1914,1338 1919,2042 1923,2216 1928,1435 1932,1609 1937,2312 1941,1825 1946,1338 1950,2042 1955,2216 1959,1435 1964,1609 1968,2312 1973,1825 1977,1338 1982,2042 1986,2216 1991,1435 1995,1609 2000,2312 2004,1825 2009,1338 2013,2042 2018,2216 2022,1435 2027,1609 2031,2312 2036,1825 2040,1338 2045,2042 2049,2216 2054,1435 2058,1609 2063,2312 2067,1825 2072,1338 2076,2042 2081,2216 2085,1435 2090,1609 2094,2312 2099,1825 2103,1338 2108,2042 2112,2216 2117,1435 2121,1609 2126,2312 2130,1825 2135,1338 2139,2042 2144,2216 2148,1435 2153,1609 2157,2312 2162,1825 2166,1338 2171,2042 2175,2216 2180,1435 2184,1609 2189,2312 2193,1825 2198,1338 2202,2042 2207,2216 2211,1435 2216,1609 2220,2312 2225,1825 2229,1338 2234,2042 2238,2216 2243,1435 2247,1609 2252,2312 2256,1825 2261,1338 2265,2042 2270,2216 2274,1435 2279,1609 2283,2312 2288,1825 2292,1338 2297,2042 2301,2216 2306,1435 2310,1609 2315,2312 2319,1825 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2148 399,2276 403,2276 408,2270 412,2176 417,2276 421,2276 426,1904 430,2239 435,2276 439,2230 444,2083 448,2276 453,2263 457,1832 462,2216 466,2276 471,2191 475,2021 480,2247 484,2235 489,1832 493,2158 498,2251 502,2167 507,1987 511,2225 516,2216 520,1832 525,2143 529,2238 534,2155 538,1971 543,2216 547,2209 552,1832 556,2138 561,2234 565,2153 570,1970 574,2216 579,2211 583,1832 588,2141 592,2238 597,2157 601,1977 606,2222 610,2216 615,1832 619,2148 624,2246 628,2166 633,1991 637,2231 642,2227 646,1832 651,2159 655,2257 660,2177 664,2008 669,2244 673,2238 678,1832 682,2182 687,2270 691,2189 696,2026 700,2257 705,2247 709,1832 714,2208 718,2276 723,2201 727,2047 732,2271 736,2259 741,1832 745,2233 750,2276 754,2214 759,2070 763,2276 768,2270 772,1832 777,2234 781,2276 786,2228 790,2095 795,2276 799,2276 804,1844 808,2234 813,2276 817,2240 822,2120 826,2276 831,2276 835,1899 840,2249 844,2276 849,2250 853,2145 858,2276 862,2276 867,1954 871,2266 876,2276 880,2260 885,2170 889,2276 894,2276 898,2008 903,2276 907,2276 912,2270 916,2194 921,2276 925,2276 930,2044 934,2276 939,2276 943,2274 948,2201 952,2276 957,2276 961,2058 966,2276 970,2276 975,2276 979,2207 984,2276 988,2276 993,2067 997,2276 1002,2276 1006,2276 1011,2210 1015,2276 1020,2276 1024,2077 1029,2276 1033,2276 1038,2276 1042,2215 1047,2276 1051,2276 1056,2083 1060,2276 1065,2276 1069,2276 1074,2217 1078,2276 1083,2276 1087,2090 1092,2276 1096,2276 1101,2276 1105,2221 1110,2276 1114,2276 1119,2097 1123,2276 1128,2276 1132,2276 1137,2221 1141,2276 1146,2276 1150,2099 1155,2276 1159,2276 1164,2276 1168,2224 1173,2276 1177,2276 1182,2104 1186,2276 1191,2276 1195,2276 1200,2224 1204,2276 1209,2276 1213,2104 1218,2276 1222,2276 1227,2276 1231,2226 1236,2276 1240,2276 1245,2107 1249,2276 1254,2276 1258,2276 1263,2225 1267,2276 1272,2276 1276,2106 1281,2276 1285,2276 1290,2276 1294,2226 1299,2276 1303,2276 1308,2108 1312,2276 1317,2276 1321,2276 1326,2225 1330,2276 1335,2276 1339,2106 1344,2276 1348,2276 1353,2276 1357,2226 1362,2276 1366,2276 1371,2107 1375,2276 1380,2276 1384,2276 1389,2226 1393,2276 1398,2276 1402,2103 1407,2276 1411,2276 1416,2276 1420,2225 1425,2276 1429,2276 1434,2104 1438,2276 1443,2276 1447,2276 1452,2225 1456,2276 1461,2276 1465,2100 1470,2276 1474,2276 1479,2276 1483,2223 1488,2276 1492,2276 1497,2099 1501,2276 1506,2276 1510,2276 1515,2223 1519,2276 1524,2276 1528,2099 1533,2276 1537,2276 1542,2276 1546,2220 1551,2276 1555,2276 1560,2094 1564,2276 1569,2276 1573,2276 1578,2220 1582,2276 1587,2276 1591,2093 1596,2276 1600,2276 1605,2276 1609,2218 1614,2276 1618,2276 1623,2088 1627,2276 1632,2276 1636,2276 1641,2217 1645,2276 1650,2276 1654,2086 1659,2276 1663,2276 1668,2276 1672,2215 1677,2276 1681,2276 1686,2081 1690,2276 1695,2276 1699,2276 1704,2213 1708,2276 1713,2276 1717,2079 1722,2276 1726,2276 1731,2276 1735,2213 1740,2276 1744,2276 1749,2073 1753,2276 1758,2276 1762,2276 1767,2210 1771,2276 1776,2276 1780,2070 1785,2276 1789,2276 1794,2276 1798,2209 1803,2276 1807,2276 1812,2065 1816,2276 1821,2276 1825,2276 1830,2206 1834,2276 1839,2276 1843,2063 1848,2276 1852,2276 1857,2276 1861,2205 1866,2276 1870,2276 1875,2056 1879,2276 1884,2276 1888,2274 1893,2202 1897,2276 1902,2276 1906,2053 1911,2276 1915,2276 1920,2274 1924,2201 1929,2276 1933,2276 1938,2052 1942,2276 1947,2276 1951,2273 1956,2198 1960,2276 1965,2276 1969,2045 1974,2276 1978,2276 1983,2272 1987,2197 1992,2276 1996,2276 2001,2043 2005,2276 2010,2276 2014,2271 2019,2194 2023,2276 2028,2276 2032,2036 2037,2276 2041,2276 2046,2271 2050,2193 2055,2276 2059,2276 2064,2034 2068,2276 2073,2276 2077,2271 2082,2190 2086,2276 2091,2276 2095,2028 2100,2276 2104,2276 2109,2269 2113,2189 2118,2276 2122,2276 2127,2026 2131,2276 2136,2276 2140,2269 2145,2188 2149,2276 2154,2276 2158,2019 2163,2276 2167,2276 2172,2268 2176,2185 2181,2276 2185,2276 2190,2017 2194,2276 2199,2276 2203,2267 2208,2184 2212,2276 2217,2276 2221,2011 2226,2276 2230,2276 2235,2266 2239,2181 2244,2276 2248,2276 2253,2008 2257,2276 2262,2276 2266,2265 2271,2180 2275,2276 2280,2276 2284,2006 2289,2276 2293,2276 2298,2264 2302,2177 2307,2276 2311,2276 2316,1999 2320,2276 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, high frequency_0.000300.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, high frequency_0.000300.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, high frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,957 88,949 93,941 97,933 102,925 106,918 111,910 115,903 120,896 124,889 129,882 133,875 138,868 142,861 147,855 151,848 156,842 160,836 165,830 169,824 174,818 178,812 183,806 187,800 192,795 196,789 201,784 205,779 210,773 214,768 219,763 223,758 228,753 232,749 237,744 241,739 246,735 250,730 255,726 259,722 264,717 268,713 273,709 277,705 282,701 286,697 291,694 295,690 300,686 304,683 309,680 313,676 318,673 322,670 327,667 331,664 336,661 340,658 345,655 349,653 354,650 358,648 363,645 367,643 372,640 376,638 381,636 385,633 390,631 394,629 399,627 403,625 408,623 412,622 417,620 421,618 426,616 430,615 435,613 439,612 444,610 448,609 453,607 457,606 462,605 466,603 471,602 475,601 480,600 484,599 489,597 493,596 498,595 502,594 506,593 511,592 515,591 520,590 524,589 529,589 533,588 538,587 542,586 547,585 551,584 556,584 560,583 565,582 569,582 574,581 578,580 583,579 587,579 592,578 596,578 601,577 605,577 610,576 614,575 619,575 623,574 628,574 632,573 637,573 641,573 646,572 650,572 655,571 659,571 664,570 668,570 673,570 677,569 682,569 686,569 691,569 695,568 700,568 704,568 709,567 713,567 718,567 722,567 727,567 731,566 736,566 740,566 745,566 749,566 754,565 758,565 763,565 767,565 772,565 776,565 781,565 785,565 790,564 794,564 799,564 803,564 808,564 812,564 817,564 821,564 826,564 830,564 835,564 839,564 844,564 848,564 853,564 857,564 862,563 866,563 871,564 875,563 880,563 884,563 889,564 893,564 898,564 902,564 907,564 911,564 916,564 920,564 925,564 929,564 934,564 938,564 943,564 947,564 952,564 956,564 961,564 965,564 970,564 974,564 979,564 983,564 988,564 992,564 997,564 1001,564 1006,564 1010,564 1015,564 1019,564 1024,564 1028,565 1033,565 1037,564 1042,565 1046,565 1051,565 1055,565 1060,565 1064,565 1069,565 1073,565 1078,565 1082,565 1087,565 1091,565 1096,565 1100,565 1105,565 1109,565 1114,565 1118,565 1123,565 1127,565 1132,565 1136,565 1141,565 1145,565 1150,565 1154,565 1159,565 1163,565 1168,565 1172,565 1177,565 1181,565 1186,565 1190,565 1195,565 1199,565 1204,565 1208,565 1213,565 1217,565 1222,565 1226,565 1231,565 1235,565 1240,565 1244,565 1249,565 1253,565 1258,565 1262,565 1267,565 1271,565 1276,565 1280,565 1285,565 1289,565 1294,565 1298,565 1303,565 1307,565 1312,565 1316,565 1321,565 1325,565 1330,565 1334,565 1339,565 1343,565 1348,565 1352,565 1357,565 1361,565 1366,565 1370,565 1375,565 1379,565 1384,565 1388,565 1393,565 1397,565 1402,565 1406,565 1411,565 1415,565 1420,565 1424,565 1429,565 1433,565 1438,565 1442,565 1447,565 1451,565 1456,565 1460,565 1465,565 1469,565 1474,565 1478,565 1483,565 1487,565 1492,565 1496,565 1501,565 1505,565 1510,565 1514,565 1519,565 1523,565 1528,565 1532,565 1537,565 1541,565 1546,565 1550,565 1555,565 1559,565 1564,565 1568,565 1573,565 1577,565 1582,565 1586,565 1591,565 1595,565 1600,565 1604,565 1609,565 1613,565 1618,565 1622,565 1626,565 1631,565 1635,565 1640,565 1644,565 1649,565 1653,565 1658,565 1662,565 1667,565 1671,565 1676,565 1680,565 1685,565 1689,565 1694,565 1698,565 1703,565 1707,565 1712,565 1716,565 1721,565 1725,565 1730,565 1734,565 1739,565 1743,565 1748,565 1752,565 1757,565 1761,565 1766,565 1770,565 1775,565 1779,565 1784,565 1788,565 1793,565 1797,565 1802,565 1806,565 1811,565 1815,565 1820,565 1824,565 1829,565 1833,565 1838,564 1842,564 1847,565 1851,564 1856,564 1860,564 1865,564 1869,564 1874,564 1878,564 1883,564 1887,564 1892,564 1896,564 1901,564 1905,564 1910,564 1914,564 1919,564 1923,564 1928,564 1932,564 1937,564 1941,564 1946,564 1950,564 1955,564 1959,564 1964,564 1968,564 1973,564 1977,564 1982,564 1986,564 1991,564 1995,564 2000,564 2004,564 2009,564 2013,564 2018,564 2022,564 2027,564 2031,564 2036,564 2040,564 2045,564 2049,564 2054,564 2058,564 2063,564 2067,564 2072,564 2076,564 2081,564 2085,564 2090,564 2094,564 2099,564 2103,564 2108,564 2112,564 2117,564 2121,564 2126,564 2130,564 2135,564 2139,564 2144,564 2148,564 2153,564 2157,564 2162,564 2166,564 2171,563 2175,563 2180,564 2184,563 2189,563 2193,563 2198,563 2202,563 2207,563 2211,563 2216,563 2220,563 2225,563 2229,563 2234,563 2238,563 2243,563 2247,563 2252,563 2256,563 2261,563 2265,563 2270,563 2274,563 2279,563 2283,563 2288,563 2292,563 2297,563 2301,563 2306,563 2310,563 2315,563 2319,563 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2225 74,2225 "/>
+<text x="65" y="2125" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2125 74,2125 "/>
+<text x="65" y="2025" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2025 74,2025 "/>
+<text x="65" y="1925" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1925 74,1925 "/>
+<text x="65" y="1825" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1825 74,1825 "/>
+<text x="65" y="1725" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1725 74,1725 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+14M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1526" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1526 74,1526 "/>
+<text x="65" y="1426" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+18M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1426 74,1426 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1609 79,2312 84,1825 88,1338 93,2042 97,2216 102,1435 106,1609 111,2312 115,1825 120,1338 124,2042 129,2216 133,1435 138,1609 142,2312 147,1825 151,1338 156,2042 160,2216 165,1435 169,1609 174,2312 178,1825 183,1338 187,2042 192,2216 196,1435 201,1609 205,2312 210,1825 214,1338 219,2042 223,2216 228,1435 232,1609 237,2312 241,1825 246,1338 250,2042 255,2216 259,1435 264,1609 268,2312 273,1825 277,1338 282,2042 286,2216 291,1435 295,1609 300,2312 304,1825 309,1338 313,2042 318,2216 322,1435 327,1609 331,2312 336,1825 340,1338 345,2042 349,2216 354,1435 358,1609 363,2312 367,1825 372,1338 376,2042 381,2216 385,1435 390,1609 394,2312 399,1825 403,1338 408,2042 412,2216 417,1435 421,1609 426,2312 430,1825 435,1338 439,2042 444,2216 448,1435 453,1609 457,2312 462,1825 466,1338 471,2042 475,2216 480,1435 484,1609 489,2312 493,1825 498,1338 502,2042 506,2216 511,1435 515,1609 520,2312 524,1825 529,1338 533,2042 538,2216 542,1435 547,1609 551,2312 556,1825 560,1338 565,2042 569,2216 574,1435 578,1609 583,2312 587,1825 592,1338 596,2042 601,2216 605,1435 610,1609 614,2312 619,1825 623,1338 628,2042 632,2216 637,1435 641,1609 646,2312 650,1825 655,1338 659,2042 664,2216 668,1435 673,1609 677,2312 682,1825 686,1338 691,2042 695,2216 700,1435 704,1609 709,2312 713,1825 718,1338 722,2042 727,2216 731,1435 736,1609 740,2312 745,1825 749,1338 754,2042 758,2216 763,1435 767,1609 772,2312 776,1825 781,1338 785,2042 790,2216 794,1435 799,1609 803,2312 808,1825 812,1338 817,2042 821,2216 826,1435 830,1609 835,2312 839,1825 844,1338 848,2042 853,2216 857,1435 862,1609 866,2312 871,1825 875,1338 880,2042 884,2216 889,1435 893,1609 898,2312 902,1825 907,1338 911,2042 916,2216 920,1435 925,1609 929,2312 934,1825 938,1338 943,2042 947,2216 952,1435 956,1609 961,2312 965,1825 970,1338 974,2042 979,2216 983,1435 988,1609 992,2312 997,1825 1001,1338 1006,2042 1010,2216 1015,1435 1019,1609 1024,2312 1028,1825 1033,1338 1037,2042 1042,2216 1046,1435 1051,1609 1055,2312 1060,1825 1064,1338 1069,2042 1073,2216 1078,1435 1082,1609 1087,2312 1091,1825 1096,1338 1100,2042 1105,2216 1109,1435 1114,1609 1118,2312 1123,1825 1127,1338 1132,2042 1136,2216 1141,1435 1145,1609 1150,2312 1154,1825 1159,1338 1163,2042 1168,2216 1172,1435 1177,1609 1181,2312 1186,1825 1190,1338 1195,2042 1199,2216 1204,1435 1208,1609 1213,2312 1217,1825 1222,1338 1226,2042 1231,2216 1235,1435 1240,1609 1244,2312 1249,1825 1253,1338 1258,2042 1262,2216 1267,1435 1271,1609 1276,2312 1280,1825 1285,1338 1289,2042 1294,2216 1298,1435 1303,1609 1307,2312 1312,1825 1316,1338 1321,2042 1325,2216 1330,1435 1334,1609 1339,2312 1343,1825 1348,1338 1352,2042 1357,2216 1361,1435 1366,1609 1370,2312 1375,1825 1379,1338 1384,2042 1388,2216 1393,1435 1397,1609 1402,2312 1406,1825 1411,1338 1415,2042 1420,2216 1424,1435 1429,1609 1433,2312 1438,1825 1442,1338 1447,2042 1451,2216 1456,1435 1460,1609 1465,2312 1469,1825 1474,1338 1478,2042 1483,2216 1487,1435 1492,1609 1496,2312 1501,1825 1505,1338 1510,2042 1514,2216 1519,1435 1523,1609 1528,2312 1532,1825 1537,1338 1541,2042 1546,2216 1550,1435 1555,1609 1559,2312 1564,1825 1568,1338 1573,2042 1577,2216 1582,1435 1586,1609 1591,2312 1595,1825 1600,1338 1604,2042 1609,2216 1613,1435 1618,1609 1622,2312 1626,1825 1631,1338 1635,2042 1640,2216 1644,1435 1649,1609 1653,2312 1658,1825 1662,1338 1667,2042 1671,2216 1676,1435 1680,1609 1685,2312 1689,1825 1694,1338 1698,2042 1703,2216 1707,1435 1712,1609 1716,2312 1721,1825 1725,1338 1730,2042 1734,2216 1739,1435 1743,1609 1748,2312 1752,1825 1757,1338 1761,2042 1766,2216 1770,1435 1775,1609 1779,2312 1784,1825 1788,1338 1793,2042 1797,2216 1802,1435 1806,1609 1811,2312 1815,1825 1820,1338 1824,2042 1829,2216 1833,1435 1838,1609 1842,2312 1847,1825 1851,1338 1856,2042 1860,2216 1865,1435 1869,1609 1874,2312 1878,1825 1883,1338 1887,2042 1892,2216 1896,1435 1901,1609 1905,2312 1910,1825 1914,1338 1919,2042 1923,2216 1928,1435 1932,1609 1937,2312 1941,1825 1946,1338 1950,2042 1955,2216 1959,1435 1964,1609 1968,2312 1973,1825 1977,1338 1982,2042 1986,2216 1991,1435 1995,1609 2000,2312 2004,1825 2009,1338 2013,2042 2018,2216 2022,1435 2027,1609 2031,2312 2036,1825 2040,1338 2045,2042 2049,2216 2054,1435 2058,1609 2063,2312 2067,1825 2072,1338 2076,2042 2081,2216 2085,1435 2090,1609 2094,2312 2099,1825 2103,1338 2108,2042 2112,2216 2117,1435 2121,1609 2126,2312 2130,1825 2135,1338 2139,2042 2144,2216 2148,1435 2153,1609 2157,2312 2162,1825 2166,1338 2171,2042 2175,2216 2180,1435 2184,1609 2189,2312 2193,1825 2198,1338 2202,2042 2207,2216 2211,1435 2216,1609 2220,2312 2225,1825 2229,1338 2234,2042 2238,2216 2243,1435 2247,1609 2252,2312 2256,1825 2261,1338 2265,2042 2270,2216 2274,1435 2279,1609 2283,2312 2288,1825 2292,1338 2297,2042 2301,2216 2306,1435 2310,1609 2315,2312 2319,1825 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2138 273,2276 277,2276 282,2276 286,2183 291,2276 295,2276 300,1879 304,2265 309,2276 313,2276 318,2093 322,2276 327,2276 331,1832 336,2221 340,2276 345,2276 349,2018 354,2276 358,2276 363,1832 367,2246 372,2276 376,2276 381,1984 385,2254 390,2276 394,1832 399,2182 403,2276 408,2276 412,1928 417,2276 421,2276 426,1832 430,2276 435,2276 439,2276 444,1915 448,2276 453,2276 457,1832 462,2276 466,2276 471,2276 475,1914 480,2276 484,2276 489,1832 493,2276 498,2276 502,2276 507,1921 511,2276 516,2276 520,1832 525,2276 529,2276 534,2276 538,1933 543,2268 547,2276 552,1832 556,2135 561,2276 565,2276 570,1983 574,2254 579,2276 583,1832 588,2171 592,2276 597,2276 601,1986 606,2268 610,2276 615,1832 619,2253 624,2276 628,2276 633,1993 637,2276 642,2276 646,1832 651,2250 655,2276 660,2276 664,2019 669,2276 673,2276 678,1832 682,2232 687,2276 691,2276 696,2048 700,2276 705,2276 709,1832 714,2213 718,2276 723,2276 727,2075 732,2276 736,2276 741,1832 745,2231 750,2276 754,2276 759,2098 763,2276 768,2276 772,1832 777,2251 781,2276 786,2276 790,2120 795,2276 799,2276 804,1856 808,2271 813,2276 817,2276 822,2142 826,2276 831,2276 835,1915 840,2276 844,2276 849,2276 853,2169 858,2276 862,2276 867,1975 871,2276 876,2276 880,2276 885,2195 889,2276 894,2276 898,2036 903,2276 907,2276 912,2276 916,2220 921,2276 925,2276 930,2069 934,2276 939,2276 943,2276 948,2223 952,2276 957,2276 961,2076 966,2276 970,2276 975,2276 979,2225 984,2276 988,2276 993,2077 997,2276 1002,2276 1006,2276 1011,2225 1015,2276 1020,2276 1024,2082 1029,2276 1033,2276 1038,2276 1042,2227 1047,2276 1051,2276 1056,2081 1060,2276 1065,2276 1069,2276 1074,2227 1078,2276 1083,2276 1087,2084 1092,2276 1096,2276 1101,2276 1105,2228 1110,2276 1114,2276 1119,2087 1123,2276 1128,2276 1132,2276 1137,2227 1141,2276 1146,2276 1150,2085 1155,2276 1159,2276 1164,2276 1168,2228 1173,2276 1177,2276 1182,2087 1186,2276 1191,2276 1195,2276 1200,2227 1204,2276 1209,2276 1213,2084 1218,2276 1222,2276 1227,2276 1231,2227 1236,2276 1240,2276 1245,2085 1249,2276 1254,2276 1258,2276 1263,2226 1267,2276 1272,2276 1276,2082 1281,2276 1285,2276 1290,2276 1294,2226 1299,2276 1303,2276 1308,2082 1312,2276 1317,2276 1321,2276 1326,2225 1330,2276 1335,2276 1339,2078 1344,2276 1348,2276 1353,2276 1357,2225 1362,2276 1366,2276 1371,2078 1375,2276 1380,2276 1384,2276 1389,2225 1393,2276 1398,2276 1402,2073 1407,2276 1411,2276 1416,2276 1420,2222 1425,2276 1429,2276 1434,2072 1438,2276 1443,2276 1447,2276 1452,2222 1456,2276 1461,2276 1465,2066 1470,2276 1474,2276 1479,2276 1483,2219 1488,2276 1492,2276 1497,2065 1501,2276 1506,2276 1510,2276 1515,2219 1519,2276 1524,2276 1528,2064 1533,2276 1537,2276 1542,2276 1546,2216 1551,2276 1555,2276 1560,2058 1564,2276 1569,2276 1573,2276 1578,2216 1582,2276 1587,2276 1591,2056 1596,2276 1600,2276 1605,2276 1609,2213 1614,2276 1618,2276 1623,2049 1627,2276 1632,2276 1636,2276 1641,2212 1645,2276 1650,2276 1654,2048 1659,2276 1663,2276 1668,2276 1672,2209 1677,2276 1681,2276 1686,2040 1690,2276 1695,2276 1699,2276 1704,2208 1708,2276 1713,2276 1717,2039 1722,2276 1726,2276 1731,2276 1735,2207 1740,2276 1744,2276 1749,2030 1753,2276 1758,2276 1762,2276 1767,2204 1771,2276 1776,2276 1780,2029 1785,2276 1789,2276 1794,2276 1798,2203 1803,2276 1807,2276 1812,2022 1816,2276 1821,2276 1825,2276 1830,2199 1834,2276 1839,2276 1843,2019 1848,2276 1852,2276 1857,2276 1861,2199 1866,2276 1870,2276 1875,2012 1879,2276 1884,2276 1888,2276 1893,2195 1897,2276 1902,2276 1906,2009 1911,2276 1915,2276 1920,2276 1924,2194 1929,2276 1933,2276 1938,2007 1942,2276 1947,2276 1951,2276 1956,2191 1960,2276 1965,2276 1969,1998 1974,2276 1978,2276 1983,2276 1987,2189 1992,2276 1996,2276 2001,1996 2005,2276 2010,2276 2014,2276 2019,2186 2023,2276 2028,2276 2032,1987 2037,2276 2041,2276 2046,2276 2050,2184 2055,2276 2059,2276 2064,1984 2068,2276 2073,2276 2077,2276 2082,2181 2086,2276 2091,2276 2095,1976 2100,2276 2104,2276 2109,2276 2113,2180 2118,2276 2122,2276 2127,1973 2131,2276 2136,2276 2140,2276 2145,2178 2149,2276 2154,2276 2158,1965 2163,2276 2167,2276 2172,2276 2176,2174 2181,2276 2185,2276 2190,1961 2194,2276 2199,2276 2203,2276 2208,2173 2212,2276 2217,2276 2221,1953 2226,2276 2230,2276 2235,2276 2239,2170 2244,2276 2248,2276 2253,1950 2257,2276 2262,2276 2266,2276 2271,2168 2275,2276 2280,2276 2284,1947 2289,2276 2293,2276 2298,2276 2302,2164 2307,2276 2311,2276 2316,1938 2320,2276 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, low frequency_0.000100.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, low frequency_0.000100.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, low frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,957 88,948 93,940 97,932 102,924 106,916 111,908 115,901 120,894 124,886 129,879 133,872 138,865 142,858 147,851 151,845 156,838 160,831 165,825 169,819 174,812 178,806 183,800 187,795 192,789 196,783 201,777 205,772 210,766 214,761 219,756 223,750 228,745 232,740 237,735 241,730 246,726 250,721 255,716 259,712 264,707 268,703 273,698 277,694 282,690 286,686 291,682 295,678 300,674 304,670 309,666 313,662 318,659 322,655 327,651 331,648 336,644 340,641 345,637 349,634 354,631 358,628 363,624 367,622 372,618 376,615 381,612 385,610 390,607 394,604 399,601 403,598 408,596 412,593 417,590 421,588 426,585 430,583 435,581 439,579 444,576 448,575 453,573 457,571 462,569 466,568 471,567 475,566 480,564 484,563 489,563 493,561 498,560 502,560 506,559 511,557 515,557 520,557 524,556 529,555 533,555 538,555 542,554 547,553 551,553 556,553 560,552 565,552 569,552 574,552 578,551 583,551 587,551 592,551 596,550 601,550 605,551 610,550 614,549 619,550 623,550 628,549 632,549 637,550 641,550 646,549 650,549 655,550 659,550 664,549 668,550 673,550 677,550 682,549 686,550 691,550 695,550 700,550 704,550 709,550 713,550 718,550 722,551 727,551 731,550 736,551 740,551 745,551 749,550 754,551 758,551 763,551 767,551 772,551 776,551 781,551 785,551 790,552 794,552 799,551 803,552 808,552 812,552 817,552 821,552 826,552 830,552 835,552 839,552 844,552 848,552 853,552 857,553 862,553 866,552 871,553 875,553 880,553 884,553 889,553 893,553 898,553 902,553 907,553 911,553 916,553 920,553 925,553 929,553 934,553 938,554 943,554 947,553 952,554 956,554 961,554 965,553 970,554 974,554 979,554 983,553 988,554 992,554 997,554 1001,554 1006,554 1010,554 1015,554 1019,554 1024,554 1028,554 1033,554 1037,554 1042,554 1046,554 1051,554 1055,554 1060,554 1064,554 1069,554 1073,554 1078,554 1082,554 1087,554 1091,554 1096,554 1100,554 1105,554 1109,554 1114,554 1118,554 1123,554 1127,554 1132,554 1136,554 1141,554 1145,554 1150,554 1154,554 1159,554 1163,554 1168,554 1172,554 1177,554 1181,554 1186,554 1190,554 1195,554 1199,554 1204,554 1208,554 1213,554 1217,554 1222,554 1226,554 1231,554 1235,554 1240,554 1244,554 1249,554 1253,554 1258,554 1262,554 1267,554 1271,554 1276,554 1280,554 1285,554 1289,554 1294,554 1298,554 1303,554 1307,554 1312,554 1316,554 1321,554 1325,554 1330,554 1334,554 1339,554 1343,554 1348,554 1352,554 1357,554 1361,554 1366,554 1370,554 1375,554 1379,554 1384,554 1388,554 1393,554 1397,554 1402,554 1406,554 1411,554 1415,554 1420,554 1424,554 1429,554 1433,554 1438,554 1442,554 1447,554 1451,554 1456,554 1460,554 1465,554 1469,554 1474,554 1478,554 1483,554 1487,554 1492,554 1496,554 1501,554 1505,554 1510,554 1514,554 1519,554 1523,554 1528,554 1532,554 1537,554 1541,554 1546,554 1550,554 1555,554 1559,554 1564,554 1568,554 1573,554 1577,554 1582,554 1586,554 1591,554 1595,554 1600,554 1604,554 1609,554 1613,554 1618,554 1622,554 1626,554 1631,554 1635,554 1640,554 1644,554 1649,554 1653,554 1658,554 1662,554 1667,554 1671,554 1676,554 1680,554 1685,554 1689,554 1694,554 1698,554 1703,554 1707,554 1712,554 1716,554 1721,554 1725,554 1730,554 1734,554 1739,554 1743,554 1748,554 1752,554 1757,554 1761,554 1766,554 1770,554 1775,554 1779,554 1784,554 1788,554 1793,554 1797,554 1802,554 1806,554 1811,554 1815,554 1820,554 1824,554 1829,554 1833,554 1838,554 1842,554 1847,554 1851,554 1856,554 1860,553 1865,554 1869,554 1874,554 1878,554 1883,554 1887,554 1892,554 1896,554 1901,554 1905,554 1910,553 1914,554 1919,554 1923,554 1928,553 1932,554 1937,554 1941,554 1946,554 1950,554 1955,554 1959,554 1964,554 1968,554 1973,554 1977,553 1982,554 1986,554 1991,554 1995,553 2000,554 2004,554 2009,554 2013,554 2018,554 2022,554 2027,554 2031,554 2036,554 2040,554 2045,553 2049,554 2054,554 2058,554 2063,553 2067,554 2072,554 2076,554 2081,554 2085,554 2090,554 2094,554 2099,554 2103,554 2108,554 2112,553 2117,554 2121,554 2126,554 2130,553 2135,554 2139,554 2144,554 2148,553 2153,554 2157,554 2162,554 2166,554 2171,554 2175,554 2180,553 2184,554 2189,554 2193,554 2198,553 2202,554 2207,554 2211,554 2216,553 2220,554 2225,554 2229,554 2234,554 2238,554 2243,554 2247,553 2252,554 2256,554 2261,554 2265,553 2270,554 2274,554 2279,554 2283,553 2288,554 2292,554 2297,553 2301,553 2306,554 2310,554 2315,553 2319,554 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2226 74,2226 "/>
+<text x="65" y="2127" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2127 74,2127 "/>
+<text x="65" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2029 74,2029 "/>
+<text x="65" y="1930" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1930 74,1930 "/>
+<text x="65" y="1831" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1831 74,1831 "/>
+<text x="65" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1733 74,1733 "/>
+<text x="65" y="1634" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1634 74,1634 "/>
+<text x="65" y="1535" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1535 74,1535 "/>
+<text x="65" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+9M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1437 74,1437 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1797 79,1346 84,1967 88,2289 93,1600 97,1423 102,2148 106,2174 111,1443 115,1570 120,2275 124,2000 129,1353 133,1763 138,2324 142,1797 147,1346 151,1967 156,2289 160,1600 165,1423 169,2148 174,2174 178,1443 183,1570 187,2275 192,2000 196,1353 201,1763 205,2324 210,1797 214,1346 219,1967 223,2289 228,1600 232,1423 237,2148 241,2174 246,1443 250,1570 255,2275 259,2000 264,1353 268,1763 273,2324 277,1797 282,1346 286,1967 291,2289 295,1600 300,1423 304,2148 309,2174 313,1443 318,1570 322,2275 327,2000 331,1353 336,1763 340,2324 345,1797 349,1346 354,1967 358,2289 363,1600 367,1423 372,2148 376,2174 381,1443 385,1570 390,2275 394,2000 399,1353 403,1763 408,2324 412,1797 417,1346 421,1967 426,2289 430,1600 435,1423 439,2148 444,2174 448,1443 453,1570 457,2275 462,2000 466,1353 471,1763 475,2324 480,1797 484,1346 489,1967 493,2289 498,1600 502,1423 506,2148 511,2174 515,1443 520,1570 524,2275 529,2000 533,1353 538,1763 542,2324 547,1797 551,1346 556,1967 560,2289 565,1600 569,1423 574,2148 578,2174 583,1443 587,1570 592,2275 596,2000 601,1353 605,1763 610,2324 614,1797 619,1346 623,1967 628,2289 632,1600 637,1423 641,2148 646,2174 650,1443 655,1570 659,2275 664,2000 668,1353 673,1763 677,2324 682,1797 686,1346 691,1967 695,2289 700,1600 704,1423 709,2148 713,2174 718,1443 722,1570 727,2275 731,2000 736,1353 740,1763 745,2324 749,1797 754,1346 758,1967 763,2289 767,1600 772,1423 776,2148 781,2174 785,1443 790,1570 794,2275 799,2000 803,1353 808,1763 812,2324 817,1797 821,1346 826,1967 830,2289 835,1600 839,1423 844,2148 848,2174 853,1443 857,1570 862,2275 866,2000 871,1353 875,1763 880,2324 884,1797 889,1346 893,1967 898,2289 902,1600 907,1423 911,2148 916,2174 920,1443 925,1570 929,2275 934,2000 938,1353 943,1763 947,2324 952,1797 956,1346 961,1967 965,2289 970,1600 974,1423 979,2148 983,2174 988,1443 992,1570 997,2275 1001,2000 1006,1353 1010,1763 1015,2324 1019,1797 1024,1346 1028,1967 1033,2289 1037,1600 1042,1423 1046,2148 1051,2174 1055,1443 1060,1570 1064,2275 1069,2000 1073,1353 1078,1763 1082,2324 1087,1797 1091,1346 1096,1967 1100,2289 1105,1600 1109,1423 1114,2148 1118,2174 1123,1443 1127,1570 1132,2275 1136,2000 1141,1353 1145,1763 1150,2324 1154,1797 1159,1346 1163,1967 1168,2289 1172,1600 1177,1423 1181,2148 1186,2174 1190,1443 1195,1570 1199,2275 1204,2000 1208,1353 1213,1763 1217,2324 1222,1797 1226,1346 1231,1967 1235,2289 1240,1600 1244,1423 1249,2148 1253,2174 1258,1443 1262,1570 1267,2275 1271,2000 1276,1353 1280,1763 1285,2324 1289,1797 1294,1346 1298,1967 1303,2289 1307,1600 1312,1423 1316,2148 1321,2174 1325,1443 1330,1570 1334,2275 1339,2000 1343,1353 1348,1763 1352,2324 1357,1797 1361,1346 1366,1967 1370,2289 1375,1600 1379,1423 1384,2148 1388,2174 1393,1443 1397,1570 1402,2275 1406,2000 1411,1353 1415,1763 1420,2324 1424,1797 1429,1346 1433,1967 1438,2289 1442,1600 1447,1423 1451,2148 1456,2174 1460,1443 1465,1570 1469,2275 1474,2000 1478,1353 1483,1763 1487,2324 1492,1797 1496,1346 1501,1967 1505,2289 1510,1600 1514,1423 1519,2148 1523,2174 1528,1443 1532,1570 1537,2275 1541,2000 1546,1353 1550,1763 1555,2324 1559,1797 1564,1346 1568,1967 1573,2289 1577,1600 1582,1423 1586,2148 1591,2174 1595,1443 1600,1570 1604,2275 1609,2000 1613,1353 1618,1763 1622,2324 1626,1797 1631,1346 1635,1967 1640,2289 1644,1600 1649,1423 1653,2148 1658,2174 1662,1443 1667,1570 1671,2275 1676,2000 1680,1353 1685,1763 1689,2324 1694,1797 1698,1346 1703,1967 1707,2289 1712,1600 1716,1423 1721,2148 1725,2174 1730,1443 1734,1570 1739,2275 1743,2000 1748,1353 1752,1763 1757,2324 1761,1797 1766,1346 1770,1967 1775,2289 1779,1600 1784,1423 1788,2148 1793,2174 1797,1443 1802,1570 1806,2275 1811,2000 1815,1353 1820,1763 1824,2324 1829,1797 1833,1346 1838,1967 1842,2289 1847,1600 1851,1423 1856,2148 1860,2174 1865,1443 1869,1570 1874,2275 1878,2000 1883,1353 1887,1763 1892,2324 1896,1797 1901,1346 1905,1967 1910,2289 1914,1600 1919,1423 1923,2148 1928,2174 1932,1443 1937,1570 1941,2275 1946,2000 1950,1353 1955,1763 1959,2324 1964,1797 1968,1346 1973,1967 1977,2289 1982,1600 1986,1423 1991,2148 1995,2174 2000,1443 2004,1570 2009,2275 2013,2000 2018,1353 2022,1763 2027,2324 2031,1797 2036,1346 2040,1967 2045,2289 2049,1600 2054,1423 2058,2148 2063,2174 2067,1443 2072,1570 2076,2275 2081,2000 2085,1353 2090,1763 2094,2324 2099,1797 2103,1346 2108,1967 2112,2289 2117,1600 2121,1423 2126,2148 2130,2174 2135,1443 2139,1570 2144,2275 2148,2000 2153,1353 2157,1763 2162,2324 2166,1797 2171,1346 2175,1967 2180,2289 2184,1600 2189,1423 2193,2148 2198,2174 2202,1443 2207,1570 2211,2275 2216,2000 2220,1353 2225,1763 2229,2324 2234,1797 2238,1346 2243,1967 2247,2289 2252,1600 2256,1423 2261,2148 2265,2174 2270,1443 2274,1570 2279,2275 2283,2000 2288,1353 2292,1763 2297,2324 2301,1797 2306,1346 2310,1967 2315,2289 2319,1600 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2132 430,2276 435,2272 439,2076 444,1832 448,2225 453,2197 457,1832 462,1888 466,2194 471,2097 475,1832 480,2013 484,2167 489,1931 493,1832 498,2082 502,2134 507,1832 511,1832 516,2113 520,2083 525,1832 529,1832 534,2126 538,1998 543,1832 547,1918 552,2125 556,1842 561,1832 565,2042 570,2109 574,1832 579,1832 583,2100 588,2072 592,1832 597,1832 601,2126 606,2003 610,1832 615,1932 619,2135 624,1870 628,1832 633,2065 637,2127 642,1832 646,1832 651,2124 655,2101 660,1832 664,1832 669,2153 673,2047 678,1832 682,1988 687,2164 691,1941 696,1832 700,2108 705,2161 709,1832 714,1832 718,2161 723,2142 727,1832 732,1852 736,2186 741,2100 745,1832 750,2054 754,2196 759,2018 763,1832 768,2153 772,2195 777,1855 781,1832 786,2196 790,2181 795,1832 799,1915 804,2217 808,2150 813,1832 817,2114 822,2225 826,2087 831,1832 835,2193 840,2225 844,1962 849,1832 853,2226 858,2214 862,1832 867,1985 871,2242 876,2191 880,1832 885,2164 889,2249 894,2143 898,1832 903,2224 907,2249 912,2047 916,1836 921,2249 925,2238 930,1844 934,2035 939,2257 943,2214 948,1832 952,2188 957,2259 961,2165 966,1832 970,2234 975,2255 979,2067 984,1840 988,2252 993,2242 997,1865 1002,2044 1006,2260 1011,2218 1015,1832 1020,2192 1024,2261 1029,2169 1033,1832 1038,2236 1042,2256 1047,2072 1051,1841 1056,2253 1060,2243 1065,1869 1069,2046 1074,2260 1078,2218 1083,1832 1087,2192 1092,2261 1096,2170 1101,1832 1105,2236 1110,2256 1114,2071 1119,1841 1123,2253 1128,2243 1132,1868 1137,2045 1141,2260 1146,2218 1150,1832 1155,2192 1159,2261 1164,2169 1168,1832 1173,2236 1177,2256 1182,2069 1186,1841 1191,2253 1195,2242 1200,1865 1204,2043 1209,2260 1213,2217 1218,1832 1222,2190 1227,2260 1231,2168 1236,1832 1240,2235 1245,2255 1249,2067 1254,1840 1258,2252 1263,2241 1267,1860 1272,2041 1276,2259 1281,2215 1285,1832 1290,2189 1294,2260 1299,2165 1303,1832 1308,2234 1312,2254 1317,2064 1321,1839 1326,2251 1330,2241 1335,1855 1339,2039 1344,2258 1348,2215 1353,1832 1357,2187 1362,2259 1366,2164 1371,1832 1375,2233 1380,2253 1384,2061 1389,1839 1393,2251 1398,2239 1402,1849 1407,2037 1411,2258 1416,2213 1420,1832 1425,2186 1429,2258 1434,2162 1438,1832 1443,2232 1447,2252 1452,2058 1456,1838 1461,2250 1465,2239 1470,1844 1474,2034 1479,2257 1483,2212 1488,1832 1492,2184 1497,2257 1501,2160 1506,1832 1510,2231 1515,2252 1519,2055 1524,1837 1528,2249 1533,2238 1537,1838 1542,2031 1546,2256 1551,2210 1555,1832 1560,2183 1564,2257 1569,2158 1573,1832 1578,2230 1582,2251 1587,2052 1591,1836 1596,2248 1600,2237 1605,1832 1609,2029 1614,2255 1618,2209 1623,1832 1627,2181 1632,2256 1636,2156 1641,1832 1645,2228 1650,2250 1654,2048 1659,1835 1663,2247 1668,2236 1672,1832 1677,2026 1681,2254 1686,2208 1690,1832 1695,2179 1699,2255 1704,2154 1708,1832 1713,2227 1717,2249 1722,2046 1726,1834 1731,2246 1735,2235 1740,1832 1744,2023 1749,2254 1753,2206 1758,1832 1762,2178 1767,2254 1771,2152 1776,1832 1780,2226 1785,2248 1789,2042 1794,1834 1798,2245 1803,2234 1807,1832 1812,2021 1816,2253 1821,2205 1825,1832 1830,2176 1834,2253 1839,2150 1843,1832 1848,2225 1852,2247 1857,2039 1861,1833 1866,2245 1870,2233 1875,1832 1879,2018 1884,2252 1888,2204 1893,1832 1897,2174 1902,2252 1906,2148 1911,1832 1915,2224 1920,2246 1924,2036 1929,1832 1933,2243 1938,2232 1942,1832 1947,2015 1951,2251 1956,2202 1960,1832 1965,2172 1969,2251 1974,2146 1978,1832 1983,2223 1987,2246 1992,2032 1996,1832 2001,2242 2005,2231 2010,1832 2014,2013 2019,2250 2023,2201 2028,1832 2032,2170 2037,2250 2041,2144 2046,1832 2050,2221 2055,2245 2059,2029 2064,1832 2068,2242 2073,2230 2077,1832 2082,2010 2086,2249 2091,2199 2095,1832 2100,2169 2104,2250 2109,2141 2113,1832 2118,2220 2122,2244 2127,2025 2131,1832 2136,2240 2140,2229 2145,1832 2149,2008 2154,2248 2158,2198 2163,1832 2167,2167 2172,2249 2176,2140 2181,1832 2185,2219 2190,2243 2194,2022 2199,1832 2203,2239 2208,2228 2212,1832 2217,2007 2221,2247 2226,2196 2230,1832 2235,2165 2239,2248 2244,2138 2248,1832 2253,2218 2257,2242 2262,2019 2266,1832 2271,2239 2275,2226 2280,1832 2284,2004 2289,2246 2293,2195 2298,1832 2302,2163 2307,2247 2311,2135 2316,1832 2320,2216 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, low frequency_0.000200.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, low frequency_0.000200.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, low frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,957 88,948 93,940 97,932 102,924 106,916 111,908 115,901 120,894 124,886 129,879 133,872 138,865 142,858 147,851 151,845 156,838 160,831 165,825 169,819 174,812 178,806 183,800 187,795 192,789 196,783 201,777 205,772 210,766 214,761 219,756 223,750 228,745 232,740 237,735 241,730 246,726 250,721 255,716 259,712 264,707 268,703 273,698 277,694 282,690 286,686 291,682 295,678 300,674 304,670 309,666 313,662 318,659 322,655 327,651 331,648 336,644 340,641 345,637 349,634 354,631 358,628 363,625 367,622 372,619 376,616 381,614 385,611 390,609 394,606 399,604 403,602 408,600 412,598 417,596 421,594 426,592 430,590 435,589 439,587 444,585 448,584 453,582 457,581 462,579 466,578 471,577 475,576 480,574 484,573 489,573 493,571 498,570 502,569 506,569 511,567 515,566 520,566 524,565 529,563 533,563 538,563 542,562 547,561 551,561 556,560 560,559 565,559 569,558 574,558 578,557 583,557 587,557 592,556 596,555 601,555 605,555 610,554 614,554 619,554 623,554 628,553 632,553 637,553 641,553 646,552 650,552 655,552 659,552 664,551 668,551 673,551 677,551 682,551 686,551 691,551 695,550 700,550 704,550 709,551 713,550 718,550 722,550 727,550 731,550 736,550 740,550 745,550 749,550 754,550 758,550 763,550 767,550 772,550 776,550 781,549 785,550 790,550 794,550 799,550 803,550 808,550 812,550 817,550 821,550 826,550 830,550 835,550 839,550 844,550 848,550 853,550 857,550 862,550 866,550 871,550 875,551 880,551 884,551 889,551 893,551 898,551 902,551 907,551 911,551 916,551 920,551 925,551 929,551 934,551 938,551 943,551 947,551 952,551 956,552 961,552 965,551 970,552 974,552 979,552 983,551 988,552 992,552 997,552 1001,552 1006,552 1010,552 1015,552 1019,552 1024,552 1028,552 1033,552 1037,552 1042,552 1046,552 1051,552 1055,552 1060,552 1064,552 1069,552 1073,552 1078,552 1082,552 1087,552 1091,552 1096,552 1100,552 1105,552 1109,552 1114,552 1118,552 1123,552 1127,552 1132,552 1136,552 1141,552 1145,552 1150,552 1154,552 1159,552 1163,553 1168,552 1172,552 1177,553 1181,553 1186,552 1190,552 1195,553 1199,553 1204,552 1208,553 1213,553 1217,552 1222,552 1226,553 1231,553 1235,552 1240,552 1244,553 1249,553 1253,552 1258,553 1262,553 1267,553 1271,552 1276,553 1280,553 1285,552 1289,552 1294,553 1298,553 1303,552 1307,553 1312,553 1316,553 1321,552 1325,553 1330,553 1334,553 1339,552 1343,553 1348,553 1352,552 1357,552 1361,553 1366,553 1370,552 1375,553 1379,553 1384,553 1388,552 1393,553 1397,553 1402,553 1406,552 1411,553 1415,553 1420,552 1424,552 1429,553 1433,553 1438,552 1442,552 1447,553 1451,553 1456,552 1460,553 1465,553 1469,553 1474,552 1478,553 1483,553 1487,552 1492,552 1496,553 1501,553 1505,552 1510,552 1514,553 1519,553 1523,552 1528,552 1532,553 1537,553 1541,552 1546,553 1550,553 1555,552 1559,552 1564,553 1568,553 1573,552 1577,552 1582,553 1586,553 1591,552 1595,552 1600,553 1604,553 1609,552 1613,552 1618,553 1622,552 1626,552 1631,552 1635,553 1640,552 1644,552 1649,553 1653,553 1658,552 1662,552 1667,553 1671,552 1676,552 1680,552 1685,553 1689,552 1694,552 1698,552 1703,553 1707,552 1712,552 1716,552 1721,553 1725,552 1730,552 1734,552 1739,552 1743,552 1748,552 1752,552 1757,552 1761,552 1766,552 1770,552 1775,552 1779,552 1784,552 1788,552 1793,552 1797,552 1802,552 1806,552 1811,552 1815,552 1820,552 1824,552 1829,552 1833,552 1838,552 1842,552 1847,552 1851,552 1856,552 1860,552 1865,552 1869,552 1874,552 1878,552 1883,552 1887,552 1892,552 1896,552 1901,552 1905,552 1910,552 1914,552 1919,552 1923,552 1928,552 1932,552 1937,552 1941,552 1946,552 1950,552 1955,552 1959,552 1964,552 1968,552 1973,552 1977,552 1982,552 1986,552 1991,552 1995,552 2000,552 2004,552 2009,552 2013,552 2018,552 2022,552 2027,552 2031,552 2036,552 2040,552 2045,552 2049,552 2054,552 2058,552 2063,552 2067,552 2072,552 2076,552 2081,552 2085,552 2090,552 2094,552 2099,552 2103,552 2108,552 2112,552 2117,552 2121,552 2126,552 2130,552 2135,552 2139,552 2144,552 2148,552 2153,552 2157,552 2162,552 2166,552 2171,552 2175,552 2180,552 2184,552 2189,552 2193,552 2198,552 2202,552 2207,552 2211,552 2216,552 2220,552 2225,552 2229,552 2234,552 2238,552 2243,552 2247,552 2252,552 2256,552 2261,552 2265,552 2270,552 2274,552 2279,552 2283,552 2288,552 2292,552 2297,552 2301,552 2306,552 2310,552 2315,552 2319,552 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2226 74,2226 "/>
+<text x="65" y="2127" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2127 74,2127 "/>
+<text x="65" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2029 74,2029 "/>
+<text x="65" y="1930" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1930 74,1930 "/>
+<text x="65" y="1831" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1831 74,1831 "/>
+<text x="65" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1733 74,1733 "/>
+<text x="65" y="1634" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1634 74,1634 "/>
+<text x="65" y="1535" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1535 74,1535 "/>
+<text x="65" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+9M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1437 74,1437 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1797 79,1346 84,1967 88,2289 93,1600 97,1423 102,2148 106,2174 111,1443 115,1570 120,2275 124,2000 129,1353 133,1763 138,2324 142,1797 147,1346 151,1967 156,2289 160,1600 165,1423 169,2148 174,2174 178,1443 183,1570 187,2275 192,2000 196,1353 201,1763 205,2324 210,1797 214,1346 219,1967 223,2289 228,1600 232,1423 237,2148 241,2174 246,1443 250,1570 255,2275 259,2000 264,1353 268,1763 273,2324 277,1797 282,1346 286,1967 291,2289 295,1600 300,1423 304,2148 309,2174 313,1443 318,1570 322,2275 327,2000 331,1353 336,1763 340,2324 345,1797 349,1346 354,1967 358,2289 363,1600 367,1423 372,2148 376,2174 381,1443 385,1570 390,2275 394,2000 399,1353 403,1763 408,2324 412,1797 417,1346 421,1967 426,2289 430,1600 435,1423 439,2148 444,2174 448,1443 453,1570 457,2275 462,2000 466,1353 471,1763 475,2324 480,1797 484,1346 489,1967 493,2289 498,1600 502,1423 506,2148 511,2174 515,1443 520,1570 524,2275 529,2000 533,1353 538,1763 542,2324 547,1797 551,1346 556,1967 560,2289 565,1600 569,1423 574,2148 578,2174 583,1443 587,1570 592,2275 596,2000 601,1353 605,1763 610,2324 614,1797 619,1346 623,1967 628,2289 632,1600 637,1423 641,2148 646,2174 650,1443 655,1570 659,2275 664,2000 668,1353 673,1763 677,2324 682,1797 686,1346 691,1967 695,2289 700,1600 704,1423 709,2148 713,2174 718,1443 722,1570 727,2275 731,2000 736,1353 740,1763 745,2324 749,1797 754,1346 758,1967 763,2289 767,1600 772,1423 776,2148 781,2174 785,1443 790,1570 794,2275 799,2000 803,1353 808,1763 812,2324 817,1797 821,1346 826,1967 830,2289 835,1600 839,1423 844,2148 848,2174 853,1443 857,1570 862,2275 866,2000 871,1353 875,1763 880,2324 884,1797 889,1346 893,1967 898,2289 902,1600 907,1423 911,2148 916,2174 920,1443 925,1570 929,2275 934,2000 938,1353 943,1763 947,2324 952,1797 956,1346 961,1967 965,2289 970,1600 974,1423 979,2148 983,2174 988,1443 992,1570 997,2275 1001,2000 1006,1353 1010,1763 1015,2324 1019,1797 1024,1346 1028,1967 1033,2289 1037,1600 1042,1423 1046,2148 1051,2174 1055,1443 1060,1570 1064,2275 1069,2000 1073,1353 1078,1763 1082,2324 1087,1797 1091,1346 1096,1967 1100,2289 1105,1600 1109,1423 1114,2148 1118,2174 1123,1443 1127,1570 1132,2275 1136,2000 1141,1353 1145,1763 1150,2324 1154,1797 1159,1346 1163,1967 1168,2289 1172,1600 1177,1423 1181,2148 1186,2174 1190,1443 1195,1570 1199,2275 1204,2000 1208,1353 1213,1763 1217,2324 1222,1797 1226,1346 1231,1967 1235,2289 1240,1600 1244,1423 1249,2148 1253,2174 1258,1443 1262,1570 1267,2275 1271,2000 1276,1353 1280,1763 1285,2324 1289,1797 1294,1346 1298,1967 1303,2289 1307,1600 1312,1423 1316,2148 1321,2174 1325,1443 1330,1570 1334,2275 1339,2000 1343,1353 1348,1763 1352,2324 1357,1797 1361,1346 1366,1967 1370,2289 1375,1600 1379,1423 1384,2148 1388,2174 1393,1443 1397,1570 1402,2275 1406,2000 1411,1353 1415,1763 1420,2324 1424,1797 1429,1346 1433,1967 1438,2289 1442,1600 1447,1423 1451,2148 1456,2174 1460,1443 1465,1570 1469,2275 1474,2000 1478,1353 1483,1763 1487,2324 1492,1797 1496,1346 1501,1967 1505,2289 1510,1600 1514,1423 1519,2148 1523,2174 1528,1443 1532,1570 1537,2275 1541,2000 1546,1353 1550,1763 1555,2324 1559,1797 1564,1346 1568,1967 1573,2289 1577,1600 1582,1423 1586,2148 1591,2174 1595,1443 1600,1570 1604,2275 1609,2000 1613,1353 1618,1763 1622,2324 1626,1797 1631,1346 1635,1967 1640,2289 1644,1600 1649,1423 1653,2148 1658,2174 1662,1443 1667,1570 1671,2275 1676,2000 1680,1353 1685,1763 1689,2324 1694,1797 1698,1346 1703,1967 1707,2289 1712,1600 1716,1423 1721,2148 1725,2174 1730,1443 1734,1570 1739,2275 1743,2000 1748,1353 1752,1763 1757,2324 1761,1797 1766,1346 1770,1967 1775,2289 1779,1600 1784,1423 1788,2148 1793,2174 1797,1443 1802,1570 1806,2275 1811,2000 1815,1353 1820,1763 1824,2324 1829,1797 1833,1346 1838,1967 1842,2289 1847,1600 1851,1423 1856,2148 1860,2174 1865,1443 1869,1570 1874,2275 1878,2000 1883,1353 1887,1763 1892,2324 1896,1797 1901,1346 1905,1967 1910,2289 1914,1600 1919,1423 1923,2148 1928,2174 1932,1443 1937,1570 1941,2275 1946,2000 1950,1353 1955,1763 1959,2324 1964,1797 1968,1346 1973,1967 1977,2289 1982,1600 1986,1423 1991,2148 1995,2174 2000,1443 2004,1570 2009,2275 2013,2000 2018,1353 2022,1763 2027,2324 2031,1797 2036,1346 2040,1967 2045,2289 2049,1600 2054,1423 2058,2148 2063,2174 2067,1443 2072,1570 2076,2275 2081,2000 2085,1353 2090,1763 2094,2324 2099,1797 2103,1346 2108,1967 2112,2289 2117,1600 2121,1423 2126,2148 2130,2174 2135,1443 2139,1570 2144,2275 2148,2000 2153,1353 2157,1763 2162,2324 2166,1797 2171,1346 2175,1967 2180,2289 2184,1600 2189,1423 2193,2148 2198,2174 2202,1443 2207,1570 2211,2275 2216,2000 2220,1353 2225,1763 2229,2324 2234,1797 2238,1346 2243,1967 2247,2289 2252,1600 2256,1423 2261,2148 2265,2174 2270,1443 2274,1570 2279,2275 2283,2000 2288,1353 2292,1763 2297,2324 2301,1797 2306,1346 2310,1967 2315,2289 2319,1600 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2263 345,2276 349,2276 354,2250 358,1832 363,2266 367,2268 372,2048 376,1849 381,2245 385,2222 390,1832 394,2029 399,2229 403,2151 408,1832 412,2122 417,2212 421,2015 426,1832 430,2158 435,2186 439,1832 444,1832 448,2175 453,2144 457,1832 462,1869 466,2179 471,2068 475,1832 480,2044 484,2173 489,1920 493,1832 498,2117 502,2154 507,1832 511,1832 516,2150 520,2117 525,1832 529,1834 534,2164 538,2046 543,1832 547,2025 552,2163 556,1902 561,1832 565,2111 570,2151 574,1832 579,1832 583,2151 588,2119 592,1832 597,1841 601,2169 606,2056 610,1832 615,2039 619,2173 624,1926 628,1832 633,2125 637,2163 642,1832 646,1832 651,2165 655,2137 660,1832 664,1873 669,2184 673,2082 678,1832 682,2070 687,2189 691,1970 696,1832 700,2149 705,2183 709,1832 714,1832 718,2186 723,2161 727,1832 732,1927 736,2203 741,2116 745,1832 750,2107 754,2209 759,2023 763,1832 768,2176 772,2205 777,1832 781,1832 786,2208 790,2188 795,1832 799,1989 804,2223 808,2151 813,1832 817,2144 822,2229 826,2075 831,1832 835,2202 840,2226 844,1905 849,1832 853,2229 858,2213 862,1832 867,2049 871,2242 876,2184 880,1832 885,2179 889,2248 894,2122 898,1832 903,2226 907,2245 912,1987 916,1838 921,2246 925,2232 930,1832 934,2091 939,2255 943,2203 948,1832 952,2195 957,2256 961,2141 966,1832 970,2233 975,2250 979,2003 984,1843 988,2249 993,2235 997,1832 1002,2098 1006,2257 1011,2206 1015,1832 1020,2198 1024,2257 1029,2145 1033,1832 1038,2234 1042,2251 1047,2008 1051,1845 1056,2251 1060,2236 1065,1832 1069,2101 1074,2257 1078,2207 1083,1832 1087,2200 1092,2258 1096,2147 1101,1832 1105,2235 1110,2251 1114,2011 1119,1847 1123,2251 1128,2237 1132,1832 1137,2102 1141,2258 1146,2208 1150,1832 1155,2200 1159,2258 1164,2147 1168,1832 1173,2236 1177,2252 1182,2011 1186,1847 1191,2251 1195,2237 1200,1832 1204,2102 1209,2258 1213,2208 1218,1832 1222,2200 1227,2258 1231,2147 1236,1832 1240,2235 1245,2252 1249,2010 1254,1847 1258,2251 1263,2236 1267,1832 1272,2101 1276,2257 1281,2207 1285,1832 1290,2199 1294,2257 1299,2145 1303,1832 1308,2235 1312,2251 1317,2008 1321,1846 1326,2250 1330,2236 1335,1832 1339,2099 1344,2257 1348,2206 1353,1832 1357,2198 1362,2257 1366,2144 1371,1832 1375,2234 1380,2250 1384,2005 1389,1845 1393,2250 1398,2235 1402,1832 1407,2097 1411,2257 1416,2205 1420,1832 1425,2197 1429,2256 1434,2142 1438,1832 1443,2233 1447,2250 1452,2002 1456,1843 1461,2249 1465,2234 1470,1832 1474,2095 1479,2255 1483,2203 1488,1832 1492,2196 1497,2256 1501,2140 1506,1832 1510,2232 1515,2249 1519,1999 1524,1842 1528,2249 1533,2233 1537,1832 1542,2093 1546,2255 1551,2203 1555,1832 1560,2194 1564,2255 1569,2139 1573,1832 1578,2231 1582,2248 1587,1996 1591,1840 1596,2248 1600,2232 1605,1832 1609,2090 1614,2254 1618,2201 1623,1832 1627,2193 1632,2254 1636,2137 1641,1832 1645,2230 1650,2247 1654,1992 1659,1839 1663,2247 1668,2232 1672,1832 1677,2088 1681,2253 1686,2200 1690,1832 1695,2192 1699,2253 1704,2135 1708,1832 1713,2229 1717,2247 1722,1989 1726,1837 1731,2246 1735,2231 1740,1832 1744,2085 1749,2252 1753,2198 1758,1832 1762,2190 1767,2253 1771,2133 1776,1832 1780,2228 1785,2246 1789,1984 1794,1836 1798,2245 1803,2230 1807,1832 1812,2082 1816,2252 1821,2197 1825,1832 1830,2188 1834,2252 1839,2130 1843,1832 1848,2227 1852,2245 1857,1980 1861,1834 1866,2244 1870,2229 1875,1832 1879,2080 1884,2250 1888,2195 1893,1832 1897,2187 1902,2251 1906,2128 1911,1832 1915,2226 1920,2244 1924,1976 1929,1832 1933,2243 1938,2228 1942,1832 1947,2077 1951,2250 1956,2194 1960,1832 1965,2185 1969,2250 1974,2126 1978,1832 1983,2225 1987,2243 1992,1973 1996,1832 2001,2242 2005,2227 2010,1832 2014,2074 2019,2249 2023,2193 2028,1832 2032,2184 2037,2249 2041,2124 2046,1832 2050,2223 2055,2242 2059,1969 2064,1832 2068,2241 2073,2226 2077,1832 2082,2071 2086,2248 2091,2191 2095,1832 2100,2182 2104,2248 2109,2121 2113,1832 2118,2222 2122,2241 2127,1965 2131,1832 2136,2241 2140,2225 2145,1832 2149,2069 2154,2247 2158,2189 2163,1832 2167,2180 2172,2248 2176,2119 2181,1832 2185,2221 2190,2240 2194,1961 2199,1832 2203,2239 2208,2223 2212,1832 2217,2068 2221,2246 2226,2188 2230,1832 2235,2179 2239,2247 2244,2117 2248,1832 2253,2220 2257,2239 2262,1957 2266,1832 2271,2238 2275,2222 2280,1832 2284,2065 2289,2246 2293,2186 2298,1832 2302,2177 2307,2246 2311,2114 2316,1832 2320,2219 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, low frequency_0.000300.svg
+++ b/src/assets/rfc-323/throttle_15000000000.000000 T_Unstable fees, low frequency_0.000300.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, low frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 15.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,974 79,965 84,957 88,948 93,940 97,932 102,924 106,916 111,908 115,901 120,894 124,886 129,879 133,872 138,865 142,858 147,851 151,845 156,838 160,831 165,825 169,819 174,812 178,806 183,800 187,795 192,789 196,783 201,777 205,772 210,766 214,761 219,756 223,750 228,745 232,740 237,735 241,730 246,726 250,721 255,717 259,712 264,708 268,704 273,699 277,695 282,691 286,688 291,684 295,680 300,677 304,673 309,669 313,666 318,663 322,660 327,657 331,654 336,651 340,648 345,645 349,643 354,641 358,638 363,635 367,633 372,631 376,628 381,626 385,624 390,622 394,619 399,618 403,616 408,614 412,612 417,610 421,609 426,607 430,605 435,604 439,602 444,600 448,599 453,598 457,596 462,594 466,593 471,593 475,591 480,589 484,588 489,588 493,586 498,585 502,584 506,583 511,582 515,581 520,580 524,579 529,578 533,577 538,577 542,576 547,575 551,574 556,574 560,573 565,572 569,572 574,571 578,570 583,569 587,569 592,569 596,567 601,567 605,567 610,566 614,565 619,565 623,565 628,564 632,564 637,564 641,563 646,562 650,562 655,562 659,562 664,561 668,561 673,561 677,560 682,560 686,560 691,560 695,559 700,559 704,559 709,559 713,558 718,558 722,558 727,558 731,557 736,557 740,557 745,557 749,556 754,556 758,556 763,556 767,556 772,556 776,556 781,555 785,555 790,555 794,555 799,555 803,555 808,555 812,555 817,554 821,555 826,555 830,554 835,554 839,554 844,554 848,554 853,554 857,554 862,554 866,554 871,554 875,554 880,554 884,554 889,554 893,554 898,553 902,553 907,553 911,554 916,553 920,553 925,553 929,553 934,553 938,553 943,553 947,553 952,553 956,553 961,553 965,553 970,553 974,553 979,553 983,553 988,553 992,553 997,553 1001,553 1006,553 1010,553 1015,553 1019,553 1024,553 1028,553 1033,553 1037,553 1042,553 1046,553 1051,553 1055,553 1060,553 1064,553 1069,553 1073,553 1078,553 1082,553 1087,553 1091,553 1096,553 1100,552 1105,553 1109,553 1114,553 1118,552 1123,552 1127,553 1132,553 1136,552 1141,552 1145,553 1150,552 1154,552 1159,552 1163,553 1168,552 1172,552 1177,552 1181,553 1186,552 1190,552 1195,552 1199,552 1204,552 1208,552 1213,552 1217,552 1222,552 1226,552 1231,552 1235,552 1240,552 1244,552 1249,552 1253,552 1258,552 1262,552 1267,552 1271,552 1276,552 1280,552 1285,552 1289,552 1294,552 1298,552 1303,552 1307,552 1312,552 1316,552 1321,552 1325,552 1330,552 1334,552 1339,552 1343,552 1348,552 1352,552 1357,552 1361,552 1366,552 1370,552 1375,552 1379,552 1384,552 1388,552 1393,552 1397,552 1402,552 1406,552 1411,552 1415,552 1420,552 1424,552 1429,552 1433,552 1438,552 1442,552 1447,552 1451,552 1456,552 1460,552 1465,552 1469,552 1474,552 1478,552 1483,552 1487,552 1492,552 1496,552 1501,552 1505,552 1510,552 1514,552 1519,552 1523,552 1528,552 1532,552 1537,552 1541,552 1546,552 1550,552 1555,552 1559,552 1564,552 1568,552 1573,552 1577,552 1582,552 1586,552 1591,552 1595,552 1600,552 1604,552 1609,552 1613,552 1618,552 1622,552 1626,552 1631,552 1635,552 1640,552 1644,552 1649,552 1653,552 1658,552 1662,552 1667,552 1671,552 1676,552 1680,552 1685,552 1689,552 1694,552 1698,552 1703,552 1707,552 1712,552 1716,552 1721,552 1725,552 1730,552 1734,552 1739,552 1743,552 1748,552 1752,552 1757,552 1761,552 1766,552 1770,552 1775,552 1779,552 1784,552 1788,552 1793,552 1797,552 1802,552 1806,552 1811,552 1815,552 1820,552 1824,552 1829,552 1833,552 1838,552 1842,552 1847,552 1851,552 1856,552 1860,552 1865,552 1869,552 1874,552 1878,552 1883,552 1887,552 1892,552 1896,552 1901,552 1905,552 1910,552 1914,552 1919,552 1923,552 1928,552 1932,552 1937,552 1941,552 1946,552 1950,552 1955,552 1959,552 1964,552 1968,552 1973,552 1977,552 1982,552 1986,552 1991,552 1995,551 2000,552 2004,552 2009,552 2013,552 2018,552 2022,552 2027,552 2031,552 2036,552 2040,552 2045,551 2049,552 2054,552 2058,552 2063,551 2067,552 2072,552 2076,552 2081,551 2085,552 2090,552 2094,552 2099,552 2103,552 2108,552 2112,551 2117,552 2121,552 2126,552 2130,551 2135,552 2139,552 2144,552 2148,551 2153,552 2157,552 2162,552 2166,551 2171,552 2175,552 2180,551 2184,552 2189,552 2193,552 2198,551 2202,552 2207,552 2211,552 2216,551 2220,552 2225,552 2229,552 2234,551 2238,552 2243,552 2247,551 2252,551 2256,552 2261,552 2265,551 2270,551 2274,552 2279,552 2283,551 2288,551 2292,552 2297,551 2301,551 2306,552 2310,552 2315,551 2319,551 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2226 74,2226 "/>
+<text x="65" y="2127" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2127 74,2127 "/>
+<text x="65" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2029 74,2029 "/>
+<text x="65" y="1930" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1930 74,1930 "/>
+<text x="65" y="1831" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1831 74,1831 "/>
+<text x="65" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1733 74,1733 "/>
+<text x="65" y="1634" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1634 74,1634 "/>
+<text x="65" y="1535" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1535 74,1535 "/>
+<text x="65" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+9M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1437 74,1437 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1797 79,1346 84,1967 88,2289 93,1600 97,1423 102,2148 106,2174 111,1443 115,1570 120,2275 124,2000 129,1353 133,1763 138,2324 142,1797 147,1346 151,1967 156,2289 160,1600 165,1423 169,2148 174,2174 178,1443 183,1570 187,2275 192,2000 196,1353 201,1763 205,2324 210,1797 214,1346 219,1967 223,2289 228,1600 232,1423 237,2148 241,2174 246,1443 250,1570 255,2275 259,2000 264,1353 268,1763 273,2324 277,1797 282,1346 286,1967 291,2289 295,1600 300,1423 304,2148 309,2174 313,1443 318,1570 322,2275 327,2000 331,1353 336,1763 340,2324 345,1797 349,1346 354,1967 358,2289 363,1600 367,1423 372,2148 376,2174 381,1443 385,1570 390,2275 394,2000 399,1353 403,1763 408,2324 412,1797 417,1346 421,1967 426,2289 430,1600 435,1423 439,2148 444,2174 448,1443 453,1570 457,2275 462,2000 466,1353 471,1763 475,2324 480,1797 484,1346 489,1967 493,2289 498,1600 502,1423 506,2148 511,2174 515,1443 520,1570 524,2275 529,2000 533,1353 538,1763 542,2324 547,1797 551,1346 556,1967 560,2289 565,1600 569,1423 574,2148 578,2174 583,1443 587,1570 592,2275 596,2000 601,1353 605,1763 610,2324 614,1797 619,1346 623,1967 628,2289 632,1600 637,1423 641,2148 646,2174 650,1443 655,1570 659,2275 664,2000 668,1353 673,1763 677,2324 682,1797 686,1346 691,1967 695,2289 700,1600 704,1423 709,2148 713,2174 718,1443 722,1570 727,2275 731,2000 736,1353 740,1763 745,2324 749,1797 754,1346 758,1967 763,2289 767,1600 772,1423 776,2148 781,2174 785,1443 790,1570 794,2275 799,2000 803,1353 808,1763 812,2324 817,1797 821,1346 826,1967 830,2289 835,1600 839,1423 844,2148 848,2174 853,1443 857,1570 862,2275 866,2000 871,1353 875,1763 880,2324 884,1797 889,1346 893,1967 898,2289 902,1600 907,1423 911,2148 916,2174 920,1443 925,1570 929,2275 934,2000 938,1353 943,1763 947,2324 952,1797 956,1346 961,1967 965,2289 970,1600 974,1423 979,2148 983,2174 988,1443 992,1570 997,2275 1001,2000 1006,1353 1010,1763 1015,2324 1019,1797 1024,1346 1028,1967 1033,2289 1037,1600 1042,1423 1046,2148 1051,2174 1055,1443 1060,1570 1064,2275 1069,2000 1073,1353 1078,1763 1082,2324 1087,1797 1091,1346 1096,1967 1100,2289 1105,1600 1109,1423 1114,2148 1118,2174 1123,1443 1127,1570 1132,2275 1136,2000 1141,1353 1145,1763 1150,2324 1154,1797 1159,1346 1163,1967 1168,2289 1172,1600 1177,1423 1181,2148 1186,2174 1190,1443 1195,1570 1199,2275 1204,2000 1208,1353 1213,1763 1217,2324 1222,1797 1226,1346 1231,1967 1235,2289 1240,1600 1244,1423 1249,2148 1253,2174 1258,1443 1262,1570 1267,2275 1271,2000 1276,1353 1280,1763 1285,2324 1289,1797 1294,1346 1298,1967 1303,2289 1307,1600 1312,1423 1316,2148 1321,2174 1325,1443 1330,1570 1334,2275 1339,2000 1343,1353 1348,1763 1352,2324 1357,1797 1361,1346 1366,1967 1370,2289 1375,1600 1379,1423 1384,2148 1388,2174 1393,1443 1397,1570 1402,2275 1406,2000 1411,1353 1415,1763 1420,2324 1424,1797 1429,1346 1433,1967 1438,2289 1442,1600 1447,1423 1451,2148 1456,2174 1460,1443 1465,1570 1469,2275 1474,2000 1478,1353 1483,1763 1487,2324 1492,1797 1496,1346 1501,1967 1505,2289 1510,1600 1514,1423 1519,2148 1523,2174 1528,1443 1532,1570 1537,2275 1541,2000 1546,1353 1550,1763 1555,2324 1559,1797 1564,1346 1568,1967 1573,2289 1577,1600 1582,1423 1586,2148 1591,2174 1595,1443 1600,1570 1604,2275 1609,2000 1613,1353 1618,1763 1622,2324 1626,1797 1631,1346 1635,1967 1640,2289 1644,1600 1649,1423 1653,2148 1658,2174 1662,1443 1667,1570 1671,2275 1676,2000 1680,1353 1685,1763 1689,2324 1694,1797 1698,1346 1703,1967 1707,2289 1712,1600 1716,1423 1721,2148 1725,2174 1730,1443 1734,1570 1739,2275 1743,2000 1748,1353 1752,1763 1757,2324 1761,1797 1766,1346 1770,1967 1775,2289 1779,1600 1784,1423 1788,2148 1793,2174 1797,1443 1802,1570 1806,2275 1811,2000 1815,1353 1820,1763 1824,2324 1829,1797 1833,1346 1838,1967 1842,2289 1847,1600 1851,1423 1856,2148 1860,2174 1865,1443 1869,1570 1874,2275 1878,2000 1883,1353 1887,1763 1892,2324 1896,1797 1901,1346 1905,1967 1910,2289 1914,1600 1919,1423 1923,2148 1928,2174 1932,1443 1937,1570 1941,2275 1946,2000 1950,1353 1955,1763 1959,2324 1964,1797 1968,1346 1973,1967 1977,2289 1982,1600 1986,1423 1991,2148 1995,2174 2000,1443 2004,1570 2009,2275 2013,2000 2018,1353 2022,1763 2027,2324 2031,1797 2036,1346 2040,1967 2045,2289 2049,1600 2054,1423 2058,2148 2063,2174 2067,1443 2072,1570 2076,2275 2081,2000 2085,1353 2090,1763 2094,2324 2099,1797 2103,1346 2108,1967 2112,2289 2117,1600 2121,1423 2126,2148 2130,2174 2135,1443 2139,1570 2144,2275 2148,2000 2153,1353 2157,1763 2162,2324 2166,1797 2171,1346 2175,1967 2180,2289 2184,1600 2189,1423 2193,2148 2198,2174 2202,1443 2207,1570 2211,2275 2216,2000 2220,1353 2225,1763 2229,2324 2234,1797 2238,1346 2243,1967 2247,2289 2252,1600 2256,1423 2261,2148 2265,2174 2270,1443 2274,1570 2279,2275 2283,2000 2288,1353 2292,1763 2297,2324 2301,1797 2306,1346 2310,1967 2315,2289 2319,1600 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2273 241,2158 246,2276 250,2276 255,1955 259,2207 264,2276 268,2227 273,1832 277,2219 282,2235 286,2140 291,1832 295,2225 300,2176 304,1908 309,1832 313,2230 318,2276 322,1832 327,2027 331,2121 336,2088 340,1832 345,2129 349,2095 354,2018 358,1832 363,2172 367,2276 372,1832 376,1832 381,2194 385,2276 390,1832 394,1941 399,2276 403,2170 408,1832 412,2089 417,2276 421,1966 426,1832 430,2150 435,2276 439,1832 444,1832 448,2182 453,2276 457,1832 462,1915 466,2249 471,2163 475,1832 480,2080 484,2022 489,1957 493,1832 498,2148 502,2276 507,1832 511,1832 516,2183 520,2276 525,1832 529,1924 534,2031 538,2018 543,1832 547,2090 552,2039 556,1975 561,1832 565,2157 570,2037 574,1832 579,1832 583,2184 588,2025 592,1832 597,1955 601,2214 606,2177 610,1832 615,2110 619,2073 624,2006 628,1832 633,2174 637,2276 642,1832 646,1832 651,2201 655,2063 660,1832 664,1995 669,2180 673,2079 678,1832 682,2135 687,2114 691,2044 696,1832 700,2191 705,2115 709,1832 714,1832 718,2223 723,2276 727,1832 732,2038 736,2144 741,2117 745,1832 750,2161 754,2276 759,2082 763,1832 768,2211 772,2276 777,1897 781,1832 786,2231 790,2146 795,1832 799,2081 804,2185 808,2152 813,1832 817,2186 822,2198 826,2120 831,1832 835,2228 840,2197 844,1964 849,1846 853,2251 858,2276 862,1832 867,2121 871,2276 876,2232 880,1832 885,2209 889,2235 894,2154 898,1832 903,2245 907,2276 912,2025 916,1886 921,2257 925,2213 930,1832 934,2144 939,2276 943,2238 948,1832 952,2217 957,2276 961,2160 966,1832 970,2246 975,2276 979,2021 984,1879 988,2257 993,2209 997,1832 1002,2139 1006,2276 1011,2237 1015,1832 1020,2214 1024,2276 1029,2157 1033,1832 1038,2244 1042,2276 1047,2015 1051,1873 1056,2257 1060,2205 1065,1832 1069,2136 1074,2262 1078,2194 1083,1832 1087,2212 1092,2276 1096,2153 1101,1832 1105,2242 1110,2225 1114,2008 1119,1870 1123,2256 1128,2201 1132,1832 1137,2132 1141,2233 1146,2191 1150,1832 1155,2210 1159,2234 1164,2150 1168,1832 1173,2241 1177,2222 1182,2004 1186,1866 1191,2258 1195,2276 1200,1832 1204,2129 1209,2249 1213,2188 1218,1832 1222,2208 1227,2276 1231,2148 1236,1832 1240,2240 1245,2276 1249,1999 1254,1863 1258,2249 1263,2196 1267,1832 1272,2127 1276,2276 1281,2232 1285,1832 1290,2207 1294,2229 1299,2146 1303,1832 1308,2239 1312,2217 1317,1995 1321,1861 1326,2255 1330,2276 1335,1832 1339,2124 1344,2225 1348,2184 1353,1832 1357,2205 1362,2226 1366,2144 1371,1832 1375,2238 1380,2276 1384,1991 1389,1859 1393,2249 1398,2191 1402,1832 1407,2122 1411,2276 1416,2231 1420,1832 1425,2204 1429,2276 1434,2142 1438,1832 1443,2237 1447,2213 1452,1987 1456,1857 1461,2250 1465,2189 1470,1832 1474,2120 1479,2220 1483,2181 1488,1832 1492,2202 1497,2276 1501,2139 1506,1832 1510,2235 1515,2210 1519,1983 1524,1854 1528,2246 1533,2187 1537,1832 1542,2117 1546,2276 1551,2229 1555,1832 1560,2201 1564,2220 1569,2137 1573,1832 1578,2235 1582,2276 1587,1980 1591,1852 1596,2244 1600,2184 1605,1832 1609,2115 1614,2219 1618,2176 1623,1832 1627,2200 1632,2217 1636,2135 1641,1832 1645,2234 1650,2206 1654,1976 1659,1850 1663,2248 1668,2184 1672,1832 1677,2113 1681,2214 1686,2175 1690,1832 1695,2198 1699,2276 1704,2133 1708,1832 1713,2233 1717,2204 1722,1972 1726,1847 1731,2243 1735,2182 1740,1832 1744,2110 1749,2236 1753,2173 1758,1832 1762,2197 1767,2276 1771,2131 1776,1832 1780,2232 1785,2276 1789,1968 1794,1845 1798,2252 1803,2276 1807,1832 1812,2108 1816,2276 1821,2227 1825,1832 1830,2196 1834,2276 1839,2129 1843,1832 1848,2231 1852,2276 1857,1964 1861,1843 1866,2249 1870,2276 1875,1832 1879,2106 1884,2266 1888,2226 1893,1832 1897,2194 1902,2276 1906,2127 1911,1832 1915,2230 1920,2276 1924,1960 1929,1841 1933,2253 1938,2276 1942,1832 1947,2104 1951,2276 1956,2225 1960,1832 1965,2193 1969,2276 1974,2125 1978,1832 1983,2229 1987,2276 1992,1957 1996,1839 2001,2242 2005,2173 2010,1832 2014,2101 2019,2236 2023,2165 2028,1832 2032,2191 2037,2276 2041,2123 2046,1832 2050,2228 2055,2276 2059,1953 2064,1836 2068,2241 2073,2171 2077,1832 2082,2099 2086,2276 2091,2223 2095,1832 2100,2190 2104,2202 2109,2121 2113,1832 2118,2227 2122,2276 2127,1950 2131,1834 2136,2239 2140,2169 2145,1832 2149,2097 2154,2276 2158,2223 2163,1832 2167,2189 2172,2199 2176,2119 2181,1832 2185,2226 2190,2276 2194,1946 2199,1832 2203,2244 2208,2276 2212,1832 2217,2096 2221,2196 2226,2159 2230,1832 2235,2187 2239,2197 2244,2117 2248,1832 2253,2225 2257,2185 2262,1941 2266,1832 2271,2236 2275,2164 2280,1832 2284,2094 2289,2193 2293,2157 2298,1832 2302,2186 2307,2276 2311,2115 2316,1832 2320,2224 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_10% annual fee growth_0.000100.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_10% annual fee growth_0.000100.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+10% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,847 129,840 133,833 138,825 142,818 147,811 151,804 156,797 160,791 165,784 169,778 174,771 178,765 183,759 187,752 192,746 196,740 201,735 205,729 210,723 214,718 219,712 223,707 228,701 232,696 237,691 241,686 246,681 250,676 255,671 259,666 264,661 268,657 273,652 277,647 282,643 286,639 291,634 295,630 300,626 304,622 309,618 313,614 318,610 322,606 327,602 331,598 336,594 340,591 345,587 349,584 354,580 358,577 363,573 367,570 372,567 376,563 381,560 385,557 390,554 394,551 399,548 403,545 408,542 412,539 417,536 421,533 426,531 430,528 435,525 439,523 444,520 448,518 453,515 457,513 462,510 466,508 471,505 475,503 480,501 484,499 489,496 493,494 498,492 502,490 506,488 511,486 515,484 520,482 524,480 529,478 533,476 538,474 542,472 547,470 551,469 556,467 560,465 565,463 569,462 574,460 578,458 583,457 587,455 592,454 596,452 601,451 605,449 610,448 614,446 619,445 623,443 628,442 632,441 637,439 641,438 646,437 650,436 655,434 659,433 664,432 668,431 673,430 677,428 682,427 686,426 691,425 695,424 700,423 704,422 709,421 713,420 718,419 722,418 727,417 731,416 736,415 740,414 745,413 749,412 754,411 758,410 763,410 767,409 772,408 776,407 781,406 785,405 790,405 794,404 799,403 803,402 808,402 812,401 817,400 821,400 826,399 830,398 835,398 839,397 844,396 848,396 853,395 857,394 862,394 866,393 871,393 875,392 880,391 884,391 889,390 893,390 898,389 902,389 907,388 911,388 916,387 920,387 925,386 929,386 934,385 938,385 943,384 947,384 952,383 956,383 961,382 965,382 970,381 974,381 979,380 983,380 988,379 992,379 997,378 1001,378 1006,377 1010,377 1015,376 1019,376 1024,375 1028,375 1033,374 1037,374 1042,373 1046,373 1051,372 1055,372 1060,371 1064,371 1069,370 1073,370 1078,369 1082,369 1087,368 1091,368 1096,367 1100,367 1105,366 1109,366 1114,365 1118,365 1123,364 1127,364 1132,363 1136,363 1141,362 1145,362 1150,361 1154,361 1159,360 1163,360 1168,359 1172,359 1177,358 1181,358 1186,357 1190,357 1195,356 1199,356 1204,355 1208,355 1213,354 1217,354 1222,353 1226,353 1231,352 1235,352 1240,351 1244,351 1249,350 1253,350 1258,349 1262,349 1267,348 1271,348 1276,347 1280,347 1285,346 1289,346 1294,345 1298,345 1303,344 1307,344 1312,343 1316,343 1321,342 1325,341 1330,341 1334,340 1339,340 1343,339 1348,339 1352,338 1357,338 1361,337 1366,337 1370,336 1375,336 1379,335 1384,335 1388,334 1393,334 1397,333 1402,333 1406,332 1411,332 1415,331 1420,331 1424,330 1429,330 1433,329 1438,329 1442,328 1447,328 1451,327 1456,327 1460,326 1465,326 1469,325 1474,325 1478,324 1483,324 1487,323 1492,323 1496,322 1501,322 1505,321 1510,321 1514,320 1519,320 1523,319 1528,319 1532,318 1537,318 1541,317 1546,317 1550,316 1555,316 1559,315 1564,315 1568,314 1573,314 1577,313 1582,313 1586,312 1591,312 1595,311 1600,311 1604,310 1609,310 1613,309 1618,309 1622,308 1626,308 1631,307 1635,307 1640,306 1644,306 1649,305 1653,304 1658,304 1662,303 1667,303 1671,302 1676,302 1680,301 1685,301 1689,300 1694,300 1698,299 1703,299 1707,298 1712,298 1716,297 1721,297 1725,296 1730,296 1734,295 1739,295 1743,294 1748,294 1752,293 1757,293 1761,292 1766,292 1770,291 1775,291 1779,290 1784,290 1788,289 1793,289 1797,288 1802,288 1806,287 1811,287 1815,286 1820,286 1824,285 1829,285 1833,284 1838,284 1842,283 1847,283 1851,282 1856,282 1860,281 1865,281 1869,280 1874,280 1878,279 1883,279 1887,278 1892,278 1896,277 1901,277 1905,276 1910,276 1914,275 1919,275 1923,275 1928,274 1932,274 1937,273 1941,273 1946,272 1950,272 1955,271 1959,271 1964,270 1968,270 1973,269 1977,269 1982,268 1986,268 1991,267 1995,267 2000,266 2004,266 2009,265 2013,265 2018,264 2022,264 2027,263 2031,263 2036,262 2040,262 2045,261 2049,261 2054,260 2058,260 2063,259 2067,259 2072,258 2076,258 2081,258 2085,257 2090,257 2094,256 2099,256 2103,255 2108,255 2112,254 2117,254 2121,253 2126,253 2130,252 2135,252 2139,251 2144,251 2148,250 2153,250 2157,249 2162,249 2166,249 2171,248 2175,248 2180,247 2184,247 2189,246 2193,246 2198,245 2202,245 2207,244 2211,244 2216,243 2220,243 2225,242 2229,242 2234,242 2238,241 2243,241 2247,240 2252,240 2256,239 2261,239 2265,238 2270,238 2274,237 2279,237 2283,237 2288,236 2292,236 2297,235 2301,235 2306,234 2310,234 2315,233 2319,233 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2206" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2206 74,2206 "/>
+<text x="65" y="2088" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2088 74,2088 "/>
+<text x="65" y="1970" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1970 74,1970 "/>
+<text x="65" y="1852" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1852 74,1852 "/>
+<text x="65" y="1734" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1734 74,1734 "/>
+<text x="65" y="1616" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1616 74,1616 "/>
+<text x="65" y="1497" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1497 74,1497 "/>
+<text x="65" y="1379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1379 74,1379 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2277 151,2277 156,2276 160,2276 165,2276 169,2275 174,2275 178,2275 183,2275 187,2274 192,2274 196,2274 201,2273 205,2273 210,2273 214,2272 219,2272 223,2272 228,2271 232,2271 237,2271 241,2270 246,2270 250,2270 255,2269 259,2269 264,2269 268,2268 273,2268 277,2268 282,2267 286,2267 291,2266 295,2266 300,2266 304,2265 309,2265 313,2265 318,2264 322,2264 327,2263 331,2263 336,2263 340,2262 345,2262 349,2262 354,2261 358,2261 363,2260 367,2260 372,2260 376,2259 381,2259 385,2258 390,2258 394,2257 399,2257 403,2257 408,2256 412,2256 417,2255 421,2255 426,2254 430,2254 435,2254 439,2253 444,2253 448,2252 453,2252 457,2251 462,2251 466,2250 471,2250 475,2249 480,2249 484,2249 489,2248 493,2248 498,2247 502,2247 506,2246 511,2246 515,2245 520,2245 524,2244 529,2244 533,2243 538,2243 542,2242 547,2242 551,2241 556,2240 560,2240 565,2239 569,2239 574,2238 578,2238 583,2237 587,2237 592,2236 596,2236 601,2235 605,2234 610,2234 614,2233 619,2233 623,2232 628,2232 632,2231 637,2230 641,2230 646,2229 650,2229 655,2228 659,2227 664,2227 668,2226 673,2226 677,2225 682,2224 686,2224 691,2223 695,2222 700,2222 704,2221 709,2221 713,2220 718,2219 722,2219 727,2218 731,2217 736,2217 740,2216 745,2215 749,2214 754,2214 758,2213 763,2212 767,2212 772,2211 776,2210 781,2210 785,2209 790,2208 794,2207 799,2207 803,2206 808,2205 812,2204 817,2204 821,2203 826,2202 830,2201 835,2201 839,2200 844,2199 848,2198 853,2197 857,2197 862,2196 866,2195 871,2194 875,2193 880,2193 884,2192 889,2191 893,2190 898,2189 902,2188 907,2188 911,2187 916,2186 920,2185 925,2184 929,2183 934,2182 938,2181 943,2180 947,2180 952,2179 956,2178 961,2177 965,2176 970,2175 974,2174 979,2173 983,2172 988,2171 992,2170 997,2169 1001,2168 1006,2167 1010,2166 1015,2165 1019,2164 1024,2163 1028,2162 1033,2161 1037,2160 1042,2159 1046,2158 1051,2157 1055,2156 1060,2155 1064,2154 1069,2153 1073,2152 1078,2151 1082,2150 1087,2148 1091,2147 1096,2146 1100,2145 1105,2144 1109,2143 1114,2142 1118,2141 1123,2139 1127,2138 1132,2137 1136,2136 1141,2135 1145,2134 1150,2132 1154,2131 1159,2130 1163,2129 1168,2127 1172,2126 1177,2125 1181,2124 1186,2122 1190,2121 1195,2120 1199,2119 1204,2117 1208,2116 1213,2115 1217,2113 1222,2112 1226,2111 1231,2109 1235,2108 1240,2107 1244,2105 1249,2104 1253,2103 1258,2101 1262,2100 1267,2098 1271,2097 1276,2096 1280,2094 1285,2093 1289,2091 1294,2090 1298,2088 1303,2087 1307,2085 1312,2084 1316,2082 1321,2081 1325,2079 1330,2078 1334,2076 1339,2075 1343,2073 1348,2071 1352,2070 1357,2068 1361,2067 1366,2065 1370,2063 1375,2062 1379,2060 1384,2058 1388,2057 1393,2055 1397,2053 1402,2052 1406,2050 1411,2048 1415,2046 1420,2045 1424,2043 1429,2041 1433,2039 1438,2038 1442,2036 1447,2034 1451,2032 1456,2030 1460,2028 1465,2027 1469,2025 1474,2023 1478,2021 1483,2019 1487,2017 1492,2015 1496,2013 1501,2011 1505,2009 1510,2007 1514,2005 1519,2003 1523,2001 1528,1999 1532,1997 1537,1995 1541,1993 1546,1991 1550,1989 1555,1987 1559,1985 1564,1983 1568,1980 1573,1978 1577,1976 1582,1974 1586,1972 1591,1969 1595,1967 1600,1965 1604,1963 1609,1960 1613,1958 1618,1956 1622,1953 1626,1951 1631,1949 1635,1946 1640,1944 1644,1942 1649,1939 1653,1937 1658,1934 1662,1932 1667,1929 1671,1927 1676,1924 1680,1922 1685,1919 1689,1917 1694,1914 1698,1912 1703,1909 1707,1907 1712,1904 1716,1901 1721,1899 1725,1896 1730,1893 1734,1891 1739,1888 1743,1885 1748,1882 1752,1880 1757,1877 1761,1874 1766,1871 1770,1868 1775,1865 1779,1862 1784,1860 1788,1857 1793,1854 1797,1851 1802,1848 1806,1845 1811,1842 1815,1839 1820,1836 1824,1833 1829,1830 1833,1826 1838,1823 1842,1820 1847,1817 1851,1814 1856,1811 1860,1807 1865,1804 1869,1801 1874,1797 1878,1794 1883,1791 1887,1787 1892,1784 1896,1781 1901,1777 1905,1774 1910,1770 1914,1767 1919,1763 1923,1760 1928,1756 1932,1753 1937,1749 1941,1746 1946,1742 1950,1738 1955,1735 1959,1731 1964,1727 1968,1723 1973,1720 1977,1716 1982,1712 1986,1708 1991,1704 1995,1700 2000,1696 2004,1692 2009,1688 2013,1684 2018,1680 2022,1676 2027,1672 2031,1668 2036,1664 2040,1660 2045,1656 2049,1652 2054,1647 2058,1643 2063,1639 2067,1634 2072,1630 2076,1626 2081,1621 2085,1617 2090,1613 2094,1608 2099,1604 2103,1599 2108,1594 2112,1590 2117,1585 2121,1581 2126,1576 2130,1571 2135,1566 2139,1562 2144,1557 2148,1552 2153,1547 2157,1542 2162,1537 2166,1532 2171,1528 2175,1522 2180,1517 2184,1512 2189,1507 2193,1502 2198,1497 2202,1492 2207,1487 2211,1481 2216,1476 2220,1471 2225,1465 2229,1460 2234,1454 2238,1449 2243,1443 2247,1438 2252,1432 2256,1427 2261,1421 2265,1415 2270,1410 2274,1404 2279,1398 2283,1392 2288,1386 2292,1381 2297,1375 2301,1369 2306,1363 2310,1357 2315,1351 2319,1344 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2132 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_10% annual fee growth_0.000200.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_10% annual fee growth_0.000200.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+10% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,847 129,840 133,833 138,825 142,818 147,811 151,804 156,797 160,791 165,784 169,778 174,771 178,765 183,759 187,752 192,746 196,740 201,735 205,729 210,723 214,718 219,712 223,707 228,701 232,696 237,691 241,686 246,681 250,676 255,671 259,666 264,661 268,657 273,652 277,647 282,643 286,639 291,634 295,630 300,626 304,622 309,618 313,614 318,610 322,606 327,602 331,598 336,594 340,591 345,587 349,584 354,580 358,577 363,573 367,570 372,567 376,563 381,560 385,557 390,554 394,551 399,548 403,545 408,542 412,539 417,536 421,533 426,531 430,528 435,525 439,523 444,520 448,518 453,515 457,513 462,510 466,508 471,505 475,503 480,501 484,499 489,496 493,494 498,492 502,490 506,488 511,486 515,484 520,482 524,480 529,478 533,476 538,474 542,472 547,470 551,469 556,467 560,465 565,464 569,462 574,460 578,459 583,457 587,455 592,454 596,452 601,451 605,449 610,448 614,447 619,445 623,444 628,442 632,441 637,440 641,438 646,437 650,436 655,435 659,433 664,432 668,431 673,430 677,429 682,427 686,426 691,425 695,424 700,423 704,422 709,421 713,420 718,419 722,418 727,417 731,416 736,415 740,414 745,413 749,412 754,412 758,411 763,410 767,409 772,408 776,407 781,406 785,406 790,405 794,404 799,403 803,403 808,402 812,401 817,400 821,400 826,399 830,398 835,398 839,397 844,396 848,396 853,395 857,395 862,394 866,393 871,393 875,392 880,392 884,391 889,391 893,390 898,389 902,389 907,388 911,388 916,387 920,387 925,386 929,386 934,385 938,385 943,384 947,384 952,383 956,383 961,382 965,382 970,381 974,381 979,380 983,380 988,379 992,379 997,378 1001,378 1006,377 1010,377 1015,376 1019,376 1024,375 1028,375 1033,374 1037,374 1042,373 1046,373 1051,372 1055,372 1060,371 1064,371 1069,370 1073,370 1078,369 1082,369 1087,368 1091,368 1096,367 1100,367 1105,366 1109,366 1114,365 1118,365 1123,364 1127,364 1132,363 1136,363 1141,362 1145,362 1150,361 1154,361 1159,360 1163,360 1168,359 1172,359 1177,358 1181,358 1186,357 1190,357 1195,356 1199,356 1204,355 1208,355 1213,354 1217,354 1222,353 1226,353 1231,352 1235,352 1240,351 1244,351 1249,350 1253,350 1258,349 1262,349 1267,348 1271,348 1276,347 1280,347 1285,346 1289,346 1294,345 1298,345 1303,344 1307,344 1312,343 1316,343 1321,342 1325,342 1330,341 1334,341 1339,340 1343,340 1348,339 1352,339 1357,338 1361,338 1366,337 1370,337 1375,336 1379,336 1384,335 1388,335 1393,334 1397,334 1402,333 1406,333 1411,332 1415,332 1420,331 1424,331 1429,330 1433,330 1438,329 1442,329 1447,328 1451,328 1456,327 1460,327 1465,326 1469,326 1474,325 1478,324 1483,324 1487,323 1492,323 1496,322 1501,322 1505,321 1510,321 1514,320 1519,320 1523,319 1528,319 1532,318 1537,318 1541,317 1546,317 1550,316 1555,316 1559,315 1564,315 1568,314 1573,314 1577,313 1582,313 1586,312 1591,312 1595,311 1600,311 1604,310 1609,310 1613,309 1618,309 1622,308 1626,308 1631,307 1635,307 1640,306 1644,306 1649,305 1653,305 1658,304 1662,304 1667,303 1671,303 1676,302 1680,302 1685,301 1689,301 1694,300 1698,300 1703,299 1707,299 1712,298 1716,298 1721,297 1725,297 1730,296 1734,296 1739,295 1743,295 1748,294 1752,294 1757,293 1761,293 1766,292 1770,292 1775,291 1779,291 1784,290 1788,290 1793,289 1797,289 1802,288 1806,288 1811,287 1815,287 1820,286 1824,286 1829,285 1833,285 1838,284 1842,284 1847,283 1851,283 1856,282 1860,282 1865,281 1869,281 1874,280 1878,280 1883,279 1887,279 1892,278 1896,278 1901,277 1905,277 1910,276 1914,276 1919,275 1923,275 1928,274 1932,274 1937,273 1941,273 1946,272 1950,272 1955,271 1959,271 1964,270 1968,270 1973,269 1977,269 1982,268 1986,268 1991,267 1995,267 2000,266 2004,266 2009,265 2013,265 2018,265 2022,264 2027,264 2031,263 2036,263 2040,262 2045,262 2049,261 2054,261 2058,260 2063,260 2067,259 2072,259 2076,258 2081,258 2085,257 2090,257 2094,256 2099,256 2103,255 2108,255 2112,254 2117,254 2121,253 2126,253 2130,253 2135,252 2139,252 2144,251 2148,251 2153,250 2157,250 2162,249 2166,249 2171,248 2175,248 2180,247 2184,247 2189,246 2193,246 2198,245 2202,245 2207,245 2211,244 2216,244 2220,243 2225,243 2229,242 2234,242 2238,241 2243,241 2247,240 2252,240 2256,240 2261,239 2265,239 2270,238 2274,238 2279,237 2283,237 2288,236 2292,236 2297,235 2301,235 2306,235 2310,234 2315,234 2319,233 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2206" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2206 74,2206 "/>
+<text x="65" y="2088" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2088 74,2088 "/>
+<text x="65" y="1970" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1970 74,1970 "/>
+<text x="65" y="1852" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1852 74,1852 "/>
+<text x="65" y="1734" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1734 74,1734 "/>
+<text x="65" y="1616" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1616 74,1616 "/>
+<text x="65" y="1497" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1497 74,1497 "/>
+<text x="65" y="1379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1379 74,1379 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2277 151,2277 156,2276 160,2276 165,2276 169,2275 174,2275 178,2275 183,2275 187,2274 192,2274 196,2274 201,2273 205,2273 210,2273 214,2272 219,2272 223,2272 228,2271 232,2271 237,2271 241,2270 246,2270 250,2270 255,2269 259,2269 264,2269 268,2268 273,2268 277,2268 282,2267 286,2267 291,2266 295,2266 300,2266 304,2265 309,2265 313,2265 318,2264 322,2264 327,2263 331,2263 336,2263 340,2262 345,2262 349,2262 354,2261 358,2261 363,2260 367,2260 372,2260 376,2259 381,2259 385,2258 390,2258 394,2257 399,2257 403,2257 408,2256 412,2256 417,2255 421,2255 426,2254 430,2254 435,2254 439,2253 444,2253 448,2252 453,2252 457,2251 462,2251 466,2250 471,2250 475,2249 480,2249 484,2249 489,2248 493,2248 498,2247 502,2247 506,2246 511,2246 515,2245 520,2245 524,2244 529,2244 533,2243 538,2243 542,2242 547,2242 551,2241 556,2240 560,2240 565,2239 569,2239 574,2238 578,2238 583,2237 587,2237 592,2236 596,2236 601,2235 605,2234 610,2234 614,2233 619,2233 623,2232 628,2232 632,2231 637,2230 641,2230 646,2229 650,2229 655,2228 659,2227 664,2227 668,2226 673,2226 677,2225 682,2224 686,2224 691,2223 695,2222 700,2222 704,2221 709,2221 713,2220 718,2219 722,2219 727,2218 731,2217 736,2217 740,2216 745,2215 749,2214 754,2214 758,2213 763,2212 767,2212 772,2211 776,2210 781,2210 785,2209 790,2208 794,2207 799,2207 803,2206 808,2205 812,2204 817,2204 821,2203 826,2202 830,2201 835,2201 839,2200 844,2199 848,2198 853,2197 857,2197 862,2196 866,2195 871,2194 875,2193 880,2193 884,2192 889,2191 893,2190 898,2189 902,2188 907,2188 911,2187 916,2186 920,2185 925,2184 929,2183 934,2182 938,2181 943,2180 947,2180 952,2179 956,2178 961,2177 965,2176 970,2175 974,2174 979,2173 983,2172 988,2171 992,2170 997,2169 1001,2168 1006,2167 1010,2166 1015,2165 1019,2164 1024,2163 1028,2162 1033,2161 1037,2160 1042,2159 1046,2158 1051,2157 1055,2156 1060,2155 1064,2154 1069,2153 1073,2152 1078,2151 1082,2150 1087,2148 1091,2147 1096,2146 1100,2145 1105,2144 1109,2143 1114,2142 1118,2141 1123,2139 1127,2138 1132,2137 1136,2136 1141,2135 1145,2134 1150,2132 1154,2131 1159,2130 1163,2129 1168,2127 1172,2126 1177,2125 1181,2124 1186,2122 1190,2121 1195,2120 1199,2119 1204,2117 1208,2116 1213,2115 1217,2113 1222,2112 1226,2111 1231,2109 1235,2108 1240,2107 1244,2105 1249,2104 1253,2103 1258,2101 1262,2100 1267,2098 1271,2097 1276,2096 1280,2094 1285,2093 1289,2091 1294,2090 1298,2088 1303,2087 1307,2085 1312,2084 1316,2082 1321,2081 1325,2079 1330,2078 1334,2076 1339,2075 1343,2073 1348,2071 1352,2070 1357,2068 1361,2067 1366,2065 1370,2063 1375,2062 1379,2060 1384,2058 1388,2057 1393,2055 1397,2053 1402,2052 1406,2050 1411,2048 1415,2046 1420,2045 1424,2043 1429,2041 1433,2039 1438,2038 1442,2036 1447,2034 1451,2032 1456,2030 1460,2028 1465,2027 1469,2025 1474,2023 1478,2021 1483,2019 1487,2017 1492,2015 1496,2013 1501,2011 1505,2009 1510,2007 1514,2005 1519,2003 1523,2001 1528,1999 1532,1997 1537,1995 1541,1993 1546,1991 1550,1989 1555,1987 1559,1985 1564,1983 1568,1980 1573,1978 1577,1976 1582,1974 1586,1972 1591,1969 1595,1967 1600,1965 1604,1963 1609,1960 1613,1958 1618,1956 1622,1953 1626,1951 1631,1949 1635,1946 1640,1944 1644,1942 1649,1939 1653,1937 1658,1934 1662,1932 1667,1929 1671,1927 1676,1924 1680,1922 1685,1919 1689,1917 1694,1914 1698,1912 1703,1909 1707,1907 1712,1904 1716,1901 1721,1899 1725,1896 1730,1893 1734,1891 1739,1888 1743,1885 1748,1882 1752,1880 1757,1877 1761,1874 1766,1871 1770,1868 1775,1865 1779,1862 1784,1860 1788,1857 1793,1854 1797,1851 1802,1848 1806,1845 1811,1842 1815,1839 1820,1836 1824,1833 1829,1830 1833,1826 1838,1823 1842,1820 1847,1817 1851,1814 1856,1811 1860,1807 1865,1804 1869,1801 1874,1797 1878,1794 1883,1791 1887,1787 1892,1784 1896,1781 1901,1777 1905,1774 1910,1770 1914,1767 1919,1763 1923,1760 1928,1756 1932,1753 1937,1749 1941,1746 1946,1742 1950,1738 1955,1735 1959,1731 1964,1727 1968,1723 1973,1720 1977,1716 1982,1712 1986,1708 1991,1704 1995,1700 2000,1696 2004,1692 2009,1688 2013,1684 2018,1680 2022,1676 2027,1672 2031,1668 2036,1664 2040,1660 2045,1656 2049,1652 2054,1647 2058,1643 2063,1639 2067,1634 2072,1630 2076,1626 2081,1621 2085,1617 2090,1613 2094,1608 2099,1604 2103,1599 2108,1594 2112,1590 2117,1585 2121,1581 2126,1576 2130,1571 2135,1566 2139,1562 2144,1557 2148,1552 2153,1547 2157,1542 2162,1537 2166,1532 2171,1528 2175,1522 2180,1517 2184,1512 2189,1507 2193,1502 2198,1497 2202,1492 2207,1487 2211,1481 2216,1476 2220,1471 2225,1465 2229,1460 2234,1454 2238,1449 2243,1443 2247,1438 2252,1432 2256,1427 2261,1421 2265,1415 2270,1410 2274,1404 2279,1398 2283,1392 2288,1386 2292,1381 2297,1375 2301,1369 2306,1363 2310,1357 2315,1351 2319,1344 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2247 525,2011 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_10% annual fee growth_0.000300.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_10% annual fee growth_0.000300.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+10% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,847 129,840 133,833 138,825 142,818 147,811 151,804 156,797 160,791 165,784 169,778 174,771 178,765 183,759 187,752 192,746 196,740 201,735 205,729 210,723 214,718 219,712 223,707 228,701 232,696 237,691 241,686 246,681 250,676 255,671 259,666 264,661 268,657 273,652 277,647 282,643 286,639 291,634 295,630 300,626 304,622 309,618 313,614 318,610 322,606 327,602 331,598 336,594 340,591 345,587 349,584 354,580 358,577 363,573 367,570 372,567 376,563 381,560 385,557 390,554 394,551 399,548 403,545 408,542 412,539 417,536 421,533 426,531 430,528 435,525 439,523 444,520 448,518 453,515 457,513 462,510 466,508 471,506 475,503 480,501 484,499 489,497 493,494 498,492 502,490 506,488 511,486 515,484 520,482 524,480 529,478 533,476 538,474 542,473 547,471 551,469 556,467 560,466 565,464 569,462 574,461 578,459 583,457 587,456 592,454 596,453 601,451 605,450 610,448 614,447 619,445 623,444 628,443 632,441 637,440 641,439 646,437 650,436 655,435 659,434 664,432 668,431 673,430 677,429 682,428 686,427 691,426 695,424 700,423 704,422 709,421 713,420 718,419 722,418 727,417 731,416 736,415 740,415 745,414 749,413 754,412 758,411 763,410 767,409 772,408 776,408 781,407 785,406 790,405 794,404 799,404 803,403 808,402 812,402 817,401 821,400 826,399 830,399 835,398 839,397 844,397 848,396 853,396 857,395 862,394 866,394 871,393 875,393 880,392 884,391 889,391 893,390 898,390 902,389 907,389 911,388 916,388 920,387 925,387 929,386 934,386 938,385 943,385 947,384 952,384 956,383 961,383 965,382 970,382 974,381 979,381 983,380 988,380 992,379 997,379 1001,378 1006,378 1010,377 1015,377 1019,376 1024,376 1028,375 1033,375 1037,374 1042,374 1046,373 1051,373 1055,372 1060,372 1064,371 1069,371 1073,370 1078,370 1082,369 1087,369 1091,368 1096,368 1100,367 1105,367 1109,366 1114,366 1118,365 1123,365 1127,364 1132,364 1136,363 1141,363 1145,362 1150,362 1154,361 1159,361 1163,360 1168,360 1172,359 1177,359 1181,358 1186,358 1190,357 1195,357 1199,356 1204,356 1208,355 1213,355 1217,354 1222,354 1226,353 1231,353 1235,352 1240,352 1244,351 1249,351 1253,350 1258,350 1262,349 1267,349 1271,348 1276,348 1280,347 1285,347 1289,346 1294,346 1298,345 1303,345 1307,344 1312,344 1316,343 1321,343 1325,342 1330,342 1334,341 1339,341 1343,340 1348,340 1352,339 1357,338 1361,338 1366,337 1370,337 1375,336 1379,336 1384,335 1388,335 1393,334 1397,334 1402,333 1406,333 1411,332 1415,332 1420,331 1424,331 1429,330 1433,330 1438,329 1442,329 1447,328 1451,328 1456,327 1460,327 1465,326 1469,326 1474,325 1478,325 1483,324 1487,324 1492,323 1496,323 1501,322 1505,322 1510,321 1514,321 1519,320 1523,320 1528,319 1532,319 1537,318 1541,318 1546,317 1550,317 1555,316 1559,316 1564,315 1568,315 1573,314 1577,314 1582,313 1586,313 1591,312 1595,312 1600,311 1604,311 1609,310 1613,310 1618,309 1622,309 1626,308 1631,308 1635,307 1640,307 1644,306 1649,306 1653,305 1658,305 1662,304 1667,304 1671,303 1676,303 1680,302 1685,302 1689,301 1694,301 1698,300 1703,299 1707,299 1712,298 1716,298 1721,297 1725,297 1730,296 1734,296 1739,295 1743,295 1748,294 1752,294 1757,293 1761,293 1766,292 1770,292 1775,291 1779,291 1784,290 1788,290 1793,289 1797,289 1802,288 1806,288 1811,287 1815,287 1820,286 1824,286 1829,285 1833,285 1838,284 1842,284 1847,283 1851,283 1856,282 1860,282 1865,281 1869,281 1874,281 1878,280 1883,280 1887,279 1892,279 1896,278 1901,278 1905,277 1910,277 1914,276 1919,276 1923,275 1928,275 1932,274 1937,274 1941,273 1946,273 1950,272 1955,272 1959,271 1964,271 1968,270 1973,270 1977,269 1982,269 1986,268 1991,268 1995,267 2000,267 2004,266 2009,266 2013,265 2018,265 2022,264 2027,264 2031,263 2036,263 2040,262 2045,262 2049,261 2054,261 2058,260 2063,260 2067,259 2072,259 2076,259 2081,258 2085,258 2090,257 2094,257 2099,256 2103,256 2108,255 2112,255 2117,254 2121,254 2126,253 2130,253 2135,252 2139,252 2144,251 2148,251 2153,250 2157,250 2162,250 2166,249 2171,249 2175,248 2180,248 2184,247 2189,247 2193,246 2198,246 2202,245 2207,245 2211,244 2216,244 2220,243 2225,243 2229,243 2234,242 2238,242 2243,241 2247,241 2252,240 2256,240 2261,239 2265,239 2270,238 2274,238 2279,238 2283,237 2288,237 2292,236 2297,236 2301,235 2306,235 2310,234 2315,234 2319,234 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2206" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2206 74,2206 "/>
+<text x="65" y="2088" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2088 74,2088 "/>
+<text x="65" y="1970" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1970 74,1970 "/>
+<text x="65" y="1852" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1852 74,1852 "/>
+<text x="65" y="1734" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1734 74,1734 "/>
+<text x="65" y="1616" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1616 74,1616 "/>
+<text x="65" y="1497" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1497 74,1497 "/>
+<text x="65" y="1379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1379 74,1379 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2277 151,2277 156,2276 160,2276 165,2276 169,2275 174,2275 178,2275 183,2275 187,2274 192,2274 196,2274 201,2273 205,2273 210,2273 214,2272 219,2272 223,2272 228,2271 232,2271 237,2271 241,2270 246,2270 250,2270 255,2269 259,2269 264,2269 268,2268 273,2268 277,2268 282,2267 286,2267 291,2266 295,2266 300,2266 304,2265 309,2265 313,2265 318,2264 322,2264 327,2263 331,2263 336,2263 340,2262 345,2262 349,2262 354,2261 358,2261 363,2260 367,2260 372,2260 376,2259 381,2259 385,2258 390,2258 394,2257 399,2257 403,2257 408,2256 412,2256 417,2255 421,2255 426,2254 430,2254 435,2254 439,2253 444,2253 448,2252 453,2252 457,2251 462,2251 466,2250 471,2250 475,2249 480,2249 484,2249 489,2248 493,2248 498,2247 502,2247 506,2246 511,2246 515,2245 520,2245 524,2244 529,2244 533,2243 538,2243 542,2242 547,2242 551,2241 556,2240 560,2240 565,2239 569,2239 574,2238 578,2238 583,2237 587,2237 592,2236 596,2236 601,2235 605,2234 610,2234 614,2233 619,2233 623,2232 628,2232 632,2231 637,2230 641,2230 646,2229 650,2229 655,2228 659,2227 664,2227 668,2226 673,2226 677,2225 682,2224 686,2224 691,2223 695,2222 700,2222 704,2221 709,2221 713,2220 718,2219 722,2219 727,2218 731,2217 736,2217 740,2216 745,2215 749,2214 754,2214 758,2213 763,2212 767,2212 772,2211 776,2210 781,2210 785,2209 790,2208 794,2207 799,2207 803,2206 808,2205 812,2204 817,2204 821,2203 826,2202 830,2201 835,2201 839,2200 844,2199 848,2198 853,2197 857,2197 862,2196 866,2195 871,2194 875,2193 880,2193 884,2192 889,2191 893,2190 898,2189 902,2188 907,2188 911,2187 916,2186 920,2185 925,2184 929,2183 934,2182 938,2181 943,2180 947,2180 952,2179 956,2178 961,2177 965,2176 970,2175 974,2174 979,2173 983,2172 988,2171 992,2170 997,2169 1001,2168 1006,2167 1010,2166 1015,2165 1019,2164 1024,2163 1028,2162 1033,2161 1037,2160 1042,2159 1046,2158 1051,2157 1055,2156 1060,2155 1064,2154 1069,2153 1073,2152 1078,2151 1082,2150 1087,2148 1091,2147 1096,2146 1100,2145 1105,2144 1109,2143 1114,2142 1118,2141 1123,2139 1127,2138 1132,2137 1136,2136 1141,2135 1145,2134 1150,2132 1154,2131 1159,2130 1163,2129 1168,2127 1172,2126 1177,2125 1181,2124 1186,2122 1190,2121 1195,2120 1199,2119 1204,2117 1208,2116 1213,2115 1217,2113 1222,2112 1226,2111 1231,2109 1235,2108 1240,2107 1244,2105 1249,2104 1253,2103 1258,2101 1262,2100 1267,2098 1271,2097 1276,2096 1280,2094 1285,2093 1289,2091 1294,2090 1298,2088 1303,2087 1307,2085 1312,2084 1316,2082 1321,2081 1325,2079 1330,2078 1334,2076 1339,2075 1343,2073 1348,2071 1352,2070 1357,2068 1361,2067 1366,2065 1370,2063 1375,2062 1379,2060 1384,2058 1388,2057 1393,2055 1397,2053 1402,2052 1406,2050 1411,2048 1415,2046 1420,2045 1424,2043 1429,2041 1433,2039 1438,2038 1442,2036 1447,2034 1451,2032 1456,2030 1460,2028 1465,2027 1469,2025 1474,2023 1478,2021 1483,2019 1487,2017 1492,2015 1496,2013 1501,2011 1505,2009 1510,2007 1514,2005 1519,2003 1523,2001 1528,1999 1532,1997 1537,1995 1541,1993 1546,1991 1550,1989 1555,1987 1559,1985 1564,1983 1568,1980 1573,1978 1577,1976 1582,1974 1586,1972 1591,1969 1595,1967 1600,1965 1604,1963 1609,1960 1613,1958 1618,1956 1622,1953 1626,1951 1631,1949 1635,1946 1640,1944 1644,1942 1649,1939 1653,1937 1658,1934 1662,1932 1667,1929 1671,1927 1676,1924 1680,1922 1685,1919 1689,1917 1694,1914 1698,1912 1703,1909 1707,1907 1712,1904 1716,1901 1721,1899 1725,1896 1730,1893 1734,1891 1739,1888 1743,1885 1748,1882 1752,1880 1757,1877 1761,1874 1766,1871 1770,1868 1775,1865 1779,1862 1784,1860 1788,1857 1793,1854 1797,1851 1802,1848 1806,1845 1811,1842 1815,1839 1820,1836 1824,1833 1829,1830 1833,1826 1838,1823 1842,1820 1847,1817 1851,1814 1856,1811 1860,1807 1865,1804 1869,1801 1874,1797 1878,1794 1883,1791 1887,1787 1892,1784 1896,1781 1901,1777 1905,1774 1910,1770 1914,1767 1919,1763 1923,1760 1928,1756 1932,1753 1937,1749 1941,1746 1946,1742 1950,1738 1955,1735 1959,1731 1964,1727 1968,1723 1973,1720 1977,1716 1982,1712 1986,1708 1991,1704 1995,1700 2000,1696 2004,1692 2009,1688 2013,1684 2018,1680 2022,1676 2027,1672 2031,1668 2036,1664 2040,1660 2045,1656 2049,1652 2054,1647 2058,1643 2063,1639 2067,1634 2072,1630 2076,1626 2081,1621 2085,1617 2090,1613 2094,1608 2099,1604 2103,1599 2108,1594 2112,1590 2117,1585 2121,1581 2126,1576 2130,1571 2135,1566 2139,1562 2144,1557 2148,1552 2153,1547 2157,1542 2162,1537 2166,1532 2171,1528 2175,1522 2180,1517 2184,1512 2189,1507 2193,1502 2198,1497 2202,1492 2207,1487 2211,1481 2216,1476 2220,1471 2225,1465 2229,1460 2234,1454 2238,1449 2243,1443 2247,1438 2252,1432 2256,1427 2261,1421 2265,1415 2270,1410 2274,1404 2279,1398 2283,1392 2288,1386 2292,1381 2297,1375 2301,1369 2306,1363 2310,1357 2315,1351 2319,1344 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2257 426,2044 430,1832 435,1832 439,1832 444,1832 448,1832 453,1832 457,1832 462,1832 466,1832 471,1832 475,1832 480,1832 484,1832 489,1832 493,1832 498,1832 502,1832 507,1832 511,1832 516,1832 520,1832 525,1832 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_25% annual fee growth_0.000100.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_25% annual fee growth_0.000100.svg
@@ -1,0 +1,661 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+25% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,847 129,840 133,833 138,825 142,818 147,811 151,804 156,797 160,791 165,784 169,778 174,771 178,765 183,759 187,752 192,746 196,740 201,735 205,729 210,723 214,717 219,712 223,707 228,701 232,696 237,691 241,686 246,681 250,676 255,671 259,666 264,661 268,656 273,652 277,647 282,643 286,639 291,634 295,630 300,626 304,622 309,618 313,613 318,610 322,606 327,602 331,598 336,594 340,591 345,587 349,583 354,580 358,577 363,573 367,570 372,567 376,563 381,560 385,557 390,554 394,551 399,548 403,545 408,542 412,539 417,536 421,533 426,531 430,528 435,525 439,523 444,520 448,518 453,515 457,513 462,510 466,508 471,505 475,503 480,501 484,499 489,496 493,494 498,492 502,490 506,488 511,486 515,484 520,482 524,480 529,478 533,476 538,474 542,472 547,470 551,469 556,467 560,465 565,463 569,462 574,460 578,458 583,457 587,455 592,454 596,452 601,451 605,449 610,448 614,446 619,445 623,443 628,442 632,441 637,439 641,438 646,437 650,435 655,434 659,433 664,432 668,430 673,429 677,428 682,427 686,426 691,425 695,424 700,423 704,422 709,421 713,419 718,418 722,417 727,417 731,416 736,415 740,414 745,413 749,412 754,411 758,410 763,409 767,408 772,408 776,407 781,406 785,405 790,404 794,404 799,403 803,402 808,401 812,401 817,400 821,399 826,398 830,398 835,397 839,396 844,396 848,395 853,395 857,394 862,393 866,393 871,392 875,392 880,391 884,390 889,390 893,389 898,389 902,388 907,388 911,387 916,387 920,386 925,386 929,385 934,385 938,384 943,384 947,383 952,383 956,382 961,382 965,381 970,381 974,380 979,380 983,379 988,379 992,378 997,378 1001,377 1006,377 1010,376 1015,376 1019,375 1024,375 1028,375 1033,374 1037,374 1042,373 1046,373 1051,372 1055,372 1060,371 1064,371 1069,370 1073,370 1078,369 1082,369 1087,368 1091,368 1096,367 1100,367 1105,366 1109,366 1114,365 1118,365 1123,364 1127,364 1132,363 1136,363 1141,362 1145,362 1150,361 1154,361 1159,360 1163,360 1168,360 1172,359 1177,359 1181,358 1186,358 1190,357 1195,357 1199,356 1204,356 1208,355 1213,355 1217,354 1222,354 1226,353 1231,353 1235,352 1240,352 1244,352 1249,351 1253,351 1258,350 1262,350 1267,349 1271,349 1276,348 1280,348 1285,347 1289,347 1294,346 1298,346 1303,346 1307,345 1312,345 1316,344 1321,344 1325,343 1330,343 1334,342 1339,342 1343,342 1348,341 1352,341 1357,340 1361,340 1366,339 1370,339 1375,339 1379,338 1384,338 1388,337 1393,337 1397,336 1402,336 1406,336 1411,335 1415,335 1420,334 1424,334 1429,334 1433,333 1438,333 1442,332 1447,332 1451,332 1456,331 1460,331 1465,330 1469,330 1474,330 1478,329 1483,329 1487,328 1492,328 1496,328 1501,327 1505,327 1510,327 1514,326 1519,326 1523,326 1528,325 1532,325 1537,324 1541,324 1546,324 1550,323 1555,323 1559,323 1564,322 1568,322 1573,322 1577,321 1582,321 1586,321 1591,321 1595,320 1600,320 1604,320 1609,319 1613,319 1618,319 1622,318 1626,318 1631,318 1635,318 1640,317 1644,317 1649,317 1653,317 1658,316 1662,316 1667,316 1671,316 1676,315 1680,315 1685,315 1689,315 1694,314 1698,314 1703,314 1707,314 1712,314 1716,313 1721,313 1725,313 1730,313 1734,313 1739,313 1743,312 1748,312 1752,312 1757,312 1761,312 1766,312 1770,312 1775,312 1779,312 1784,311 1788,311 1793,311 1797,311 1802,311 1806,311 1811,311 1815,311 1820,311 1824,311 1829,311 1833,311 1838,311 1842,311 1847,311 1851,311 1856,311 1860,311 1865,311 1869,311 1874,311 1878,311 1883,311 1887,311 1892,312 1896,312 1901,312 1905,312 1910,312 1914,312 1919,312 1923,313 1928,313 1932,313 1937,313 1941,314 1946,314 1950,314 1955,314 1959,315 1964,315 1968,315 1973,315 1977,316 1982,316 1986,316 1991,317 1995,317 2000,318 2004,318 2009,319 2013,319 2018,319 2022,320 2027,320 2031,321 2036,321 2040,322 2045,323 2049,323 2054,324 2058,324 2063,325 2067,326 2072,326 2076,327 2081,328 2085,328 2090,329 2094,330 2099,331 2103,331 2108,332 2112,333 2117,334 2121,335 2126,336 2130,337 2135,338 2139,339 2144,340 2148,341 2153,342 2157,343 2162,344 2166,345 2171,346 2175,347 2180,348 2184,350 2189,351 2193,352 2198,353 2202,355 2207,356 2211,358 2216,359 2220,360 2225,362 2229,363 2234,365 2238,367 2243,368 2247,370 2252,371 2256,373 2261,375 2265,377 2270,378 2274,380 2279,382 2283,384 2288,386 2292,388 2297,390 2301,392 2306,394 2310,396 2315,399 2319,401 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2164" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2164 74,2164 "/>
+<text x="65" y="2003" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2003 74,2003 "/>
+<text x="65" y="1842" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1842 74,1842 "/>
+<text x="65" y="1682" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1682 74,1682 "/>
+<text x="65" y="1521" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1521 74,1521 "/>
+<text x="65" y="1360" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1360 74,1360 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2324 151,2324 156,2324 160,2324 165,2324 169,2324 174,2324 178,2324 183,2324 187,2324 192,2324 196,2324 201,2324 205,2324 210,2324 214,2323 219,2323 223,2323 228,2323 232,2323 237,2323 241,2323 246,2323 250,2323 255,2323 259,2323 264,2323 268,2323 273,2323 277,2323 282,2323 286,2323 291,2323 295,2323 300,2323 304,2323 309,2323 313,2323 318,2323 322,2323 327,2323 331,2323 336,2323 340,2323 345,2323 349,2323 354,2323 358,2323 363,2323 367,2323 372,2323 376,2323 381,2323 385,2323 390,2323 394,2323 399,2323 403,2323 408,2323 412,2323 417,2323 421,2323 426,2322 430,2322 435,2322 439,2322 444,2322 448,2322 453,2322 457,2322 462,2322 466,2322 471,2322 475,2322 480,2322 484,2322 489,2322 493,2322 498,2322 502,2322 506,2322 511,2322 515,2322 520,2322 524,2322 529,2322 533,2322 538,2322 542,2322 547,2321 551,2321 556,2321 560,2321 565,2321 569,2321 574,2321 578,2321 583,2321 587,2321 592,2321 596,2321 601,2321 605,2321 610,2321 614,2321 619,2321 623,2321 628,2321 632,2321 637,2320 641,2320 646,2320 650,2320 655,2320 659,2320 664,2320 668,2320 673,2320 677,2320 682,2320 686,2320 691,2320 695,2320 700,2320 704,2319 709,2319 713,2319 718,2319 722,2319 727,2319 731,2319 736,2319 740,2319 745,2319 749,2319 754,2319 758,2319 763,2318 767,2318 772,2318 776,2318 781,2318 785,2318 790,2318 794,2318 799,2318 803,2318 808,2317 812,2317 817,2317 821,2317 826,2317 830,2317 835,2317 839,2317 844,2317 848,2316 853,2316 857,2316 862,2316 866,2316 871,2316 875,2316 880,2316 884,2315 889,2315 893,2315 898,2315 902,2315 907,2315 911,2315 916,2315 920,2314 925,2314 929,2314 934,2314 938,2314 943,2314 947,2313 952,2313 956,2313 961,2313 965,2313 970,2313 974,2312 979,2312 983,2312 988,2312 992,2312 997,2311 1001,2311 1006,2311 1010,2311 1015,2311 1019,2310 1024,2310 1028,2310 1033,2310 1037,2310 1042,2309 1046,2309 1051,2309 1055,2309 1060,2309 1064,2308 1069,2308 1073,2308 1078,2308 1082,2307 1087,2307 1091,2307 1096,2307 1100,2306 1105,2306 1109,2306 1114,2305 1118,2305 1123,2305 1127,2305 1132,2304 1136,2304 1141,2304 1145,2303 1150,2303 1154,2303 1159,2302 1163,2302 1168,2302 1172,2301 1177,2301 1181,2301 1186,2300 1190,2300 1195,2300 1199,2299 1204,2299 1208,2299 1213,2298 1217,2298 1222,2297 1226,2297 1231,2297 1235,2296 1240,2296 1244,2295 1249,2295 1253,2294 1258,2294 1262,2294 1267,2293 1271,2293 1276,2292 1280,2292 1285,2291 1289,2291 1294,2290 1298,2290 1303,2289 1307,2289 1312,2288 1316,2288 1321,2287 1325,2287 1330,2286 1334,2285 1339,2285 1343,2284 1348,2284 1352,2283 1357,2282 1361,2282 1366,2281 1370,2281 1375,2280 1379,2279 1384,2279 1388,2278 1393,2277 1397,2276 1402,2276 1406,2275 1411,2274 1415,2274 1420,2273 1424,2272 1429,2271 1433,2270 1438,2270 1442,2269 1447,2268 1451,2267 1456,2266 1460,2266 1465,2265 1469,2264 1474,2263 1478,2262 1483,2261 1487,2260 1492,2259 1496,2258 1501,2257 1505,2256 1510,2255 1514,2254 1519,2253 1523,2252 1528,2251 1532,2250 1537,2249 1541,2248 1546,2247 1550,2245 1555,2244 1559,2243 1564,2242 1568,2241 1573,2239 1577,2238 1582,2237 1586,2236 1591,2234 1595,2233 1600,2232 1604,2230 1609,2229 1613,2227 1618,2226 1622,2224 1626,2223 1631,2222 1635,2220 1640,2218 1644,2217 1649,2215 1653,2214 1658,2212 1662,2210 1667,2209 1671,2207 1676,2205 1680,2203 1685,2202 1689,2200 1694,2198 1698,2196 1703,2194 1707,2192 1712,2190 1716,2188 1721,2186 1725,2184 1730,2182 1734,2180 1739,2178 1743,2176 1748,2174 1752,2171 1757,2169 1761,2167 1766,2165 1770,2162 1775,2160 1779,2157 1784,2155 1788,2152 1793,2150 1797,2147 1802,2145 1806,2142 1811,2139 1815,2137 1820,2134 1824,2131 1829,2128 1833,2125 1838,2122 1842,2119 1847,2116 1851,2113 1856,2110 1860,2107 1865,2104 1869,2100 1874,2097 1878,2094 1883,2090 1887,2087 1892,2083 1896,2080 1901,2076 1905,2072 1910,2069 1914,2065 1919,2061 1923,2057 1928,2053 1932,2049 1937,2045 1941,2041 1946,2037 1950,2033 1955,2028 1959,2024 1964,2019 1968,2015 1973,2010 1977,2006 1982,2001 1986,1996 1991,1991 1995,1986 2000,1981 2004,1976 2009,1971 2013,1966 2018,1961 2022,1955 2027,1950 2031,1944 2036,1939 2040,1933 2045,1927 2049,1921 2054,1915 2058,1909 2063,1903 2067,1897 2072,1891 2076,1884 2081,1878 2085,1871 2090,1864 2094,1858 2099,1851 2103,1844 2108,1837 2112,1829 2117,1822 2121,1815 2126,1807 2130,1800 2135,1792 2139,1784 2144,1776 2148,1768 2153,1760 2157,1751 2162,1743 2166,1734 2171,1725 2175,1717 2180,1708 2184,1698 2189,1689 2193,1680 2198,1670 2202,1661 2207,1651 2211,1641 2216,1631 2220,1620 2225,1610 2229,1600 2234,1589 2238,1578 2243,1567 2247,1556 2252,1544 2256,1533 2261,1521 2265,1509 2270,1497 2274,1485 2279,1473 2283,1460 2288,1447 2292,1434 2297,1421 2301,1408 2306,1394 2310,1380 2315,1366 2319,1352 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2274 597,2110 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_25% annual fee growth_0.000200.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_25% annual fee growth_0.000200.svg
@@ -1,0 +1,661 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+25% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,847 129,840 133,833 138,825 142,818 147,811 151,804 156,797 160,791 165,784 169,778 174,771 178,765 183,759 187,752 192,746 196,740 201,735 205,729 210,723 214,717 219,712 223,707 228,701 232,696 237,691 241,686 246,681 250,676 255,671 259,666 264,661 268,656 273,652 277,647 282,643 286,639 291,634 295,630 300,626 304,622 309,618 313,613 318,610 322,606 327,602 331,598 336,594 340,591 345,587 349,583 354,580 358,577 363,573 367,570 372,567 376,563 381,560 385,557 390,554 394,551 399,548 403,545 408,542 412,539 417,536 421,533 426,531 430,528 435,525 439,523 444,520 448,518 453,515 457,513 462,510 466,508 471,505 475,503 480,501 484,499 489,496 493,494 498,492 502,490 506,488 511,486 515,484 520,482 524,480 529,478 533,476 538,474 542,472 547,470 551,469 556,467 560,465 565,463 569,462 574,460 578,458 583,457 587,455 592,454 596,452 601,451 605,449 610,448 614,446 619,445 623,443 628,442 632,441 637,439 641,438 646,437 650,436 655,434 659,433 664,432 668,431 673,429 677,428 682,427 686,426 691,425 695,424 700,423 704,422 709,421 713,420 718,419 722,418 727,417 731,416 736,415 740,414 745,413 749,412 754,411 758,410 763,409 767,409 772,408 776,407 781,406 785,405 790,404 794,404 799,403 803,402 808,401 812,401 817,400 821,399 826,399 830,398 835,397 839,397 844,396 848,395 853,395 857,394 862,393 866,393 871,392 875,392 880,391 884,391 889,390 893,390 898,389 902,388 907,388 911,387 916,387 920,386 925,386 929,385 934,385 938,384 943,384 947,383 952,383 956,383 961,382 965,382 970,381 974,381 979,380 983,380 988,379 992,379 997,378 1001,378 1006,377 1010,377 1015,376 1019,376 1024,375 1028,375 1033,374 1037,374 1042,373 1046,373 1051,372 1055,372 1060,371 1064,371 1069,370 1073,370 1078,369 1082,369 1087,368 1091,368 1096,367 1100,367 1105,366 1109,366 1114,365 1118,365 1123,364 1127,364 1132,363 1136,363 1141,363 1145,362 1150,362 1154,361 1159,361 1163,360 1168,360 1172,359 1177,359 1181,358 1186,358 1190,357 1195,357 1199,356 1204,356 1208,355 1213,355 1217,354 1222,354 1226,354 1231,353 1235,353 1240,352 1244,352 1249,351 1253,351 1258,350 1262,350 1267,349 1271,349 1276,348 1280,348 1285,348 1289,347 1294,347 1298,346 1303,346 1307,345 1312,345 1316,344 1321,344 1325,343 1330,343 1334,343 1339,342 1343,342 1348,341 1352,341 1357,340 1361,340 1366,340 1370,339 1375,339 1379,338 1384,338 1388,337 1393,337 1397,337 1402,336 1406,336 1411,335 1415,335 1420,335 1424,334 1429,334 1433,333 1438,333 1442,332 1447,332 1451,332 1456,331 1460,331 1465,331 1469,330 1474,330 1478,329 1483,329 1487,329 1492,328 1496,328 1501,327 1505,327 1510,327 1514,326 1519,326 1523,326 1528,325 1532,325 1537,325 1541,324 1546,324 1550,324 1555,323 1559,323 1564,323 1568,322 1573,322 1577,322 1582,321 1586,321 1591,321 1595,320 1600,320 1604,320 1609,319 1613,319 1618,319 1622,319 1626,318 1631,318 1635,318 1640,317 1644,317 1649,317 1653,317 1658,316 1662,316 1667,316 1671,316 1676,315 1680,315 1685,315 1689,315 1694,315 1698,314 1703,314 1707,314 1712,314 1716,314 1721,313 1725,313 1730,313 1734,313 1739,313 1743,313 1748,312 1752,312 1757,312 1761,312 1766,312 1770,312 1775,312 1779,312 1784,312 1788,311 1793,311 1797,311 1802,311 1806,311 1811,311 1815,311 1820,311 1824,311 1829,311 1833,311 1838,311 1842,311 1847,311 1851,311 1856,311 1860,311 1865,311 1869,311 1874,311 1878,311 1883,312 1887,312 1892,312 1896,312 1901,312 1905,312 1910,312 1914,312 1919,313 1923,313 1928,313 1932,313 1937,313 1941,314 1946,314 1950,314 1955,314 1959,315 1964,315 1968,315 1973,316 1977,316 1982,316 1986,317 1991,317 1995,317 2000,318 2004,318 2009,319 2013,319 2018,320 2022,320 2027,321 2031,321 2036,322 2040,322 2045,323 2049,323 2054,324 2058,324 2063,325 2067,326 2072,326 2076,327 2081,328 2085,328 2090,329 2094,330 2099,331 2103,332 2108,332 2112,333 2117,334 2121,335 2126,336 2130,337 2135,338 2139,339 2144,340 2148,341 2153,342 2157,343 2162,344 2166,345 2171,346 2175,347 2180,349 2184,350 2189,351 2193,352 2198,354 2202,355 2207,356 2211,358 2216,359 2220,361 2225,362 2229,364 2234,365 2238,367 2243,368 2247,370 2252,372 2256,373 2261,375 2265,377 2270,379 2274,380 2279,382 2283,384 2288,386 2292,388 2297,390 2301,392 2306,394 2310,396 2315,397 2319,399 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2164" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2164 74,2164 "/>
+<text x="65" y="2003" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2003 74,2003 "/>
+<text x="65" y="1842" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1842 74,1842 "/>
+<text x="65" y="1682" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1682 74,1682 "/>
+<text x="65" y="1521" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1521 74,1521 "/>
+<text x="65" y="1360" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1360 74,1360 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2324 151,2324 156,2324 160,2324 165,2324 169,2324 174,2324 178,2324 183,2324 187,2324 192,2324 196,2324 201,2324 205,2324 210,2324 214,2323 219,2323 223,2323 228,2323 232,2323 237,2323 241,2323 246,2323 250,2323 255,2323 259,2323 264,2323 268,2323 273,2323 277,2323 282,2323 286,2323 291,2323 295,2323 300,2323 304,2323 309,2323 313,2323 318,2323 322,2323 327,2323 331,2323 336,2323 340,2323 345,2323 349,2323 354,2323 358,2323 363,2323 367,2323 372,2323 376,2323 381,2323 385,2323 390,2323 394,2323 399,2323 403,2323 408,2323 412,2323 417,2323 421,2323 426,2322 430,2322 435,2322 439,2322 444,2322 448,2322 453,2322 457,2322 462,2322 466,2322 471,2322 475,2322 480,2322 484,2322 489,2322 493,2322 498,2322 502,2322 506,2322 511,2322 515,2322 520,2322 524,2322 529,2322 533,2322 538,2322 542,2322 547,2321 551,2321 556,2321 560,2321 565,2321 569,2321 574,2321 578,2321 583,2321 587,2321 592,2321 596,2321 601,2321 605,2321 610,2321 614,2321 619,2321 623,2321 628,2321 632,2321 637,2320 641,2320 646,2320 650,2320 655,2320 659,2320 664,2320 668,2320 673,2320 677,2320 682,2320 686,2320 691,2320 695,2320 700,2320 704,2319 709,2319 713,2319 718,2319 722,2319 727,2319 731,2319 736,2319 740,2319 745,2319 749,2319 754,2319 758,2319 763,2318 767,2318 772,2318 776,2318 781,2318 785,2318 790,2318 794,2318 799,2318 803,2318 808,2317 812,2317 817,2317 821,2317 826,2317 830,2317 835,2317 839,2317 844,2317 848,2316 853,2316 857,2316 862,2316 866,2316 871,2316 875,2316 880,2316 884,2315 889,2315 893,2315 898,2315 902,2315 907,2315 911,2315 916,2315 920,2314 925,2314 929,2314 934,2314 938,2314 943,2314 947,2313 952,2313 956,2313 961,2313 965,2313 970,2313 974,2312 979,2312 983,2312 988,2312 992,2312 997,2311 1001,2311 1006,2311 1010,2311 1015,2311 1019,2310 1024,2310 1028,2310 1033,2310 1037,2310 1042,2309 1046,2309 1051,2309 1055,2309 1060,2309 1064,2308 1069,2308 1073,2308 1078,2308 1082,2307 1087,2307 1091,2307 1096,2307 1100,2306 1105,2306 1109,2306 1114,2305 1118,2305 1123,2305 1127,2305 1132,2304 1136,2304 1141,2304 1145,2303 1150,2303 1154,2303 1159,2302 1163,2302 1168,2302 1172,2301 1177,2301 1181,2301 1186,2300 1190,2300 1195,2300 1199,2299 1204,2299 1208,2299 1213,2298 1217,2298 1222,2297 1226,2297 1231,2297 1235,2296 1240,2296 1244,2295 1249,2295 1253,2294 1258,2294 1262,2294 1267,2293 1271,2293 1276,2292 1280,2292 1285,2291 1289,2291 1294,2290 1298,2290 1303,2289 1307,2289 1312,2288 1316,2288 1321,2287 1325,2287 1330,2286 1334,2285 1339,2285 1343,2284 1348,2284 1352,2283 1357,2282 1361,2282 1366,2281 1370,2281 1375,2280 1379,2279 1384,2279 1388,2278 1393,2277 1397,2276 1402,2276 1406,2275 1411,2274 1415,2274 1420,2273 1424,2272 1429,2271 1433,2270 1438,2270 1442,2269 1447,2268 1451,2267 1456,2266 1460,2266 1465,2265 1469,2264 1474,2263 1478,2262 1483,2261 1487,2260 1492,2259 1496,2258 1501,2257 1505,2256 1510,2255 1514,2254 1519,2253 1523,2252 1528,2251 1532,2250 1537,2249 1541,2248 1546,2247 1550,2245 1555,2244 1559,2243 1564,2242 1568,2241 1573,2239 1577,2238 1582,2237 1586,2236 1591,2234 1595,2233 1600,2232 1604,2230 1609,2229 1613,2227 1618,2226 1622,2224 1626,2223 1631,2222 1635,2220 1640,2218 1644,2217 1649,2215 1653,2214 1658,2212 1662,2210 1667,2209 1671,2207 1676,2205 1680,2203 1685,2202 1689,2200 1694,2198 1698,2196 1703,2194 1707,2192 1712,2190 1716,2188 1721,2186 1725,2184 1730,2182 1734,2180 1739,2178 1743,2176 1748,2174 1752,2171 1757,2169 1761,2167 1766,2165 1770,2162 1775,2160 1779,2157 1784,2155 1788,2152 1793,2150 1797,2147 1802,2145 1806,2142 1811,2139 1815,2137 1820,2134 1824,2131 1829,2128 1833,2125 1838,2122 1842,2119 1847,2116 1851,2113 1856,2110 1860,2107 1865,2104 1869,2100 1874,2097 1878,2094 1883,2090 1887,2087 1892,2083 1896,2080 1901,2076 1905,2072 1910,2069 1914,2065 1919,2061 1923,2057 1928,2053 1932,2049 1937,2045 1941,2041 1946,2037 1950,2033 1955,2028 1959,2024 1964,2019 1968,2015 1973,2010 1977,2006 1982,2001 1986,1996 1991,1991 1995,1986 2000,1981 2004,1976 2009,1971 2013,1966 2018,1961 2022,1955 2027,1950 2031,1944 2036,1939 2040,1933 2045,1927 2049,1921 2054,1915 2058,1909 2063,1903 2067,1897 2072,1891 2076,1884 2081,1878 2085,1871 2090,1864 2094,1858 2099,1851 2103,1844 2108,1837 2112,1829 2117,1822 2121,1815 2126,1807 2130,1800 2135,1792 2139,1784 2144,1776 2148,1768 2153,1760 2157,1751 2162,1743 2166,1734 2171,1725 2175,1717 2180,1708 2184,1698 2189,1689 2193,1680 2198,1670 2202,1661 2207,1651 2211,1641 2216,1631 2220,1620 2225,1610 2229,1600 2234,1589 2238,1578 2243,1567 2247,1556 2252,1544 2256,1533 2261,1521 2265,1509 2270,1497 2274,1485 2279,1473 2283,1460 2288,1447 2292,1434 2297,1421 2301,1408 2306,1394 2310,1380 2315,1366 2319,1352 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2238 525,1976 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1838 2298,1860 2302,1881 2307,1901 2311,1919 2316,1937 2320,1954 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_25% annual fee growth_0.000300.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_25% annual fee growth_0.000300.svg
@@ -1,0 +1,661 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+25% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,847 129,840 133,833 138,825 142,818 147,811 151,804 156,797 160,791 165,784 169,778 174,771 178,765 183,759 187,752 192,746 196,740 201,735 205,729 210,723 214,717 219,712 223,707 228,701 232,696 237,691 241,686 246,681 250,676 255,671 259,666 264,661 268,656 273,652 277,647 282,643 286,639 291,634 295,630 300,626 304,622 309,618 313,613 318,610 322,606 327,602 331,598 336,594 340,591 345,587 349,583 354,580 358,577 363,573 367,570 372,567 376,563 381,560 385,557 390,554 394,551 399,548 403,545 408,542 412,539 417,536 421,533 426,531 430,528 435,525 439,523 444,520 448,518 453,515 457,513 462,510 466,508 471,505 475,503 480,501 484,499 489,496 493,494 498,492 502,490 506,488 511,486 515,484 520,482 524,480 529,478 533,476 538,474 542,472 547,471 551,469 556,467 560,465 565,464 569,462 574,460 578,459 583,457 587,455 592,454 596,452 601,451 605,449 610,448 614,446 619,445 623,444 628,442 632,441 637,440 641,438 646,437 650,436 655,434 659,433 664,432 668,431 673,430 677,428 682,427 686,426 691,425 695,424 700,423 704,422 709,421 713,420 718,419 722,418 727,417 731,416 736,415 740,414 745,413 749,412 754,411 758,410 763,410 767,409 772,408 776,407 781,406 785,405 790,405 794,404 799,403 803,402 808,402 812,401 817,400 821,399 826,399 830,398 835,397 839,397 844,396 848,395 853,395 857,394 862,394 866,393 871,392 875,392 880,391 884,391 889,390 893,390 898,389 902,389 907,388 911,388 916,387 920,387 925,386 929,386 934,385 938,385 943,384 947,384 952,383 956,383 961,382 965,382 970,381 974,381 979,380 983,380 988,379 992,379 997,378 1001,378 1006,377 1010,377 1015,376 1019,376 1024,375 1028,375 1033,374 1037,374 1042,373 1046,373 1051,372 1055,372 1060,371 1064,371 1069,370 1073,370 1078,369 1082,369 1087,368 1091,368 1096,367 1100,367 1105,367 1109,366 1114,366 1118,365 1123,365 1127,364 1132,364 1136,363 1141,363 1145,362 1150,362 1154,361 1159,361 1163,360 1168,360 1172,359 1177,359 1181,358 1186,358 1190,357 1195,357 1199,356 1204,356 1208,356 1213,355 1217,355 1222,354 1226,354 1231,353 1235,353 1240,352 1244,352 1249,351 1253,351 1258,350 1262,350 1267,349 1271,349 1276,349 1280,348 1285,348 1289,347 1294,347 1298,346 1303,346 1307,345 1312,345 1316,345 1321,344 1325,344 1330,343 1334,343 1339,342 1343,342 1348,341 1352,341 1357,341 1361,340 1366,340 1370,339 1375,339 1379,338 1384,338 1388,338 1393,337 1397,337 1402,336 1406,336 1411,335 1415,335 1420,335 1424,334 1429,334 1433,333 1438,333 1442,333 1447,332 1451,332 1456,331 1460,331 1465,331 1469,330 1474,330 1478,329 1483,329 1487,329 1492,328 1496,328 1501,328 1505,327 1510,327 1514,327 1519,326 1523,326 1528,325 1532,325 1537,325 1541,324 1546,324 1550,324 1555,323 1559,323 1564,323 1568,322 1573,322 1577,322 1582,321 1586,321 1591,321 1595,320 1600,320 1604,320 1609,320 1613,319 1618,319 1622,319 1626,318 1631,318 1635,318 1640,318 1644,317 1649,317 1653,317 1658,317 1662,316 1667,316 1671,316 1676,316 1680,315 1685,315 1689,315 1694,315 1698,315 1703,314 1707,314 1712,314 1716,314 1721,314 1725,313 1730,313 1734,313 1739,313 1743,313 1748,313 1752,312 1757,312 1761,312 1766,312 1770,312 1775,312 1779,312 1784,312 1788,312 1793,312 1797,311 1802,311 1806,311 1811,311 1815,311 1820,311 1824,311 1829,311 1833,311 1838,311 1842,311 1847,311 1851,311 1856,311 1860,311 1865,311 1869,311 1874,311 1878,312 1883,312 1887,312 1892,312 1896,312 1901,312 1905,312 1910,312 1914,313 1919,313 1923,313 1928,313 1932,313 1937,314 1941,314 1946,314 1950,314 1955,315 1959,315 1964,315 1968,315 1973,316 1977,316 1982,316 1986,317 1991,317 1995,318 2000,318 2004,318 2009,319 2013,319 2018,320 2022,320 2027,321 2031,321 2036,322 2040,322 2045,323 2049,323 2054,324 2058,325 2063,325 2067,326 2072,327 2076,327 2081,328 2085,329 2090,329 2094,330 2099,331 2103,332 2108,332 2112,333 2117,334 2121,335 2126,336 2130,337 2135,338 2139,339 2144,340 2148,341 2153,342 2157,343 2162,344 2166,345 2171,346 2175,347 2180,349 2184,350 2189,351 2193,352 2198,354 2202,355 2207,356 2211,358 2216,359 2220,361 2225,362 2229,364 2234,365 2238,367 2243,368 2247,370 2252,372 2256,373 2261,375 2265,377 2270,378 2274,380 2279,382 2283,383 2288,384 2292,386 2297,387 2301,389 2306,390 2310,391 2315,392 2319,394 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2164" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2164 74,2164 "/>
+<text x="65" y="2003" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2003 74,2003 "/>
+<text x="65" y="1842" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1842 74,1842 "/>
+<text x="65" y="1682" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1682 74,1682 "/>
+<text x="65" y="1521" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1521 74,1521 "/>
+<text x="65" y="1360" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1360 74,1360 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2324 151,2324 156,2324 160,2324 165,2324 169,2324 174,2324 178,2324 183,2324 187,2324 192,2324 196,2324 201,2324 205,2324 210,2324 214,2323 219,2323 223,2323 228,2323 232,2323 237,2323 241,2323 246,2323 250,2323 255,2323 259,2323 264,2323 268,2323 273,2323 277,2323 282,2323 286,2323 291,2323 295,2323 300,2323 304,2323 309,2323 313,2323 318,2323 322,2323 327,2323 331,2323 336,2323 340,2323 345,2323 349,2323 354,2323 358,2323 363,2323 367,2323 372,2323 376,2323 381,2323 385,2323 390,2323 394,2323 399,2323 403,2323 408,2323 412,2323 417,2323 421,2323 426,2322 430,2322 435,2322 439,2322 444,2322 448,2322 453,2322 457,2322 462,2322 466,2322 471,2322 475,2322 480,2322 484,2322 489,2322 493,2322 498,2322 502,2322 506,2322 511,2322 515,2322 520,2322 524,2322 529,2322 533,2322 538,2322 542,2322 547,2321 551,2321 556,2321 560,2321 565,2321 569,2321 574,2321 578,2321 583,2321 587,2321 592,2321 596,2321 601,2321 605,2321 610,2321 614,2321 619,2321 623,2321 628,2321 632,2321 637,2320 641,2320 646,2320 650,2320 655,2320 659,2320 664,2320 668,2320 673,2320 677,2320 682,2320 686,2320 691,2320 695,2320 700,2320 704,2319 709,2319 713,2319 718,2319 722,2319 727,2319 731,2319 736,2319 740,2319 745,2319 749,2319 754,2319 758,2319 763,2318 767,2318 772,2318 776,2318 781,2318 785,2318 790,2318 794,2318 799,2318 803,2318 808,2317 812,2317 817,2317 821,2317 826,2317 830,2317 835,2317 839,2317 844,2317 848,2316 853,2316 857,2316 862,2316 866,2316 871,2316 875,2316 880,2316 884,2315 889,2315 893,2315 898,2315 902,2315 907,2315 911,2315 916,2315 920,2314 925,2314 929,2314 934,2314 938,2314 943,2314 947,2313 952,2313 956,2313 961,2313 965,2313 970,2313 974,2312 979,2312 983,2312 988,2312 992,2312 997,2311 1001,2311 1006,2311 1010,2311 1015,2311 1019,2310 1024,2310 1028,2310 1033,2310 1037,2310 1042,2309 1046,2309 1051,2309 1055,2309 1060,2309 1064,2308 1069,2308 1073,2308 1078,2308 1082,2307 1087,2307 1091,2307 1096,2307 1100,2306 1105,2306 1109,2306 1114,2305 1118,2305 1123,2305 1127,2305 1132,2304 1136,2304 1141,2304 1145,2303 1150,2303 1154,2303 1159,2302 1163,2302 1168,2302 1172,2301 1177,2301 1181,2301 1186,2300 1190,2300 1195,2300 1199,2299 1204,2299 1208,2299 1213,2298 1217,2298 1222,2297 1226,2297 1231,2297 1235,2296 1240,2296 1244,2295 1249,2295 1253,2294 1258,2294 1262,2294 1267,2293 1271,2293 1276,2292 1280,2292 1285,2291 1289,2291 1294,2290 1298,2290 1303,2289 1307,2289 1312,2288 1316,2288 1321,2287 1325,2287 1330,2286 1334,2285 1339,2285 1343,2284 1348,2284 1352,2283 1357,2282 1361,2282 1366,2281 1370,2281 1375,2280 1379,2279 1384,2279 1388,2278 1393,2277 1397,2276 1402,2276 1406,2275 1411,2274 1415,2274 1420,2273 1424,2272 1429,2271 1433,2270 1438,2270 1442,2269 1447,2268 1451,2267 1456,2266 1460,2266 1465,2265 1469,2264 1474,2263 1478,2262 1483,2261 1487,2260 1492,2259 1496,2258 1501,2257 1505,2256 1510,2255 1514,2254 1519,2253 1523,2252 1528,2251 1532,2250 1537,2249 1541,2248 1546,2247 1550,2245 1555,2244 1559,2243 1564,2242 1568,2241 1573,2239 1577,2238 1582,2237 1586,2236 1591,2234 1595,2233 1600,2232 1604,2230 1609,2229 1613,2227 1618,2226 1622,2224 1626,2223 1631,2222 1635,2220 1640,2218 1644,2217 1649,2215 1653,2214 1658,2212 1662,2210 1667,2209 1671,2207 1676,2205 1680,2203 1685,2202 1689,2200 1694,2198 1698,2196 1703,2194 1707,2192 1712,2190 1716,2188 1721,2186 1725,2184 1730,2182 1734,2180 1739,2178 1743,2176 1748,2174 1752,2171 1757,2169 1761,2167 1766,2165 1770,2162 1775,2160 1779,2157 1784,2155 1788,2152 1793,2150 1797,2147 1802,2145 1806,2142 1811,2139 1815,2137 1820,2134 1824,2131 1829,2128 1833,2125 1838,2122 1842,2119 1847,2116 1851,2113 1856,2110 1860,2107 1865,2104 1869,2100 1874,2097 1878,2094 1883,2090 1887,2087 1892,2083 1896,2080 1901,2076 1905,2072 1910,2069 1914,2065 1919,2061 1923,2057 1928,2053 1932,2049 1937,2045 1941,2041 1946,2037 1950,2033 1955,2028 1959,2024 1964,2019 1968,2015 1973,2010 1977,2006 1982,2001 1986,1996 1991,1991 1995,1986 2000,1981 2004,1976 2009,1971 2013,1966 2018,1961 2022,1955 2027,1950 2031,1944 2036,1939 2040,1933 2045,1927 2049,1921 2054,1915 2058,1909 2063,1903 2067,1897 2072,1891 2076,1884 2081,1878 2085,1871 2090,1864 2094,1858 2099,1851 2103,1844 2108,1837 2112,1829 2117,1822 2121,1815 2126,1807 2130,1800 2135,1792 2139,1784 2144,1776 2148,1768 2153,1760 2157,1751 2162,1743 2166,1734 2171,1725 2175,1717 2180,1708 2184,1698 2189,1689 2193,1680 2198,1670 2202,1661 2207,1651 2211,1641 2216,1631 2220,1620 2225,1610 2229,1600 2234,1589 2238,1578 2243,1567 2247,1556 2252,1544 2256,1533 2261,1521 2265,1509 2270,1497 2274,1485 2279,1473 2283,1460 2288,1447 2292,1434 2297,1421 2301,1408 2306,1394 2310,1380 2315,1366 2319,1352 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2249 426,2011 430,1832 435,1832 439,1832 444,1832 448,1832 453,1832 457,1832 462,1832 466,1832 471,1832 475,1832 480,1832 484,1832 489,1832 493,1832 498,1832 502,1832 507,1832 511,1832 516,1832 520,1832 525,1832 529,1832 534,1832 538,1832 543,1832 547,1832 552,1832 556,1832 561,1832 565,1832 570,1832 574,1832 579,1832 583,1832 588,1832 592,1832 597,1832 601,1832 606,1832 610,1832 615,1832 619,1832 624,1832 628,1832 633,1832 637,1832 642,1832 646,1832 651,1832 655,1832 660,1832 664,1832 669,1832 673,1832 678,1832 682,1832 687,1832 691,1832 696,1832 700,1832 705,1832 709,1832 714,1832 718,1832 723,1832 727,1832 732,1832 736,1832 741,1832 745,1832 750,1832 754,1832 759,1832 763,1832 768,1832 772,1832 777,1832 781,1832 786,1832 790,1832 795,1832 799,1832 804,1832 808,1832 813,1832 817,1832 822,1832 826,1832 831,1832 835,1832 840,1832 844,1832 849,1832 853,1832 858,1832 862,1832 867,1832 871,1832 876,1832 880,1832 885,1832 889,1832 894,1832 898,1832 903,1832 907,1832 912,1832 916,1832 921,1832 925,1832 930,1832 934,1832 939,1832 943,1832 948,1832 952,1832 957,1832 961,1832 966,1832 970,1832 975,1832 979,1832 984,1832 988,1832 993,1832 997,1832 1002,1832 1006,1832 1011,1832 1015,1832 1020,1832 1024,1832 1029,1832 1033,1832 1038,1832 1042,1832 1047,1832 1051,1832 1056,1832 1060,1832 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1847 2266,1863 2271,1879 2275,1894 2280,1909 2284,1923 2289,1935 2293,1948 2298,1961 2302,1973 2307,1984 2311,1996 2316,2007 2320,2017 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Slower growth, tapering fees_0.000100.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Slower growth, tapering fees_0.000100.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Slower growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,848 129,840 133,833 138,826 142,818 147,811 151,805 156,798 160,791 165,784 169,778 174,772 178,765 183,759 187,753 192,747 196,741 201,735 205,730 210,724 214,718 219,713 223,707 228,702 232,697 237,692 241,687 246,682 250,677 255,672 259,667 264,663 268,658 273,653 277,649 282,645 286,640 291,636 295,632 300,628 304,624 309,619 313,616 318,612 322,608 327,604 331,600 336,597 340,593 345,590 349,586 354,583 358,579 363,576 367,573 372,569 376,566 381,563 385,560 390,557 394,554 399,551 403,548 408,545 412,542 417,540 421,537 426,534 430,532 435,529 439,527 444,524 448,522 453,519 457,517 462,514 466,512 471,510 475,508 480,505 484,503 489,501 493,499 498,497 502,495 506,493 511,491 515,489 520,487 524,485 529,483 533,481 538,480 542,478 547,476 551,474 556,473 560,471 565,469 569,468 574,466 578,465 583,463 587,462 592,460 596,459 601,457 605,456 610,454 614,453 619,452 623,450 628,449 632,448 637,447 641,446 646,445 650,444 655,444 659,443 664,442 668,442 673,441 677,441 682,440 686,440 691,439 695,439 700,439 704,439 709,438 713,438 718,438 722,438 727,437 731,437 736,437 740,437 745,437 749,437 754,437 758,436 763,436 767,436 772,436 776,436 781,436 785,436 790,436 794,436 799,436 803,436 808,436 812,436 817,436 821,436 826,436 830,436 835,436 839,436 844,436 848,436 853,436 857,436 862,435 866,435 871,435 875,435 880,435 884,435 889,435 893,435 898,435 902,435 907,435 911,435 916,435 920,435 925,435 929,435 934,435 938,435 943,435 947,435 952,435 956,435 961,435 965,435 970,435 974,435 979,435 983,435 988,435 992,435 997,435 1001,435 1006,435 1010,435 1015,435 1019,435 1024,435 1028,435 1033,435 1037,435 1042,435 1046,435 1051,435 1055,435 1060,435 1064,435 1069,435 1073,435 1078,435 1082,435 1087,435 1091,435 1096,435 1100,435 1105,435 1109,435 1114,435 1118,435 1123,435 1127,435 1132,435 1136,435 1141,435 1145,435 1150,435 1154,435 1159,435 1163,435 1168,435 1172,435 1177,435 1181,435 1186,435 1190,435 1195,435 1199,435 1204,435 1208,435 1213,435 1217,435 1222,435 1226,435 1231,435 1235,435 1240,435 1244,435 1249,435 1253,435 1258,435 1262,435 1267,435 1271,435 1276,435 1280,435 1285,435 1289,435 1294,435 1298,435 1303,435 1307,435 1312,435 1316,435 1321,435 1325,435 1330,435 1334,435 1339,435 1343,435 1348,435 1352,435 1357,435 1361,435 1366,435 1370,435 1375,435 1379,435 1384,435 1388,435 1393,435 1397,435 1402,435 1406,435 1411,435 1415,435 1420,435 1424,435 1429,435 1433,435 1438,435 1442,435 1447,435 1451,435 1456,435 1460,435 1465,435 1469,435 1474,435 1478,435 1483,435 1487,435 1492,435 1496,435 1501,435 1505,435 1510,435 1514,435 1519,435 1523,435 1528,435 1532,435 1537,435 1541,435 1546,435 1550,435 1555,435 1559,435 1564,435 1568,435 1573,435 1577,435 1582,435 1586,435 1591,435 1595,435 1600,435 1604,435 1609,435 1613,435 1618,435 1622,435 1626,435 1631,435 1635,435 1640,435 1644,435 1649,435 1653,435 1658,435 1662,435 1667,435 1671,435 1676,435 1680,435 1685,435 1689,435 1694,435 1698,435 1703,435 1707,435 1712,435 1716,435 1721,435 1725,435 1730,435 1734,435 1739,435 1743,435 1748,435 1752,435 1757,435 1761,435 1766,435 1770,435 1775,435 1779,435 1784,435 1788,435 1793,435 1797,435 1802,435 1806,435 1811,435 1815,435 1820,435 1824,435 1829,435 1833,435 1838,435 1842,435 1847,435 1851,435 1856,435 1860,435 1865,435 1869,435 1874,435 1878,435 1883,435 1887,435 1892,435 1896,435 1901,435 1905,435 1910,435 1914,435 1919,435 1923,435 1928,435 1932,435 1937,435 1941,435 1946,435 1950,435 1955,435 1959,435 1964,435 1968,435 1973,435 1977,435 1982,435 1986,435 1991,435 1995,435 2000,435 2004,435 2009,435 2013,435 2018,435 2022,435 2027,435 2031,435 2036,435 2040,435 2045,435 2049,435 2054,435 2058,435 2063,435 2067,435 2072,435 2076,435 2081,435 2085,435 2090,435 2094,435 2099,435 2103,435 2108,435 2112,435 2117,435 2121,435 2126,435 2130,435 2135,435 2139,435 2144,435 2148,435 2153,435 2157,435 2162,435 2166,435 2171,435 2175,435 2180,435 2184,435 2189,435 2193,435 2198,435 2202,435 2207,435 2211,435 2216,435 2220,435 2225,435 2229,435 2234,435 2238,435 2243,435 2247,435 2252,435 2256,435 2261,435 2265,435 2270,435 2274,435 2279,435 2283,435 2288,435 2292,435 2297,435 2301,435 2306,435 2310,435 2315,435 2319,435 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2208" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2208 74,2208 "/>
+<text x="65" y="2092" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2092 74,2092 "/>
+<text x="65" y="1975" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1975 74,1975 "/>
+<text x="65" y="1859" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1859 74,1859 "/>
+<text x="65" y="1743" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1743 74,1743 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1510" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1510 74,1510 "/>
+<text x="65" y="1394" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1394 74,1394 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2207 115,2201 120,2195 124,2190 129,2184 133,2178 138,2173 142,2167 147,2162 151,2157 156,2151 160,2146 165,2141 169,2136 174,2131 178,2127 183,2122 187,2117 192,2113 196,2109 201,2105 205,2101 210,2097 214,2093 219,2089 223,2086 228,2082 232,2079 237,2075 241,2072 246,2069 250,2066 255,2063 259,2060 264,2057 268,2055 273,2052 277,2050 282,2047 286,2045 291,2042 295,2040 300,2038 304,2035 309,2033 313,2031 318,2029 322,2027 327,2025 331,2023 336,2021 340,2019 345,2017 349,2015 354,2013 358,2011 363,2009 367,2008 372,2006 376,2004 381,2002 385,2001 390,1999 394,1997 399,1996 403,1994 408,1992 412,1990 417,1989 421,1987 426,1986 430,1984 435,1982 439,1981 444,1979 448,1977 453,1976 457,1974 462,1973 466,1971 471,1970 475,1968 480,1966 484,1965 489,1963 493,1962 498,1960 502,1959 506,1957 511,1955 515,1954 520,1952 524,1951 529,1949 533,1948 538,1946 542,1945 547,1943 551,1941 556,1940 560,1938 565,1937 569,1935 574,1934 578,1932 583,1931 587,1929 592,1928 596,1926 601,1925 605,1923 610,1921 614,1920 619,1918 623,1917 628,1915 632,1914 637,1912 641,1911 646,1909 650,1908 655,1906 659,1905 664,1903 668,1901 673,1900 677,1898 682,1897 686,1895 691,1894 695,1892 700,1891 704,1889 709,1888 713,1886 718,1885 722,1883 727,1882 731,1880 736,1879 740,1877 745,1875 749,1874 754,1872 758,1871 763,1869 767,1868 772,1866 776,1865 781,1863 785,1862 790,1860 794,1859 799,1857 803,1856 808,1854 812,1853 817,1851 821,1849 826,1848 830,1846 835,1845 839,1843 844,1842 848,1840 853,1839 857,1837 862,1836 866,1834 871,1833 875,1831 880,1830 884,1828 889,1826 893,1825 898,1823 902,1822 907,1820 911,1819 916,1817 920,1816 925,1814 929,1813 934,1811 938,1810 943,1808 947,1807 952,1805 956,1804 961,1802 965,1800 970,1799 974,1797 979,1796 983,1794 988,1793 992,1791 997,1790 1001,1788 1006,1787 1010,1785 1015,1784 1019,1782 1024,1781 1028,1779 1033,1778 1037,1776 1042,1774 1046,1773 1051,1771 1055,1770 1060,1768 1064,1767 1069,1765 1073,1764 1078,1762 1082,1761 1087,1759 1091,1758 1096,1756 1100,1755 1105,1753 1109,1752 1114,1750 1118,1748 1123,1747 1127,1745 1132,1744 1136,1742 1141,1741 1145,1739 1150,1738 1154,1736 1159,1735 1163,1733 1168,1732 1172,1730 1177,1729 1181,1727 1186,1726 1190,1724 1195,1722 1199,1721 1204,1719 1208,1718 1213,1716 1217,1715 1222,1713 1226,1712 1231,1710 1235,1709 1240,1707 1244,1706 1249,1704 1253,1703 1258,1701 1262,1700 1267,1698 1271,1696 1276,1695 1280,1693 1285,1692 1289,1690 1294,1689 1298,1687 1303,1686 1307,1684 1312,1683 1316,1681 1321,1680 1325,1678 1330,1677 1334,1675 1339,1673 1343,1672 1348,1670 1352,1669 1357,1667 1361,1666 1366,1664 1370,1663 1375,1661 1379,1660 1384,1658 1388,1657 1393,1655 1397,1654 1402,1652 1406,1651 1411,1649 1415,1647 1420,1646 1424,1644 1429,1643 1433,1641 1438,1640 1442,1638 1447,1637 1451,1635 1456,1634 1460,1632 1465,1631 1469,1629 1474,1628 1478,1626 1483,1625 1487,1623 1492,1621 1496,1620 1501,1618 1505,1617 1510,1615 1514,1614 1519,1612 1523,1611 1528,1609 1532,1608 1537,1606 1541,1605 1546,1603 1550,1602 1555,1600 1559,1599 1564,1597 1568,1595 1573,1594 1577,1592 1582,1591 1586,1589 1591,1588 1595,1586 1600,1585 1604,1583 1609,1582 1613,1580 1618,1579 1622,1577 1626,1576 1631,1574 1635,1573 1640,1571 1644,1569 1649,1568 1653,1566 1658,1565 1662,1563 1667,1562 1671,1560 1676,1559 1680,1557 1685,1556 1689,1554 1694,1553 1698,1551 1703,1550 1707,1548 1712,1547 1716,1545 1721,1543 1725,1542 1730,1540 1734,1539 1739,1537 1743,1536 1748,1534 1752,1533 1757,1531 1761,1530 1766,1528 1770,1527 1775,1525 1779,1524 1784,1522 1788,1521 1793,1519 1797,1517 1802,1516 1806,1514 1811,1513 1815,1511 1820,1510 1824,1508 1829,1507 1833,1505 1838,1504 1842,1502 1847,1501 1851,1499 1856,1498 1860,1496 1865,1494 1869,1493 1874,1491 1878,1490 1883,1488 1887,1487 1892,1485 1896,1484 1901,1482 1905,1481 1910,1479 1914,1478 1919,1476 1923,1475 1928,1473 1932,1472 1937,1470 1941,1468 1946,1467 1950,1465 1955,1464 1959,1462 1964,1461 1968,1459 1973,1458 1977,1456 1982,1455 1986,1453 1991,1452 1995,1450 2000,1449 2004,1447 2009,1446 2013,1444 2018,1442 2022,1441 2027,1439 2031,1438 2036,1436 2040,1435 2045,1433 2049,1432 2054,1430 2058,1429 2063,1427 2067,1426 2072,1424 2076,1423 2081,1421 2085,1420 2090,1418 2094,1416 2099,1415 2103,1413 2108,1412 2112,1410 2117,1409 2121,1407 2126,1406 2130,1404 2135,1403 2139,1401 2144,1400 2148,1398 2153,1397 2157,1395 2162,1394 2166,1392 2171,1390 2175,1389 2180,1387 2184,1386 2189,1384 2193,1383 2198,1381 2202,1380 2207,1378 2211,1377 2216,1375 2220,1374 2225,1372 2229,1371 2234,1369 2238,1368 2243,1366 2247,1364 2252,1363 2256,1361 2261,1360 2265,1358 2270,1357 2274,1355 2279,1354 2283,1352 2288,1351 2292,1349 2297,1348 2301,1346 2306,1345 2310,1343 2315,1341 2319,1340 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2256 628,2208 633,2164 637,2125 642,2090 646,2059 651,2032 655,2008 660,1987 664,1969 669,1953 673,1939 678,1927 682,1918 687,1909 691,1903 696,1897 700,1893 705,1891 709,1889 714,1887 718,1887 723,1887 727,1889 732,1890 736,1892 741,1895 745,1898 750,1901 754,1905 759,1909 763,1913 768,1917 772,1922 777,1927 781,1932 786,1937 790,1942 795,1947 799,1952 804,1957 808,1963 813,1968 817,1973 822,1979 826,1984 831,1989 835,1995 840,2000 844,2005 849,2010 853,2015 858,2021 862,2026 867,2030 871,2035 876,2041 880,2045 885,2050 889,2055 894,2060 898,2064 903,2068 907,2072 912,2077 916,2080 921,2080 925,2081 930,2081 934,2081 939,2082 943,2083 948,2083 952,2084 957,2085 961,2086 966,2086 970,2087 975,2088 979,2087 984,2085 988,2085 993,2086 997,2087 1002,2087 1006,2088 1011,2089 1015,2090 1020,2091 1024,2091 1029,2092 1033,2092 1038,2093 1042,2093 1047,2094 1051,2094 1056,2093 1060,2094 1065,2095 1069,2095 1074,2096 1078,2097 1083,2097 1087,2098 1092,2098 1096,2099 1101,2099 1105,2100 1110,2101 1114,2101 1119,2102 1123,2100 1128,2100 1132,2101 1137,2102 1141,2103 1146,2103 1150,2104 1155,2104 1159,2105 1164,2106 1168,2106 1173,2107 1177,2107 1182,2108 1186,2108 1191,2107 1195,2107 1200,2107 1204,2108 1209,2108 1213,2109 1218,2110 1222,2110 1227,2111 1231,2112 1236,2112 1240,2113 1245,2114 1249,2113 1254,2115 1258,2113 1263,2113 1267,2113 1272,2114 1276,2114 1281,2115 1285,2115 1290,2116 1294,2116 1299,2117 1303,2117 1308,2118 1312,2119 1317,2119 1321,2120 1326,2119 1330,2118 1335,2119 1339,2119 1344,2120 1348,2120 1353,2121 1357,2122 1362,2122 1366,2123 1371,2123 1375,2124 1380,2124 1384,2124 1389,2124 1393,2125 1398,2124 1402,2124 1407,2124 1411,2125 1416,2125 1420,2126 1425,2126 1429,2127 1434,2127 1438,2128 1443,2128 1447,2129 1452,2129 1456,2130 1461,2130 1465,2129 1470,2129 1474,2129 1479,2130 1483,2130 1488,2131 1492,2131 1497,2132 1501,2132 1506,2132 1510,2132 1515,2133 1519,2133 1524,2134 1528,2134 1533,2133 1537,2133 1542,2133 1546,2134 1551,2134 1555,2135 1560,2135 1564,2136 1569,2136 1573,2136 1578,2137 1582,2137 1587,2138 1591,2138 1596,2138 1600,2138 1605,2137 1609,2137 1614,2138 1618,2138 1623,2139 1627,2139 1632,2139 1636,2140 1641,2140 1645,2141 1650,2141 1654,2141 1659,2142 1663,2142 1668,2143 1672,2141 1677,2141 1681,2142 1686,2142 1690,2143 1695,2143 1699,2143 1704,2143 1708,2144 1713,2145 1717,2145 1722,2146 1726,2145 1731,2146 1735,2146 1740,2145 1744,2145 1749,2145 1753,2146 1758,2146 1762,2146 1767,2147 1771,2147 1776,2148 1780,2148 1785,2149 1789,2148 1794,2149 1798,2149 1803,2150 1807,2148 1812,2148 1816,2149 1821,2150 1825,2149 1830,2150 1834,2150 1839,2151 1843,2151 1848,2151 1852,2151 1857,2152 1861,2152 1866,2153 1870,2153 1875,2152 1879,2151 1884,2152 1888,2152 1893,2152 1897,2153 1902,2153 1906,2154 1911,2154 1915,2154 1920,2154 1924,2155 1929,2155 1933,2155 1938,2156 1942,2156 1947,2154 1951,2155 1956,2155 1960,2155 1965,2156 1969,2156 1974,2156 1978,2156 1983,2157 1987,2157 1992,2157 1996,2158 2001,2158 2005,2159 2010,2159 2014,2157 2019,2157 2023,2158 2028,2158 2032,2158 2037,2159 2041,2159 2046,2159 2050,2159 2055,2160 2059,2160 2064,2161 2068,2161 2073,2161 2077,2161 2082,2160 2086,2160 2091,2160 2095,2161 2100,2161 2104,2161 2109,2161 2113,2162 2118,2162 2122,2162 2127,2163 2131,2163 2136,2163 2140,2163 2145,2164 2149,2163 2154,2163 2158,2163 2163,2164 2167,2163 2172,2164 2176,2164 2181,2164 2185,2164 2190,2165 2194,2165 2199,2165 2203,2166 2208,2166 2212,2166 2217,2166 2221,2165 2226,2165 2230,2166 2235,2166 2239,2166 2244,2166 2248,2166 2253,2167 2257,2167 2262,2167 2266,2167 2271,2168 2275,2168 2280,2168 2284,2169 2289,2167 2293,2167 2298,2168 2302,2168 2307,2168 2311,2169 2316,2169 2320,2169 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Slower growth, tapering fees_0.000200.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Slower growth, tapering fees_0.000200.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Slower growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,848 129,840 133,833 138,826 142,818 147,811 151,805 156,798 160,791 165,784 169,778 174,772 178,765 183,759 187,753 192,747 196,741 201,735 205,730 210,724 214,718 219,713 223,707 228,702 232,697 237,692 241,687 246,682 250,677 255,672 259,667 264,663 268,658 273,653 277,649 282,645 286,640 291,636 295,632 300,628 304,624 309,619 313,616 318,612 322,608 327,604 331,600 336,597 340,593 345,590 349,586 354,583 358,579 363,576 367,573 372,569 376,566 381,563 385,560 390,557 394,554 399,551 403,548 408,545 412,542 417,540 421,537 426,534 430,532 435,529 439,527 444,524 448,522 453,519 457,517 462,514 466,512 471,510 475,508 480,505 484,503 489,501 493,499 498,497 502,495 506,493 511,491 515,489 520,487 524,485 529,483 533,481 538,480 542,478 547,476 551,474 556,473 560,471 565,470 569,468 574,467 578,466 583,464 587,463 592,462 596,461 601,460 605,459 610,458 614,457 619,456 623,455 628,454 632,454 637,453 641,452 646,451 650,451 655,450 659,449 664,449 668,448 673,448 677,447 682,447 686,446 691,446 695,445 700,445 704,445 709,444 713,444 718,444 722,443 727,443 731,443 736,442 740,442 745,442 749,441 754,441 758,441 763,441 767,440 772,440 776,440 781,440 785,440 790,439 794,439 799,439 803,439 808,439 812,439 817,439 821,438 826,438 830,438 835,438 839,438 844,438 848,438 853,438 857,438 862,437 866,437 871,437 875,437 880,437 884,437 889,437 893,437 898,437 902,437 907,437 911,437 916,437 920,437 925,436 929,436 934,436 938,436 943,436 947,436 952,436 956,436 961,436 965,436 970,436 974,436 979,436 983,436 988,436 992,436 997,436 1001,436 1006,436 1010,436 1015,436 1019,436 1024,436 1028,436 1033,436 1037,436 1042,436 1046,436 1051,436 1055,436 1060,436 1064,436 1069,436 1073,436 1078,436 1082,436 1087,436 1091,436 1096,436 1100,436 1105,436 1109,436 1114,436 1118,435 1123,435 1127,435 1132,435 1136,435 1141,435 1145,435 1150,435 1154,435 1159,435 1163,435 1168,435 1172,435 1177,435 1181,435 1186,435 1190,435 1195,435 1199,435 1204,435 1208,435 1213,435 1217,435 1222,435 1226,435 1231,435 1235,435 1240,435 1244,435 1249,435 1253,435 1258,435 1262,435 1267,435 1271,435 1276,435 1280,435 1285,435 1289,435 1294,435 1298,435 1303,435 1307,435 1312,435 1316,435 1321,435 1325,435 1330,435 1334,435 1339,435 1343,435 1348,435 1352,435 1357,435 1361,435 1366,435 1370,435 1375,435 1379,435 1384,435 1388,435 1393,435 1397,435 1402,435 1406,435 1411,435 1415,435 1420,435 1424,435 1429,435 1433,435 1438,435 1442,435 1447,435 1451,435 1456,435 1460,435 1465,435 1469,435 1474,435 1478,435 1483,435 1487,435 1492,435 1496,435 1501,435 1505,435 1510,435 1514,435 1519,435 1523,435 1528,435 1532,435 1537,435 1541,435 1546,435 1550,435 1555,435 1559,435 1564,435 1568,435 1573,435 1577,435 1582,435 1586,435 1591,435 1595,435 1600,435 1604,435 1609,435 1613,435 1618,435 1622,435 1626,435 1631,435 1635,435 1640,435 1644,435 1649,435 1653,435 1658,435 1662,435 1667,435 1671,435 1676,435 1680,435 1685,435 1689,435 1694,435 1698,435 1703,435 1707,435 1712,435 1716,435 1721,435 1725,435 1730,435 1734,435 1739,435 1743,435 1748,435 1752,435 1757,435 1761,435 1766,435 1770,435 1775,435 1779,435 1784,435 1788,435 1793,435 1797,435 1802,435 1806,435 1811,435 1815,435 1820,435 1824,435 1829,435 1833,435 1838,435 1842,435 1847,435 1851,435 1856,435 1860,435 1865,435 1869,435 1874,435 1878,435 1883,435 1887,435 1892,435 1896,435 1901,435 1905,435 1910,435 1914,435 1919,435 1923,435 1928,435 1932,435 1937,435 1941,435 1946,435 1950,435 1955,435 1959,435 1964,435 1968,435 1973,435 1977,435 1982,435 1986,435 1991,435 1995,435 2000,435 2004,435 2009,435 2013,435 2018,435 2022,435 2027,435 2031,435 2036,435 2040,435 2045,435 2049,435 2054,435 2058,435 2063,435 2067,435 2072,435 2076,435 2081,435 2085,435 2090,435 2094,435 2099,435 2103,435 2108,435 2112,435 2117,435 2121,435 2126,435 2130,435 2135,435 2139,435 2144,435 2148,435 2153,435 2157,435 2162,435 2166,435 2171,435 2175,435 2180,435 2184,435 2189,435 2193,435 2198,435 2202,435 2207,435 2211,435 2216,435 2220,435 2225,435 2229,435 2234,435 2238,435 2243,435 2247,435 2252,435 2256,435 2261,435 2265,435 2270,435 2274,435 2279,435 2283,435 2288,435 2292,435 2297,435 2301,435 2306,435 2310,435 2315,435 2319,435 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2208" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2208 74,2208 "/>
+<text x="65" y="2092" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2092 74,2092 "/>
+<text x="65" y="1975" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1975 74,1975 "/>
+<text x="65" y="1859" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1859 74,1859 "/>
+<text x="65" y="1743" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1743 74,1743 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1510" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1510 74,1510 "/>
+<text x="65" y="1394" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1394 74,1394 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2207 115,2201 120,2195 124,2190 129,2184 133,2178 138,2173 142,2167 147,2162 151,2157 156,2151 160,2146 165,2141 169,2136 174,2131 178,2127 183,2122 187,2117 192,2113 196,2109 201,2105 205,2101 210,2097 214,2093 219,2089 223,2086 228,2082 232,2079 237,2075 241,2072 246,2069 250,2066 255,2063 259,2060 264,2057 268,2055 273,2052 277,2050 282,2047 286,2045 291,2042 295,2040 300,2038 304,2035 309,2033 313,2031 318,2029 322,2027 327,2025 331,2023 336,2021 340,2019 345,2017 349,2015 354,2013 358,2011 363,2009 367,2008 372,2006 376,2004 381,2002 385,2001 390,1999 394,1997 399,1996 403,1994 408,1992 412,1990 417,1989 421,1987 426,1986 430,1984 435,1982 439,1981 444,1979 448,1977 453,1976 457,1974 462,1973 466,1971 471,1970 475,1968 480,1966 484,1965 489,1963 493,1962 498,1960 502,1959 506,1957 511,1955 515,1954 520,1952 524,1951 529,1949 533,1948 538,1946 542,1945 547,1943 551,1941 556,1940 560,1938 565,1937 569,1935 574,1934 578,1932 583,1931 587,1929 592,1928 596,1926 601,1925 605,1923 610,1921 614,1920 619,1918 623,1917 628,1915 632,1914 637,1912 641,1911 646,1909 650,1908 655,1906 659,1905 664,1903 668,1901 673,1900 677,1898 682,1897 686,1895 691,1894 695,1892 700,1891 704,1889 709,1888 713,1886 718,1885 722,1883 727,1882 731,1880 736,1879 740,1877 745,1875 749,1874 754,1872 758,1871 763,1869 767,1868 772,1866 776,1865 781,1863 785,1862 790,1860 794,1859 799,1857 803,1856 808,1854 812,1853 817,1851 821,1849 826,1848 830,1846 835,1845 839,1843 844,1842 848,1840 853,1839 857,1837 862,1836 866,1834 871,1833 875,1831 880,1830 884,1828 889,1826 893,1825 898,1823 902,1822 907,1820 911,1819 916,1817 920,1816 925,1814 929,1813 934,1811 938,1810 943,1808 947,1807 952,1805 956,1804 961,1802 965,1800 970,1799 974,1797 979,1796 983,1794 988,1793 992,1791 997,1790 1001,1788 1006,1787 1010,1785 1015,1784 1019,1782 1024,1781 1028,1779 1033,1778 1037,1776 1042,1774 1046,1773 1051,1771 1055,1770 1060,1768 1064,1767 1069,1765 1073,1764 1078,1762 1082,1761 1087,1759 1091,1758 1096,1756 1100,1755 1105,1753 1109,1752 1114,1750 1118,1748 1123,1747 1127,1745 1132,1744 1136,1742 1141,1741 1145,1739 1150,1738 1154,1736 1159,1735 1163,1733 1168,1732 1172,1730 1177,1729 1181,1727 1186,1726 1190,1724 1195,1722 1199,1721 1204,1719 1208,1718 1213,1716 1217,1715 1222,1713 1226,1712 1231,1710 1235,1709 1240,1707 1244,1706 1249,1704 1253,1703 1258,1701 1262,1700 1267,1698 1271,1696 1276,1695 1280,1693 1285,1692 1289,1690 1294,1689 1298,1687 1303,1686 1307,1684 1312,1683 1316,1681 1321,1680 1325,1678 1330,1677 1334,1675 1339,1673 1343,1672 1348,1670 1352,1669 1357,1667 1361,1666 1366,1664 1370,1663 1375,1661 1379,1660 1384,1658 1388,1657 1393,1655 1397,1654 1402,1652 1406,1651 1411,1649 1415,1647 1420,1646 1424,1644 1429,1643 1433,1641 1438,1640 1442,1638 1447,1637 1451,1635 1456,1634 1460,1632 1465,1631 1469,1629 1474,1628 1478,1626 1483,1625 1487,1623 1492,1621 1496,1620 1501,1618 1505,1617 1510,1615 1514,1614 1519,1612 1523,1611 1528,1609 1532,1608 1537,1606 1541,1605 1546,1603 1550,1602 1555,1600 1559,1599 1564,1597 1568,1595 1573,1594 1577,1592 1582,1591 1586,1589 1591,1588 1595,1586 1600,1585 1604,1583 1609,1582 1613,1580 1618,1579 1622,1577 1626,1576 1631,1574 1635,1573 1640,1571 1644,1569 1649,1568 1653,1566 1658,1565 1662,1563 1667,1562 1671,1560 1676,1559 1680,1557 1685,1556 1689,1554 1694,1553 1698,1551 1703,1550 1707,1548 1712,1547 1716,1545 1721,1543 1725,1542 1730,1540 1734,1539 1739,1537 1743,1536 1748,1534 1752,1533 1757,1531 1761,1530 1766,1528 1770,1527 1775,1525 1779,1524 1784,1522 1788,1521 1793,1519 1797,1517 1802,1516 1806,1514 1811,1513 1815,1511 1820,1510 1824,1508 1829,1507 1833,1505 1838,1504 1842,1502 1847,1501 1851,1499 1856,1498 1860,1496 1865,1494 1869,1493 1874,1491 1878,1490 1883,1488 1887,1487 1892,1485 1896,1484 1901,1482 1905,1481 1910,1479 1914,1478 1919,1476 1923,1475 1928,1473 1932,1472 1937,1470 1941,1468 1946,1467 1950,1465 1955,1464 1959,1462 1964,1461 1968,1459 1973,1458 1977,1456 1982,1455 1986,1453 1991,1452 1995,1450 2000,1449 2004,1447 2009,1446 2013,1444 2018,1442 2022,1441 2027,1439 2031,1438 2036,1436 2040,1435 2045,1433 2049,1432 2054,1430 2058,1429 2063,1427 2067,1426 2072,1424 2076,1423 2081,1421 2085,1420 2090,1418 2094,1416 2099,1415 2103,1413 2108,1412 2112,1410 2117,1409 2121,1407 2126,1406 2130,1404 2135,1403 2139,1401 2144,1400 2148,1398 2153,1397 2157,1395 2162,1394 2166,1392 2171,1390 2175,1389 2180,1387 2184,1386 2189,1384 2193,1383 2198,1381 2202,1380 2207,1378 2211,1377 2216,1375 2220,1374 2225,1372 2229,1371 2234,1369 2238,1368 2243,1366 2247,1364 2252,1363 2256,1361 2261,1360 2265,1358 2270,1357 2274,1355 2279,1354 2283,1352 2288,1351 2292,1349 2297,1348 2301,1346 2306,1345 2310,1343 2315,1341 2319,1340 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2267 552,2240 556,2215 561,2191 565,2169 570,2149 574,2130 579,2112 583,2096 588,2080 592,2066 597,2053 601,2041 606,2031 610,2021 615,2012 619,2003 624,1996 628,1989 633,1983 637,1978 642,1973 646,1969 651,1966 655,1963 660,1960 664,1958 669,1956 673,1955 678,1954 682,1954 687,1954 691,1953 696,1954 700,1955 705,1956 709,1957 714,1958 718,1960 723,1962 727,1964 732,1966 736,1968 741,1971 745,1973 750,1976 754,1979 759,1982 763,1985 768,1988 772,1991 777,1995 781,1998 786,2001 790,2005 795,2008 799,2012 804,2015 808,2019 813,2022 817,2026 822,2030 826,2033 831,2037 835,2041 840,2045 844,2048 849,2052 853,2056 858,2059 862,2063 867,2066 871,2070 876,2074 880,2077 885,2081 889,2084 894,2088 898,2091 903,2094 907,2098 912,2101 916,2103 921,2102 925,2102 930,2102 934,2101 939,2101 943,2100 948,2100 952,2100 957,2100 961,2100 966,2100 970,2101 975,2101 979,2100 984,2098 988,2098 993,2099 997,2099 1002,2098 1006,2099 1011,2099 1015,2100 1020,2099 1024,2100 1029,2100 1033,2101 1038,2101 1042,2101 1047,2101 1051,2100 1056,2100 1060,2100 1065,2100 1069,2101 1074,2101 1078,2102 1083,2102 1087,2102 1092,2103 1096,2103 1101,2104 1105,2104 1110,2104 1114,2105 1119,2105 1123,2103 1128,2104 1132,2104 1137,2105 1141,2105 1146,2106 1150,2106 1155,2107 1159,2107 1164,2108 1168,2108 1173,2109 1177,2109 1182,2109 1186,2110 1191,2108 1195,2109 1200,2109 1204,2110 1209,2110 1213,2111 1218,2111 1222,2112 1227,2113 1231,2112 1236,2113 1240,2113 1245,2114 1249,2114 1254,2115 1258,2113 1263,2114 1267,2114 1272,2115 1276,2115 1281,2116 1285,2116 1290,2117 1294,2117 1299,2118 1303,2118 1308,2119 1312,2119 1317,2119 1321,2119 1326,2118 1330,2118 1335,2119 1339,2120 1344,2120 1348,2120 1353,2121 1357,2121 1362,2122 1366,2122 1371,2123 1375,2123 1380,2124 1384,2124 1389,2124 1393,2125 1398,2124 1402,2124 1407,2125 1411,2125 1416,2125 1420,2126 1425,2127 1429,2127 1434,2127 1438,2128 1443,2128 1447,2128 1452,2129 1456,2130 1461,2130 1465,2128 1470,2129 1474,2129 1479,2130 1483,2130 1488,2131 1492,2131 1497,2131 1501,2132 1506,2132 1510,2132 1515,2133 1519,2134 1524,2134 1528,2134 1533,2133 1537,2133 1542,2134 1546,2134 1551,2135 1555,2135 1560,2135 1564,2136 1569,2136 1573,2136 1578,2137 1582,2137 1587,2138 1591,2139 1596,2138 1600,2137 1605,2137 1609,2138 1614,2138 1618,2139 1623,2139 1627,2139 1632,2140 1636,2140 1641,2140 1645,2140 1650,2141 1654,2142 1659,2142 1663,2142 1668,2143 1672,2141 1677,2141 1681,2142 1686,2142 1690,2143 1695,2143 1699,2143 1704,2144 1708,2144 1713,2145 1717,2145 1722,2145 1726,2145 1731,2146 1735,2147 1740,2145 1744,2145 1749,2146 1753,2146 1758,2146 1762,2146 1767,2147 1771,2147 1776,2147 1780,2148 1785,2148 1789,2148 1794,2149 1798,2149 1803,2149 1807,2148 1812,2148 1816,2149 1821,2149 1825,2150 1830,2150 1834,2150 1839,2150 1843,2151 1848,2151 1852,2152 1857,2152 1861,2152 1866,2153 1870,2153 1875,2151 1879,2151 1884,2152 1888,2152 1893,2153 1897,2153 1902,2153 1906,2153 1911,2154 1915,2154 1920,2154 1924,2155 1929,2155 1933,2155 1938,2156 1942,2156 1947,2154 1951,2155 1956,2155 1960,2155 1965,2155 1969,2156 1974,2156 1978,2156 1983,2157 1987,2157 1992,2157 1996,2158 2001,2158 2005,2159 2010,2159 2014,2157 2019,2157 2023,2158 2028,2158 2032,2158 2037,2159 2041,2159 2046,2159 2050,2160 2055,2160 2059,2160 2064,2161 2068,2161 2073,2161 2077,2161 2082,2160 2086,2160 2091,2160 2095,2161 2100,2161 2104,2161 2109,2162 2113,2162 2118,2162 2122,2162 2127,2163 2131,2163 2136,2163 2140,2164 2145,2164 2149,2162 2154,2162 2158,2163 2163,2163 2167,2164 2172,2164 2176,2164 2181,2164 2185,2164 2190,2165 2194,2165 2199,2165 2203,2165 2208,2166 2212,2167 2217,2166 2221,2165 2226,2165 2230,2166 2235,2166 2239,2166 2244,2166 2248,2166 2253,2167 2257,2167 2262,2167 2266,2167 2271,2168 2275,2168 2280,2168 2284,2168 2289,2167 2293,2167 2298,2168 2302,2168 2307,2168 2311,2169 2316,2169 2320,2169 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Slower growth, tapering fees_0.000300.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Slower growth, tapering fees_0.000300.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Slower growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,848 129,840 133,833 138,826 142,818 147,811 151,805 156,798 160,791 165,784 169,778 174,772 178,765 183,759 187,753 192,747 196,741 201,735 205,730 210,724 214,718 219,713 223,707 228,702 232,697 237,692 241,687 246,682 250,677 255,672 259,667 264,663 268,658 273,653 277,649 282,645 286,640 291,636 295,632 300,628 304,624 309,619 313,616 318,612 322,608 327,604 331,600 336,597 340,593 345,590 349,586 354,583 358,579 363,576 367,573 372,569 376,566 381,563 385,560 390,557 394,554 399,551 403,548 408,545 412,542 417,540 421,537 426,534 430,532 435,529 439,527 444,524 448,522 453,519 457,517 462,515 466,512 471,510 475,508 480,506 484,504 489,502 493,500 498,499 502,497 506,495 511,494 515,492 520,490 524,489 529,487 533,486 538,485 542,483 547,482 551,481 556,479 560,478 565,477 569,476 574,475 578,474 583,473 587,471 592,470 596,470 601,469 605,468 610,467 614,466 619,465 623,464 628,463 632,463 637,462 641,461 646,460 650,460 655,459 659,458 664,458 668,457 673,457 677,456 682,455 686,455 691,454 695,454 700,453 704,453 709,452 713,452 718,451 722,451 727,450 731,450 736,450 740,449 745,449 749,448 754,448 758,448 763,447 767,447 772,447 776,446 781,446 785,446 790,446 794,445 799,445 803,445 808,444 812,444 817,444 821,444 826,443 830,443 835,443 839,443 844,443 848,442 853,442 857,442 862,442 866,442 871,441 875,441 880,441 884,441 889,441 893,441 898,441 902,440 907,440 911,440 916,440 920,440 925,440 929,440 934,439 938,439 943,439 947,439 952,439 956,439 961,439 965,439 970,439 974,439 979,438 983,438 988,438 992,438 997,438 1001,438 1006,438 1010,438 1015,438 1019,438 1024,438 1028,438 1033,438 1037,437 1042,437 1046,437 1051,437 1055,437 1060,437 1064,437 1069,437 1073,437 1078,437 1082,437 1087,437 1091,437 1096,437 1100,437 1105,437 1109,437 1114,437 1118,437 1123,437 1127,437 1132,437 1136,436 1141,436 1145,436 1150,436 1154,436 1159,436 1163,436 1168,436 1172,436 1177,436 1181,436 1186,436 1190,436 1195,436 1199,436 1204,436 1208,436 1213,436 1217,436 1222,436 1226,436 1231,436 1235,436 1240,436 1244,436 1249,436 1253,436 1258,436 1262,436 1267,436 1271,436 1276,436 1280,436 1285,436 1289,436 1294,436 1298,436 1303,436 1307,436 1312,436 1316,436 1321,436 1325,436 1330,436 1334,436 1339,436 1343,436 1348,436 1352,436 1357,436 1361,436 1366,436 1370,436 1375,436 1379,436 1384,436 1388,436 1393,436 1397,436 1402,436 1406,436 1411,436 1415,435 1420,435 1424,435 1429,435 1433,435 1438,435 1442,435 1447,435 1451,435 1456,435 1460,435 1465,435 1469,435 1474,435 1478,435 1483,435 1487,435 1492,435 1496,435 1501,435 1505,435 1510,435 1514,435 1519,435 1523,435 1528,435 1532,435 1537,435 1541,435 1546,435 1550,435 1555,435 1559,435 1564,435 1568,435 1573,435 1577,435 1582,435 1586,435 1591,435 1595,435 1600,435 1604,435 1609,435 1613,435 1618,435 1622,435 1626,435 1631,435 1635,435 1640,435 1644,435 1649,435 1653,435 1658,435 1662,435 1667,435 1671,435 1676,435 1680,435 1685,435 1689,435 1694,435 1698,435 1703,435 1707,435 1712,435 1716,435 1721,435 1725,435 1730,435 1734,435 1739,435 1743,435 1748,435 1752,435 1757,435 1761,435 1766,435 1770,435 1775,435 1779,435 1784,435 1788,435 1793,435 1797,435 1802,435 1806,435 1811,435 1815,435 1820,435 1824,435 1829,435 1833,435 1838,435 1842,435 1847,435 1851,435 1856,435 1860,435 1865,435 1869,435 1874,435 1878,435 1883,435 1887,435 1892,435 1896,435 1901,435 1905,435 1910,435 1914,435 1919,435 1923,435 1928,435 1932,435 1937,435 1941,435 1946,435 1950,435 1955,435 1959,435 1964,435 1968,435 1973,435 1977,435 1982,435 1986,435 1991,435 1995,435 2000,435 2004,435 2009,435 2013,435 2018,435 2022,435 2027,435 2031,435 2036,435 2040,435 2045,435 2049,435 2054,435 2058,435 2063,435 2067,435 2072,435 2076,435 2081,435 2085,435 2090,435 2094,435 2099,435 2103,435 2108,435 2112,435 2117,435 2121,435 2126,435 2130,435 2135,435 2139,435 2144,435 2148,435 2153,435 2157,435 2162,435 2166,435 2171,435 2175,435 2180,435 2184,435 2189,435 2193,435 2198,435 2202,435 2207,435 2211,435 2216,435 2220,435 2225,435 2229,435 2234,435 2238,435 2243,435 2247,435 2252,435 2256,435 2261,435 2265,435 2270,435 2274,435 2279,435 2283,435 2288,435 2292,435 2297,435 2301,435 2306,435 2310,435 2315,435 2319,435 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2208" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2208 74,2208 "/>
+<text x="65" y="2092" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2092 74,2092 "/>
+<text x="65" y="1975" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1975 74,1975 "/>
+<text x="65" y="1859" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1859 74,1859 "/>
+<text x="65" y="1743" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1743 74,1743 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1510" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1510 74,1510 "/>
+<text x="65" y="1394" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1394 74,1394 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2207 115,2201 120,2195 124,2190 129,2184 133,2178 138,2173 142,2167 147,2162 151,2157 156,2151 160,2146 165,2141 169,2136 174,2131 178,2127 183,2122 187,2117 192,2113 196,2109 201,2105 205,2101 210,2097 214,2093 219,2089 223,2086 228,2082 232,2079 237,2075 241,2072 246,2069 250,2066 255,2063 259,2060 264,2057 268,2055 273,2052 277,2050 282,2047 286,2045 291,2042 295,2040 300,2038 304,2035 309,2033 313,2031 318,2029 322,2027 327,2025 331,2023 336,2021 340,2019 345,2017 349,2015 354,2013 358,2011 363,2009 367,2008 372,2006 376,2004 381,2002 385,2001 390,1999 394,1997 399,1996 403,1994 408,1992 412,1990 417,1989 421,1987 426,1986 430,1984 435,1982 439,1981 444,1979 448,1977 453,1976 457,1974 462,1973 466,1971 471,1970 475,1968 480,1966 484,1965 489,1963 493,1962 498,1960 502,1959 506,1957 511,1955 515,1954 520,1952 524,1951 529,1949 533,1948 538,1946 542,1945 547,1943 551,1941 556,1940 560,1938 565,1937 569,1935 574,1934 578,1932 583,1931 587,1929 592,1928 596,1926 601,1925 605,1923 610,1921 614,1920 619,1918 623,1917 628,1915 632,1914 637,1912 641,1911 646,1909 650,1908 655,1906 659,1905 664,1903 668,1901 673,1900 677,1898 682,1897 686,1895 691,1894 695,1892 700,1891 704,1889 709,1888 713,1886 718,1885 722,1883 727,1882 731,1880 736,1879 740,1877 745,1875 749,1874 754,1872 758,1871 763,1869 767,1868 772,1866 776,1865 781,1863 785,1862 790,1860 794,1859 799,1857 803,1856 808,1854 812,1853 817,1851 821,1849 826,1848 830,1846 835,1845 839,1843 844,1842 848,1840 853,1839 857,1837 862,1836 866,1834 871,1833 875,1831 880,1830 884,1828 889,1826 893,1825 898,1823 902,1822 907,1820 911,1819 916,1817 920,1816 925,1814 929,1813 934,1811 938,1810 943,1808 947,1807 952,1805 956,1804 961,1802 965,1800 970,1799 974,1797 979,1796 983,1794 988,1793 992,1791 997,1790 1001,1788 1006,1787 1010,1785 1015,1784 1019,1782 1024,1781 1028,1779 1033,1778 1037,1776 1042,1774 1046,1773 1051,1771 1055,1770 1060,1768 1064,1767 1069,1765 1073,1764 1078,1762 1082,1761 1087,1759 1091,1758 1096,1756 1100,1755 1105,1753 1109,1752 1114,1750 1118,1748 1123,1747 1127,1745 1132,1744 1136,1742 1141,1741 1145,1739 1150,1738 1154,1736 1159,1735 1163,1733 1168,1732 1172,1730 1177,1729 1181,1727 1186,1726 1190,1724 1195,1722 1199,1721 1204,1719 1208,1718 1213,1716 1217,1715 1222,1713 1226,1712 1231,1710 1235,1709 1240,1707 1244,1706 1249,1704 1253,1703 1258,1701 1262,1700 1267,1698 1271,1696 1276,1695 1280,1693 1285,1692 1289,1690 1294,1689 1298,1687 1303,1686 1307,1684 1312,1683 1316,1681 1321,1680 1325,1678 1330,1677 1334,1675 1339,1673 1343,1672 1348,1670 1352,1669 1357,1667 1361,1666 1366,1664 1370,1663 1375,1661 1379,1660 1384,1658 1388,1657 1393,1655 1397,1654 1402,1652 1406,1651 1411,1649 1415,1647 1420,1646 1424,1644 1429,1643 1433,1641 1438,1640 1442,1638 1447,1637 1451,1635 1456,1634 1460,1632 1465,1631 1469,1629 1474,1628 1478,1626 1483,1625 1487,1623 1492,1621 1496,1620 1501,1618 1505,1617 1510,1615 1514,1614 1519,1612 1523,1611 1528,1609 1532,1608 1537,1606 1541,1605 1546,1603 1550,1602 1555,1600 1559,1599 1564,1597 1568,1595 1573,1594 1577,1592 1582,1591 1586,1589 1591,1588 1595,1586 1600,1585 1604,1583 1609,1582 1613,1580 1618,1579 1622,1577 1626,1576 1631,1574 1635,1573 1640,1571 1644,1569 1649,1568 1653,1566 1658,1565 1662,1563 1667,1562 1671,1560 1676,1559 1680,1557 1685,1556 1689,1554 1694,1553 1698,1551 1703,1550 1707,1548 1712,1547 1716,1545 1721,1543 1725,1542 1730,1540 1734,1539 1739,1537 1743,1536 1748,1534 1752,1533 1757,1531 1761,1530 1766,1528 1770,1527 1775,1525 1779,1524 1784,1522 1788,1521 1793,1519 1797,1517 1802,1516 1806,1514 1811,1513 1815,1511 1820,1510 1824,1508 1829,1507 1833,1505 1838,1504 1842,1502 1847,1501 1851,1499 1856,1498 1860,1496 1865,1494 1869,1493 1874,1491 1878,1490 1883,1488 1887,1487 1892,1485 1896,1484 1901,1482 1905,1481 1910,1479 1914,1478 1919,1476 1923,1475 1928,1473 1932,1472 1937,1470 1941,1468 1946,1467 1950,1465 1955,1464 1959,1462 1964,1461 1968,1459 1973,1458 1977,1456 1982,1455 1986,1453 1991,1452 1995,1450 2000,1449 2004,1447 2009,1446 2013,1444 2018,1442 2022,1441 2027,1439 2031,1438 2036,1436 2040,1435 2045,1433 2049,1432 2054,1430 2058,1429 2063,1427 2067,1426 2072,1424 2076,1423 2081,1421 2085,1420 2090,1418 2094,1416 2099,1415 2103,1413 2108,1412 2112,1410 2117,1409 2121,1407 2126,1406 2130,1404 2135,1403 2139,1401 2144,1400 2148,1398 2153,1397 2157,1395 2162,1394 2166,1392 2171,1390 2175,1389 2180,1387 2184,1386 2189,1384 2193,1383 2198,1381 2202,1380 2207,1378 2211,1377 2216,1375 2220,1374 2225,1372 2229,1371 2234,1369 2238,1368 2243,1366 2247,1364 2252,1363 2256,1361 2261,1360 2265,1358 2270,1357 2274,1355 2279,1354 2283,1352 2288,1351 2292,1349 2297,1348 2301,1346 2306,1345 2310,1343 2315,1341 2319,1340 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2273 448,2253 453,2233 457,2215 462,2197 466,2181 471,2165 475,2151 480,2137 484,2124 489,2111 493,2100 498,2089 502,2079 507,2069 511,2060 516,2052 520,2045 525,2037 529,2031 534,2025 538,2019 543,2014 547,2009 552,2005 556,2001 561,1998 565,1995 570,1992 574,1989 579,1987 583,1985 588,1984 592,1983 597,1981 601,1981 606,1980 610,1980 615,1980 619,1980 624,1980 628,1981 633,1981 637,1983 642,1983 646,1984 651,1986 655,1987 660,1989 664,1990 669,1992 673,1994 678,1996 682,1998 687,2000 691,2002 696,2004 700,2007 705,2009 709,2012 714,2014 718,2017 723,2020 727,2022 732,2025 736,2028 741,2030 745,2033 750,2036 754,2039 759,2042 763,2045 768,2048 772,2051 777,2054 781,2056 786,2059 790,2062 795,2065 799,2068 804,2071 808,2074 813,2077 817,2080 822,2083 826,2086 831,2089 835,2091 840,2094 844,2098 849,2101 853,2103 858,2106 862,2109 867,2112 871,2114 876,2117 880,2120 885,2123 889,2125 894,2128 898,2130 903,2133 907,2136 912,2139 916,2138 921,2137 925,2136 930,2135 934,2135 939,2133 943,2132 948,2132 952,2131 957,2130 961,2129 966,2128 970,2128 975,2127 979,2127 984,2124 988,2124 993,2123 997,2123 1002,2122 1006,2122 1011,2122 1015,2121 1020,2121 1024,2121 1029,2121 1033,2120 1038,2120 1042,2120 1047,2120 1051,2117 1056,2117 1060,2117 1065,2117 1069,2117 1074,2117 1078,2117 1083,2117 1087,2117 1092,2117 1096,2117 1101,2117 1105,2117 1110,2117 1114,2117 1119,2117 1123,2115 1128,2115 1132,2115 1137,2115 1141,2116 1146,2116 1150,2116 1155,2116 1159,2116 1164,2117 1168,2117 1173,2117 1177,2117 1182,2118 1186,2118 1191,2116 1195,2116 1200,2117 1204,2117 1209,2117 1213,2117 1218,2118 1222,2118 1227,2119 1231,2119 1236,2119 1240,2119 1245,2120 1249,2120 1254,2120 1258,2119 1263,2119 1267,2119 1272,2119 1276,2120 1281,2120 1285,2120 1290,2121 1294,2121 1299,2121 1303,2122 1308,2123 1312,2123 1317,2123 1321,2123 1326,2122 1330,2123 1335,2123 1339,2123 1344,2124 1348,2124 1353,2124 1357,2124 1362,2125 1366,2125 1371,2126 1375,2126 1380,2126 1384,2127 1389,2127 1393,2128 1398,2126 1402,2126 1407,2127 1411,2127 1416,2128 1420,2128 1425,2129 1429,2129 1434,2129 1438,2129 1443,2130 1447,2130 1452,2131 1456,2131 1461,2132 1465,2130 1470,2130 1474,2131 1479,2131 1483,2131 1488,2132 1492,2132 1497,2133 1501,2133 1506,2134 1510,2134 1515,2134 1519,2134 1524,2135 1528,2135 1533,2134 1537,2134 1542,2135 1546,2135 1551,2135 1555,2136 1560,2136 1564,2137 1569,2137 1573,2138 1578,2138 1582,2138 1587,2138 1591,2138 1596,2139 1600,2137 1605,2138 1609,2138 1614,2138 1618,2139 1623,2139 1627,2140 1632,2140 1636,2141 1641,2141 1645,2141 1650,2141 1654,2142 1659,2142 1663,2143 1668,2143 1672,2142 1677,2142 1681,2142 1686,2143 1690,2143 1695,2143 1699,2143 1704,2144 1708,2144 1713,2145 1717,2145 1722,2145 1726,2145 1731,2146 1735,2146 1740,2144 1744,2145 1749,2145 1753,2146 1758,2146 1762,2146 1767,2147 1771,2147 1776,2147 1780,2148 1785,2148 1789,2148 1794,2149 1798,2149 1803,2150 1807,2148 1812,2148 1816,2149 1821,2149 1825,2149 1830,2150 1834,2150 1839,2150 1843,2151 1848,2151 1852,2152 1857,2152 1861,2152 1866,2152 1870,2152 1875,2151 1879,2152 1884,2152 1888,2152 1893,2152 1897,2153 1902,2153 1906,2154 1911,2154 1915,2154 1920,2155 1924,2155 1929,2155 1933,2155 1938,2155 1942,2156 1947,2154 1951,2155 1956,2155 1960,2155 1965,2156 1969,2156 1974,2156 1978,2157 1983,2157 1987,2157 1992,2158 1996,2158 2001,2158 2005,2158 2010,2158 2014,2157 2019,2158 2023,2158 2028,2158 2032,2158 2037,2158 2041,2159 2046,2159 2050,2159 2055,2160 2059,2161 2064,2160 2068,2161 2073,2161 2077,2161 2082,2160 2086,2160 2091,2160 2095,2161 2100,2161 2104,2161 2109,2162 2113,2162 2118,2162 2122,2162 2127,2162 2131,2163 2136,2163 2140,2163 2145,2164 2149,2162 2154,2162 2158,2163 2163,2163 2167,2164 2172,2164 2176,2164 2181,2165 2185,2164 2190,2165 2194,2165 2199,2165 2203,2165 2208,2166 2212,2166 2217,2166 2221,2165 2226,2165 2230,2165 2235,2166 2239,2166 2244,2166 2248,2166 2253,2167 2257,2168 2262,2168 2266,2167 2271,2168 2275,2168 2280,2169 2284,2169 2289,2167 2293,2168 2298,2168 2302,2168 2307,2169 2311,2168 2316,2169 2320,2169 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Strong growth, tapering fees_0.000100.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Strong growth, tapering fees_0.000100.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Strong growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,847 129,840 133,833 138,825 142,818 147,811 151,804 156,798 160,791 165,785 169,778 174,772 178,766 183,760 187,754 192,748 196,742 201,736 205,731 210,725 214,720 219,715 223,709 228,704 232,699 237,694 241,689 246,684 250,680 255,675 259,670 264,666 268,661 273,657 277,653 282,648 286,644 291,640 295,636 300,632 304,628 309,624 313,621 318,617 322,613 327,610 331,606 336,603 340,599 345,596 349,593 354,589 358,586 363,583 367,580 372,577 376,574 381,571 385,568 390,565 394,562 399,560 403,557 408,554 412,552 417,549 421,547 426,544 430,542 435,539 439,537 444,534 448,532 453,530 457,528 462,526 466,523 471,521 475,519 480,517 484,515 489,513 493,511 498,509 502,508 506,506 511,504 515,502 520,501 524,499 529,497 533,496 538,494 542,492 547,491 551,489 556,488 560,486 565,485 569,483 574,482 578,481 583,479 587,478 592,477 596,475 601,474 605,473 610,472 614,471 619,469 623,468 628,467 632,466 637,465 641,464 646,463 650,462 655,461 659,460 664,459 668,458 673,457 677,456 682,455 686,454 691,454 695,453 700,452 704,451 709,450 713,450 718,449 722,448 727,447 731,447 736,446 740,445 745,445 749,444 754,444 758,443 763,442 767,442 772,441 776,441 781,440 785,440 790,440 794,439 799,439 803,439 808,438 812,438 817,438 821,438 826,437 830,437 835,437 839,437 844,437 848,437 853,437 857,436 862,436 866,436 871,436 875,436 880,436 884,436 889,436 893,436 898,436 902,436 907,436 911,436 916,436 920,436 925,436 929,436 934,436 938,436 943,436 947,436 952,436 956,435 961,435 965,435 970,435 974,435 979,435 983,435 988,435 992,435 997,435 1001,435 1006,435 1010,435 1015,435 1019,435 1024,435 1028,435 1033,435 1037,435 1042,435 1046,435 1051,435 1055,435 1060,435 1064,435 1069,435 1073,435 1078,435 1082,435 1087,435 1091,435 1096,435 1100,435 1105,435 1109,435 1114,435 1118,435 1123,435 1127,435 1132,435 1136,435 1141,435 1145,435 1150,435 1154,435 1159,435 1163,435 1168,435 1172,435 1177,435 1181,435 1186,435 1190,435 1195,435 1199,435 1204,435 1208,435 1213,435 1217,435 1222,435 1226,435 1231,435 1235,435 1240,435 1244,435 1249,435 1253,435 1258,435 1262,435 1267,435 1271,435 1276,435 1280,435 1285,435 1289,435 1294,435 1298,435 1303,435 1307,435 1312,435 1316,435 1321,435 1325,435 1330,435 1334,435 1339,435 1343,435 1348,435 1352,435 1357,435 1361,435 1366,435 1370,435 1375,435 1379,435 1384,435 1388,435 1393,435 1397,435 1402,435 1406,435 1411,435 1415,435 1420,435 1424,435 1429,435 1433,435 1438,435 1442,435 1447,435 1451,435 1456,435 1460,435 1465,435 1469,435 1474,435 1478,435 1483,435 1487,435 1492,435 1496,435 1501,435 1505,435 1510,435 1514,435 1519,435 1523,435 1528,435 1532,435 1537,435 1541,435 1546,435 1550,435 1555,435 1559,435 1564,435 1568,435 1573,435 1577,435 1582,435 1586,435 1591,435 1595,435 1600,435 1604,435 1609,435 1613,435 1618,435 1622,435 1626,435 1631,435 1635,435 1640,435 1644,435 1649,435 1653,435 1658,435 1662,435 1667,435 1671,435 1676,435 1680,435 1685,435 1689,435 1694,435 1698,435 1703,435 1707,435 1712,435 1716,435 1721,435 1725,435 1730,435 1734,435 1739,435 1743,435 1748,435 1752,435 1757,435 1761,435 1766,435 1770,435 1775,435 1779,435 1784,435 1788,435 1793,435 1797,435 1802,435 1806,435 1811,435 1815,435 1820,435 1824,435 1829,435 1833,435 1838,435 1842,435 1847,435 1851,435 1856,435 1860,435 1865,435 1869,435 1874,435 1878,435 1883,435 1887,435 1892,435 1896,435 1901,435 1905,435 1910,435 1914,435 1919,435 1923,435 1928,435 1932,435 1937,435 1941,435 1946,435 1950,435 1955,435 1959,435 1964,435 1968,435 1973,435 1977,435 1982,435 1986,435 1991,435 1995,435 2000,435 2004,435 2009,435 2013,435 2018,435 2022,435 2027,435 2031,435 2036,435 2040,435 2045,435 2049,435 2054,435 2058,435 2063,435 2067,435 2072,435 2076,435 2081,435 2085,435 2090,435 2094,435 2099,435 2103,435 2108,435 2112,435 2117,435 2121,435 2126,435 2130,435 2135,435 2139,435 2144,435 2148,435 2153,435 2157,435 2162,435 2166,435 2171,435 2175,435 2180,435 2184,435 2189,435 2193,435 2198,435 2202,435 2207,435 2211,435 2216,435 2220,435 2225,435 2229,435 2234,435 2238,435 2243,435 2247,435 2252,435 2256,435 2261,435 2265,435 2270,435 2274,435 2279,435 2283,435 2288,435 2292,435 2297,435 2301,435 2306,435 2310,435 2315,435 2319,435 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2204" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2204 74,2204 "/>
+<text x="65" y="2084" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2084 74,2084 "/>
+<text x="65" y="1963" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1963 74,1963 "/>
+<text x="65" y="1843" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1843 74,1843 "/>
+<text x="65" y="1722" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1722 74,1722 "/>
+<text x="65" y="1602" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1602 74,1602 "/>
+<text x="65" y="1481" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1481 74,1481 "/>
+<text x="65" y="1361" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1361 74,1361 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2016 151,2004 156,1992 160,1981 165,1970 169,1958 174,1947 178,1936 183,1925 187,1915 192,1905 196,1895 201,1885 205,1875 210,1866 214,1857 219,1848 223,1840 228,1832 232,1824 237,1817 241,1810 246,1803 250,1796 255,1790 259,1784 264,1778 268,1773 273,1767 277,1762 282,1758 286,1753 291,1749 295,1745 300,1741 304,1737 309,1733 313,1730 318,1727 322,1724 327,1721 331,1718 336,1715 340,1713 345,1710 349,1708 354,1706 358,1703 363,1701 367,1699 372,1697 376,1696 381,1694 385,1692 390,1690 394,1689 399,1687 403,1686 408,1684 412,1683 417,1682 421,1680 426,1679 430,1678 435,1677 439,1676 444,1674 448,1673 453,1672 457,1671 462,1670 466,1669 471,1668 475,1667 480,1666 484,1665 489,1664 493,1663 498,1662 502,1661 506,1660 511,1659 515,1658 520,1657 524,1657 529,1656 533,1655 538,1654 542,1653 547,1652 551,1651 556,1650 560,1650 565,1649 569,1648 574,1647 578,1646 583,1645 587,1645 592,1644 596,1643 601,1642 605,1641 610,1641 614,1640 619,1639 623,1638 628,1637 632,1636 637,1636 641,1635 646,1634 650,1633 655,1632 659,1632 664,1631 668,1630 673,1629 677,1628 682,1628 686,1627 691,1626 695,1625 700,1624 704,1624 709,1623 713,1622 718,1621 722,1620 727,1620 731,1619 736,1618 740,1617 745,1616 749,1616 754,1615 758,1614 763,1613 767,1612 772,1612 776,1611 781,1610 785,1609 790,1609 794,1608 799,1607 803,1606 808,1605 812,1605 817,1604 821,1603 826,1602 830,1601 835,1601 839,1600 844,1599 848,1598 853,1597 857,1597 862,1596 866,1595 871,1594 875,1593 880,1593 884,1592 889,1591 893,1590 898,1589 902,1589 907,1588 911,1587 916,1586 920,1586 925,1585 929,1584 934,1583 938,1582 943,1582 947,1581 952,1580 956,1579 961,1578 965,1578 970,1577 974,1576 979,1575 983,1574 988,1574 992,1573 997,1572 1001,1571 1006,1570 1010,1570 1015,1569 1019,1568 1024,1567 1028,1567 1033,1566 1037,1565 1042,1564 1046,1563 1051,1563 1055,1562 1060,1561 1064,1560 1069,1559 1073,1559 1078,1558 1082,1557 1087,1556 1091,1555 1096,1555 1100,1554 1105,1553 1109,1552 1114,1551 1118,1551 1123,1550 1127,1549 1132,1548 1136,1548 1141,1547 1145,1546 1150,1545 1154,1544 1159,1544 1163,1543 1168,1542 1172,1541 1177,1540 1181,1540 1186,1539 1190,1538 1195,1537 1199,1536 1204,1536 1208,1535 1213,1534 1217,1533 1222,1532 1226,1532 1231,1531 1235,1530 1240,1529 1244,1529 1249,1528 1253,1527 1258,1526 1262,1525 1267,1525 1271,1524 1276,1523 1280,1522 1285,1521 1289,1521 1294,1520 1298,1519 1303,1518 1307,1517 1312,1517 1316,1516 1321,1515 1325,1514 1330,1513 1334,1513 1339,1512 1343,1511 1348,1510 1352,1510 1357,1509 1361,1508 1366,1507 1370,1506 1375,1506 1379,1505 1384,1504 1388,1503 1393,1502 1397,1502 1402,1501 1406,1500 1411,1499 1415,1498 1420,1498 1424,1497 1429,1496 1433,1495 1438,1494 1442,1494 1447,1493 1451,1492 1456,1491 1460,1491 1465,1490 1469,1489 1474,1488 1478,1487 1483,1487 1487,1486 1492,1485 1496,1484 1501,1483 1505,1483 1510,1482 1514,1481 1519,1480 1523,1479 1528,1479 1532,1478 1537,1477 1541,1476 1546,1475 1550,1475 1555,1474 1559,1473 1564,1472 1568,1471 1573,1471 1577,1470 1582,1469 1586,1468 1591,1468 1595,1467 1600,1466 1604,1465 1609,1464 1613,1464 1618,1463 1622,1462 1626,1461 1631,1460 1635,1460 1640,1459 1644,1458 1649,1457 1653,1456 1658,1456 1662,1455 1667,1454 1671,1453 1676,1452 1680,1452 1685,1451 1689,1450 1694,1449 1698,1449 1703,1448 1707,1447 1712,1446 1716,1445 1721,1445 1725,1444 1730,1443 1734,1442 1739,1441 1743,1441 1748,1440 1752,1439 1757,1438 1761,1437 1766,1437 1770,1436 1775,1435 1779,1434 1784,1433 1788,1433 1793,1432 1797,1431 1802,1430 1806,1430 1811,1429 1815,1428 1820,1427 1824,1426 1829,1426 1833,1425 1838,1424 1842,1423 1847,1422 1851,1422 1856,1421 1860,1420 1865,1419 1869,1418 1874,1418 1878,1417 1883,1416 1887,1415 1892,1414 1896,1414 1901,1413 1905,1412 1910,1411 1914,1411 1919,1410 1923,1409 1928,1408 1932,1407 1937,1407 1941,1406 1946,1405 1950,1404 1955,1403 1959,1403 1964,1402 1968,1401 1973,1400 1977,1399 1982,1399 1986,1398 1991,1397 1995,1396 2000,1395 2004,1395 2009,1394 2013,1393 2018,1392 2022,1392 2027,1391 2031,1390 2036,1389 2040,1388 2045,1388 2049,1387 2054,1386 2058,1385 2063,1384 2067,1384 2072,1383 2076,1382 2081,1381 2085,1380 2090,1380 2094,1379 2099,1378 2103,1377 2108,1376 2112,1376 2117,1375 2121,1374 2126,1373 2130,1373 2135,1372 2139,1371 2144,1370 2148,1369 2153,1369 2157,1368 2162,1367 2166,1366 2171,1365 2175,1365 2180,1364 2184,1363 2189,1362 2193,1361 2198,1361 2202,1360 2207,1359 2211,1358 2216,1357 2220,1357 2225,1356 2229,1355 2234,1354 2238,1354 2243,1353 2247,1352 2252,1351 2256,1350 2261,1350 2265,1349 2270,1348 2274,1347 2279,1346 2283,1346 2288,1345 2292,1344 2297,1343 2301,1342 2306,1342 2310,1341 2315,1340 2319,1339 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2271 772,2265 777,2260 781,2256 786,2253 790,2249 795,2246 799,2244 804,2242 808,2240 813,2239 817,2237 822,2236 826,2235 831,2235 835,2234 840,2234 844,2234 849,2234 853,2234 858,2234 862,2235 867,2235 871,2235 876,2236 880,2237 885,2237 889,2238 894,2239 898,2240 903,2241 907,2242 912,2243 916,2243 921,2242 925,2242 930,2242 934,2241 939,2241 943,2241 948,2241 952,2241 957,2241 961,2240 966,2240 970,2240 975,2240 979,2240 984,2239 988,2239 993,2239 997,2239 1002,2239 1006,2239 1011,2239 1015,2239 1020,2239 1024,2239 1029,2239 1033,2239 1038,2239 1042,2239 1047,2239 1051,2239 1056,2239 1060,2238 1065,2238 1069,2238 1074,2238 1078,2239 1083,2239 1087,2239 1092,2239 1096,2239 1101,2239 1105,2239 1110,2239 1114,2239 1119,2240 1123,2239 1128,2239 1132,2239 1137,2239 1141,2239 1146,2239 1150,2239 1155,2239 1159,2239 1164,2239 1168,2239 1173,2240 1177,2240 1182,2240 1186,2240 1191,2239 1195,2239 1200,2239 1204,2239 1209,2239 1213,2239 1218,2239 1222,2239 1227,2240 1231,2240 1236,2240 1240,2240 1245,2240 1249,2240 1254,2240 1258,2239 1263,2239 1267,2239 1272,2240 1276,2240 1281,2240 1285,2241 1290,2240 1294,2240 1299,2240 1303,2240 1308,2240 1312,2240 1317,2240 1321,2241 1326,2240 1330,2240 1335,2240 1339,2240 1344,2240 1348,2240 1353,2240 1357,2240 1362,2241 1366,2241 1371,2241 1375,2241 1380,2241 1384,2241 1389,2241 1393,2241 1398,2240 1402,2240 1407,2241 1411,2241 1416,2241 1420,2241 1425,2241 1429,2241 1434,2241 1438,2241 1443,2241 1447,2241 1452,2241 1456,2242 1461,2242 1465,2241 1470,2241 1474,2241 1479,2241 1483,2241 1488,2241 1492,2241 1497,2241 1501,2241 1506,2241 1510,2241 1515,2242 1519,2242 1524,2242 1528,2242 1533,2241 1537,2241 1542,2241 1546,2241 1551,2241 1555,2242 1560,2242 1564,2242 1569,2242 1573,2242 1578,2242 1582,2242 1587,2242 1591,2242 1596,2242 1600,2242 1605,2242 1609,2242 1614,2242 1618,2242 1623,2242 1627,2242 1632,2242 1636,2242 1641,2242 1645,2242 1650,2242 1654,2242 1659,2242 1663,2242 1668,2243 1672,2242 1677,2242 1681,2242 1686,2242 1690,2242 1695,2242 1699,2242 1704,2242 1708,2242 1713,2242 1717,2243 1722,2243 1726,2243 1731,2243 1735,2243 1740,2242 1744,2242 1749,2242 1753,2242 1758,2242 1762,2242 1767,2242 1771,2242 1776,2243 1780,2243 1785,2243 1789,2243 1794,2243 1798,2243 1803,2243 1807,2242 1812,2242 1816,2242 1821,2243 1825,2243 1830,2243 1834,2243 1839,2243 1843,2243 1848,2243 1852,2243 1857,2243 1861,2243 1866,2243 1870,2243 1875,2243 1879,2243 1884,2243 1888,2243 1893,2243 1897,2243 1902,2243 1906,2243 1911,2243 1915,2243 1920,2243 1924,2243 1929,2243 1933,2244 1938,2244 1942,2244 1947,2243 1951,2243 1956,2243 1960,2243 1965,2243 1969,2243 1974,2243 1978,2243 1983,2244 1987,2244 1992,2244 1996,2244 2001,2244 2005,2244 2010,2244 2014,2243 2019,2243 2023,2243 2028,2243 2032,2244 2037,2244 2041,2244 2046,2244 2050,2244 2055,2244 2059,2244 2064,2244 2068,2244 2073,2244 2077,2244 2082,2243 2086,2243 2091,2243 2095,2244 2100,2244 2104,2244 2109,2244 2113,2244 2118,2244 2122,2244 2127,2244 2131,2244 2136,2244 2140,2244 2145,2244 2149,2244 2154,2244 2158,2244 2163,2244 2167,2244 2172,2244 2176,2244 2181,2244 2185,2244 2190,2244 2194,2244 2199,2244 2203,2244 2208,2245 2212,2245 2217,2245 2221,2244 2226,2244 2230,2244 2235,2244 2239,2244 2244,2244 2248,2244 2253,2244 2257,2244 2262,2244 2266,2244 2271,2245 2275,2245 2280,2245 2284,2245 2289,2244 2293,2244 2298,2244 2302,2244 2307,2244 2311,2244 2316,2244 2320,2244 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Strong growth, tapering fees_0.000200.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Strong growth, tapering fees_0.000200.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Strong growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,847 129,840 133,833 138,825 142,818 147,811 151,804 156,798 160,791 165,785 169,778 174,772 178,766 183,760 187,754 192,748 196,742 201,736 205,731 210,725 214,720 219,715 223,709 228,704 232,699 237,694 241,689 246,684 250,680 255,675 259,670 264,666 268,661 273,657 277,653 282,648 286,644 291,640 295,636 300,632 304,628 309,624 313,621 318,617 322,613 327,610 331,606 336,603 340,599 345,596 349,593 354,589 358,586 363,583 367,580 372,577 376,574 381,571 385,568 390,565 394,562 399,560 403,557 408,554 412,552 417,549 421,547 426,544 430,542 435,539 439,537 444,534 448,532 453,530 457,528 462,526 466,523 471,521 475,519 480,517 484,515 489,513 493,511 498,509 502,508 506,506 511,504 515,502 520,501 524,499 529,497 533,496 538,494 542,492 547,491 551,489 556,488 560,486 565,485 569,483 574,482 578,481 583,479 587,478 592,477 596,475 601,474 605,473 610,472 614,471 619,469 623,468 628,467 632,466 637,465 641,464 646,463 650,462 655,461 659,460 664,459 668,458 673,457 677,456 682,455 686,455 691,454 695,453 700,452 704,452 709,451 713,450 718,450 722,449 727,448 731,448 736,447 740,447 745,446 749,446 754,446 758,445 763,445 767,444 772,444 776,444 781,443 785,443 790,443 794,442 799,442 803,442 808,441 812,441 817,441 821,441 826,441 830,440 835,440 839,440 844,440 848,440 853,439 857,439 862,439 866,439 871,439 875,439 880,438 884,438 889,438 893,438 898,438 902,438 907,438 911,438 916,438 920,437 925,437 929,437 934,437 938,437 943,437 947,437 952,437 956,437 961,437 965,437 970,437 974,437 979,437 983,436 988,436 992,436 997,436 1001,436 1006,436 1010,436 1015,436 1019,436 1024,436 1028,436 1033,436 1037,436 1042,436 1046,436 1051,436 1055,436 1060,436 1064,436 1069,436 1073,436 1078,436 1082,436 1087,436 1091,436 1096,436 1100,436 1105,436 1109,436 1114,436 1118,436 1123,436 1127,436 1132,436 1136,436 1141,436 1145,436 1150,436 1154,436 1159,436 1163,436 1168,436 1172,435 1177,435 1181,435 1186,435 1190,435 1195,435 1199,435 1204,435 1208,435 1213,435 1217,435 1222,435 1226,435 1231,435 1235,435 1240,435 1244,435 1249,435 1253,435 1258,435 1262,435 1267,435 1271,435 1276,435 1280,435 1285,435 1289,435 1294,435 1298,435 1303,435 1307,435 1312,435 1316,435 1321,435 1325,435 1330,435 1334,435 1339,435 1343,435 1348,435 1352,435 1357,435 1361,435 1366,435 1370,435 1375,435 1379,435 1384,435 1388,435 1393,435 1397,435 1402,435 1406,435 1411,435 1415,435 1420,435 1424,435 1429,435 1433,435 1438,435 1442,435 1447,435 1451,435 1456,435 1460,435 1465,435 1469,435 1474,435 1478,435 1483,435 1487,435 1492,435 1496,435 1501,435 1505,435 1510,435 1514,435 1519,435 1523,435 1528,435 1532,435 1537,435 1541,435 1546,435 1550,435 1555,435 1559,435 1564,435 1568,435 1573,435 1577,435 1582,435 1586,435 1591,435 1595,435 1600,435 1604,435 1609,435 1613,435 1618,435 1622,435 1626,435 1631,435 1635,435 1640,435 1644,435 1649,435 1653,435 1658,435 1662,435 1667,435 1671,435 1676,435 1680,435 1685,435 1689,435 1694,435 1698,435 1703,435 1707,435 1712,435 1716,435 1721,435 1725,435 1730,435 1734,435 1739,435 1743,435 1748,435 1752,435 1757,435 1761,435 1766,435 1770,435 1775,435 1779,435 1784,435 1788,435 1793,435 1797,435 1802,435 1806,435 1811,435 1815,435 1820,435 1824,435 1829,435 1833,435 1838,435 1842,435 1847,435 1851,435 1856,435 1860,435 1865,435 1869,435 1874,435 1878,435 1883,435 1887,435 1892,435 1896,435 1901,435 1905,435 1910,435 1914,435 1919,435 1923,435 1928,435 1932,435 1937,435 1941,435 1946,435 1950,435 1955,435 1959,435 1964,435 1968,435 1973,435 1977,435 1982,435 1986,435 1991,435 1995,435 2000,435 2004,435 2009,435 2013,435 2018,435 2022,435 2027,435 2031,435 2036,435 2040,435 2045,435 2049,435 2054,435 2058,435 2063,435 2067,435 2072,435 2076,435 2081,435 2085,435 2090,435 2094,435 2099,435 2103,435 2108,435 2112,435 2117,435 2121,435 2126,435 2130,435 2135,435 2139,435 2144,435 2148,435 2153,435 2157,435 2162,435 2166,435 2171,435 2175,435 2180,435 2184,435 2189,435 2193,435 2198,435 2202,435 2207,435 2211,435 2216,435 2220,435 2225,435 2229,435 2234,435 2238,435 2243,435 2247,435 2252,435 2256,435 2261,435 2265,435 2270,435 2274,435 2279,435 2283,435 2288,435 2292,435 2297,435 2301,435 2306,435 2310,435 2315,435 2319,435 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2204" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2204 74,2204 "/>
+<text x="65" y="2084" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2084 74,2084 "/>
+<text x="65" y="1963" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1963 74,1963 "/>
+<text x="65" y="1843" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1843 74,1843 "/>
+<text x="65" y="1722" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1722 74,1722 "/>
+<text x="65" y="1602" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1602 74,1602 "/>
+<text x="65" y="1481" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1481 74,1481 "/>
+<text x="65" y="1361" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1361 74,1361 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2016 151,2004 156,1992 160,1981 165,1970 169,1958 174,1947 178,1936 183,1925 187,1915 192,1905 196,1895 201,1885 205,1875 210,1866 214,1857 219,1848 223,1840 228,1832 232,1824 237,1817 241,1810 246,1803 250,1796 255,1790 259,1784 264,1778 268,1773 273,1767 277,1762 282,1758 286,1753 291,1749 295,1745 300,1741 304,1737 309,1733 313,1730 318,1727 322,1724 327,1721 331,1718 336,1715 340,1713 345,1710 349,1708 354,1706 358,1703 363,1701 367,1699 372,1697 376,1696 381,1694 385,1692 390,1690 394,1689 399,1687 403,1686 408,1684 412,1683 417,1682 421,1680 426,1679 430,1678 435,1677 439,1676 444,1674 448,1673 453,1672 457,1671 462,1670 466,1669 471,1668 475,1667 480,1666 484,1665 489,1664 493,1663 498,1662 502,1661 506,1660 511,1659 515,1658 520,1657 524,1657 529,1656 533,1655 538,1654 542,1653 547,1652 551,1651 556,1650 560,1650 565,1649 569,1648 574,1647 578,1646 583,1645 587,1645 592,1644 596,1643 601,1642 605,1641 610,1641 614,1640 619,1639 623,1638 628,1637 632,1636 637,1636 641,1635 646,1634 650,1633 655,1632 659,1632 664,1631 668,1630 673,1629 677,1628 682,1628 686,1627 691,1626 695,1625 700,1624 704,1624 709,1623 713,1622 718,1621 722,1620 727,1620 731,1619 736,1618 740,1617 745,1616 749,1616 754,1615 758,1614 763,1613 767,1612 772,1612 776,1611 781,1610 785,1609 790,1609 794,1608 799,1607 803,1606 808,1605 812,1605 817,1604 821,1603 826,1602 830,1601 835,1601 839,1600 844,1599 848,1598 853,1597 857,1597 862,1596 866,1595 871,1594 875,1593 880,1593 884,1592 889,1591 893,1590 898,1589 902,1589 907,1588 911,1587 916,1586 920,1586 925,1585 929,1584 934,1583 938,1582 943,1582 947,1581 952,1580 956,1579 961,1578 965,1578 970,1577 974,1576 979,1575 983,1574 988,1574 992,1573 997,1572 1001,1571 1006,1570 1010,1570 1015,1569 1019,1568 1024,1567 1028,1567 1033,1566 1037,1565 1042,1564 1046,1563 1051,1563 1055,1562 1060,1561 1064,1560 1069,1559 1073,1559 1078,1558 1082,1557 1087,1556 1091,1555 1096,1555 1100,1554 1105,1553 1109,1552 1114,1551 1118,1551 1123,1550 1127,1549 1132,1548 1136,1548 1141,1547 1145,1546 1150,1545 1154,1544 1159,1544 1163,1543 1168,1542 1172,1541 1177,1540 1181,1540 1186,1539 1190,1538 1195,1537 1199,1536 1204,1536 1208,1535 1213,1534 1217,1533 1222,1532 1226,1532 1231,1531 1235,1530 1240,1529 1244,1529 1249,1528 1253,1527 1258,1526 1262,1525 1267,1525 1271,1524 1276,1523 1280,1522 1285,1521 1289,1521 1294,1520 1298,1519 1303,1518 1307,1517 1312,1517 1316,1516 1321,1515 1325,1514 1330,1513 1334,1513 1339,1512 1343,1511 1348,1510 1352,1510 1357,1509 1361,1508 1366,1507 1370,1506 1375,1506 1379,1505 1384,1504 1388,1503 1393,1502 1397,1502 1402,1501 1406,1500 1411,1499 1415,1498 1420,1498 1424,1497 1429,1496 1433,1495 1438,1494 1442,1494 1447,1493 1451,1492 1456,1491 1460,1491 1465,1490 1469,1489 1474,1488 1478,1487 1483,1487 1487,1486 1492,1485 1496,1484 1501,1483 1505,1483 1510,1482 1514,1481 1519,1480 1523,1479 1528,1479 1532,1478 1537,1477 1541,1476 1546,1475 1550,1475 1555,1474 1559,1473 1564,1472 1568,1471 1573,1471 1577,1470 1582,1469 1586,1468 1591,1468 1595,1467 1600,1466 1604,1465 1609,1464 1613,1464 1618,1463 1622,1462 1626,1461 1631,1460 1635,1460 1640,1459 1644,1458 1649,1457 1653,1456 1658,1456 1662,1455 1667,1454 1671,1453 1676,1452 1680,1452 1685,1451 1689,1450 1694,1449 1698,1449 1703,1448 1707,1447 1712,1446 1716,1445 1721,1445 1725,1444 1730,1443 1734,1442 1739,1441 1743,1441 1748,1440 1752,1439 1757,1438 1761,1437 1766,1437 1770,1436 1775,1435 1779,1434 1784,1433 1788,1433 1793,1432 1797,1431 1802,1430 1806,1430 1811,1429 1815,1428 1820,1427 1824,1426 1829,1426 1833,1425 1838,1424 1842,1423 1847,1422 1851,1422 1856,1421 1860,1420 1865,1419 1869,1418 1874,1418 1878,1417 1883,1416 1887,1415 1892,1414 1896,1414 1901,1413 1905,1412 1910,1411 1914,1411 1919,1410 1923,1409 1928,1408 1932,1407 1937,1407 1941,1406 1946,1405 1950,1404 1955,1403 1959,1403 1964,1402 1968,1401 1973,1400 1977,1399 1982,1399 1986,1398 1991,1397 1995,1396 2000,1395 2004,1395 2009,1394 2013,1393 2018,1392 2022,1392 2027,1391 2031,1390 2036,1389 2040,1388 2045,1388 2049,1387 2054,1386 2058,1385 2063,1384 2067,1384 2072,1383 2076,1382 2081,1381 2085,1380 2090,1380 2094,1379 2099,1378 2103,1377 2108,1376 2112,1376 2117,1375 2121,1374 2126,1373 2130,1373 2135,1372 2139,1371 2144,1370 2148,1369 2153,1369 2157,1368 2162,1367 2166,1366 2171,1365 2175,1365 2180,1364 2184,1363 2189,1362 2193,1361 2198,1361 2202,1360 2207,1359 2211,1358 2216,1357 2220,1357 2225,1356 2229,1355 2234,1354 2238,1354 2243,1353 2247,1352 2252,1351 2256,1350 2261,1350 2265,1349 2270,1348 2274,1347 2279,1346 2283,1346 2288,1345 2292,1344 2297,1343 2301,1342 2306,1342 2310,1341 2315,1340 2319,1339 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2275 682,2272 687,2269 691,2266 696,2263 700,2261 705,2258 709,2256 714,2254 718,2253 723,2251 727,2250 732,2248 736,2247 741,2246 745,2245 750,2244 754,2244 759,2243 763,2242 768,2242 772,2241 777,2241 781,2241 786,2241 790,2240 795,2241 799,2241 804,2241 808,2241 813,2241 817,2241 822,2242 826,2242 831,2242 835,2242 840,2243 844,2244 849,2244 853,2245 858,2245 862,2246 867,2246 871,2247 876,2247 880,2248 885,2249 889,2249 894,2250 898,2251 903,2251 907,2252 912,2253 916,2253 921,2252 925,2252 930,2251 934,2251 939,2250 943,2250 948,2249 952,2249 957,2249 961,2248 966,2248 970,2248 975,2247 979,2247 984,2246 988,2246 993,2245 997,2245 1002,2245 1006,2245 1011,2245 1015,2244 1020,2244 1024,2244 1029,2244 1033,2244 1038,2244 1042,2243 1047,2243 1051,2242 1056,2242 1060,2242 1065,2242 1069,2242 1074,2242 1078,2242 1083,2242 1087,2242 1092,2242 1096,2242 1101,2242 1105,2242 1110,2242 1114,2242 1119,2242 1123,2241 1128,2241 1132,2241 1137,2241 1141,2241 1146,2241 1150,2241 1155,2241 1159,2241 1164,2241 1168,2241 1173,2241 1177,2241 1182,2241 1186,2241 1191,2240 1195,2240 1200,2240 1204,2240 1209,2240 1213,2240 1218,2240 1222,2241 1227,2241 1231,2241 1236,2241 1240,2241 1245,2241 1249,2241 1254,2241 1258,2240 1263,2240 1267,2240 1272,2240 1276,2240 1281,2241 1285,2240 1290,2240 1294,2240 1299,2241 1303,2241 1308,2241 1312,2241 1317,2241 1321,2241 1326,2240 1330,2240 1335,2240 1339,2240 1344,2240 1348,2241 1353,2241 1357,2241 1362,2241 1366,2241 1371,2241 1375,2241 1380,2241 1384,2241 1389,2241 1393,2241 1398,2240 1402,2240 1407,2240 1411,2241 1416,2241 1420,2241 1425,2241 1429,2241 1434,2241 1438,2241 1443,2242 1447,2241 1452,2241 1456,2241 1461,2241 1465,2241 1470,2241 1474,2241 1479,2241 1483,2241 1488,2241 1492,2241 1497,2241 1501,2241 1506,2241 1510,2241 1515,2242 1519,2242 1524,2242 1528,2242 1533,2241 1537,2241 1542,2241 1546,2241 1551,2241 1555,2241 1560,2242 1564,2242 1569,2242 1573,2242 1578,2242 1582,2242 1587,2242 1591,2242 1596,2242 1600,2241 1605,2242 1609,2242 1614,2242 1618,2242 1623,2242 1627,2242 1632,2242 1636,2242 1641,2242 1645,2242 1650,2242 1654,2242 1659,2242 1663,2242 1668,2243 1672,2242 1677,2242 1681,2242 1686,2242 1690,2242 1695,2242 1699,2242 1704,2242 1708,2243 1713,2242 1717,2243 1722,2243 1726,2243 1731,2243 1735,2243 1740,2242 1744,2243 1749,2242 1753,2242 1758,2242 1762,2242 1767,2242 1771,2243 1776,2243 1780,2243 1785,2243 1789,2243 1794,2243 1798,2243 1803,2243 1807,2242 1812,2242 1816,2243 1821,2243 1825,2243 1830,2243 1834,2243 1839,2243 1843,2243 1848,2243 1852,2243 1857,2243 1861,2243 1866,2243 1870,2243 1875,2243 1879,2243 1884,2243 1888,2243 1893,2243 1897,2243 1902,2243 1906,2243 1911,2243 1915,2243 1920,2243 1924,2243 1929,2244 1933,2244 1938,2244 1942,2244 1947,2243 1951,2243 1956,2243 1960,2243 1965,2243 1969,2243 1974,2243 1978,2243 1983,2244 1987,2244 1992,2244 1996,2244 2001,2244 2005,2244 2010,2244 2014,2243 2019,2243 2023,2243 2028,2243 2032,2243 2037,2244 2041,2244 2046,2244 2050,2244 2055,2244 2059,2244 2064,2244 2068,2244 2073,2244 2077,2244 2082,2243 2086,2243 2091,2244 2095,2244 2100,2244 2104,2244 2109,2244 2113,2244 2118,2244 2122,2244 2127,2244 2131,2244 2136,2244 2140,2244 2145,2244 2149,2244 2154,2244 2158,2244 2163,2244 2167,2244 2172,2244 2176,2244 2181,2244 2185,2244 2190,2244 2194,2244 2199,2244 2203,2244 2208,2244 2212,2245 2217,2245 2221,2244 2226,2244 2230,2244 2235,2244 2239,2244 2244,2244 2248,2244 2253,2244 2257,2244 2262,2245 2266,2245 2271,2245 2275,2245 2280,2245 2284,2245 2289,2244 2293,2244 2298,2244 2302,2244 2307,2244 2311,2244 2316,2244 2320,2245 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Strong growth, tapering fees_0.000300.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Strong growth, tapering fees_0.000300.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Strong growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,920 88,912 93,903 97,895 102,887 106,879 111,871 115,863 120,855 124,847 129,840 133,833 138,825 142,818 147,811 151,804 156,798 160,791 165,785 169,778 174,772 178,766 183,760 187,754 192,748 196,742 201,736 205,731 210,725 214,720 219,715 223,709 228,704 232,699 237,694 241,689 246,684 250,680 255,675 259,670 264,666 268,661 273,657 277,653 282,648 286,644 291,640 295,636 300,632 304,628 309,624 313,621 318,617 322,613 327,610 331,606 336,603 340,599 345,596 349,593 354,589 358,586 363,583 367,580 372,577 376,574 381,571 385,568 390,565 394,562 399,560 403,557 408,554 412,552 417,549 421,547 426,544 430,542 435,539 439,537 444,534 448,532 453,530 457,528 462,526 466,523 471,521 475,519 480,517 484,515 489,513 493,511 498,509 502,508 506,506 511,504 515,502 520,501 524,499 529,497 533,496 538,494 542,492 547,491 551,489 556,488 560,486 565,485 569,484 574,482 578,481 583,480 587,478 592,477 596,476 601,475 605,474 610,473 614,472 619,471 623,470 628,469 632,468 637,467 641,466 646,465 650,464 655,464 659,463 664,462 668,461 673,461 677,460 682,459 686,459 691,458 695,457 700,457 704,456 709,456 713,455 718,454 722,454 727,453 731,453 736,452 740,452 745,451 749,451 754,451 758,450 763,450 767,449 772,449 776,449 781,448 785,448 790,448 794,447 799,447 803,447 808,446 812,446 817,446 821,445 826,445 830,445 835,445 839,444 844,444 848,444 853,444 857,443 862,443 866,443 871,443 875,442 880,442 884,442 889,442 893,442 898,442 902,441 907,441 911,441 916,441 920,441 925,441 929,440 934,440 938,440 943,440 947,440 952,440 956,440 961,440 965,439 970,439 974,439 979,439 983,439 988,439 992,439 997,439 1001,439 1006,438 1010,438 1015,438 1019,438 1024,438 1028,438 1033,438 1037,438 1042,438 1046,438 1051,438 1055,438 1060,438 1064,437 1069,437 1073,437 1078,437 1082,437 1087,437 1091,437 1096,437 1100,437 1105,437 1109,437 1114,437 1118,437 1123,437 1127,437 1132,437 1136,437 1141,437 1145,437 1150,437 1154,437 1159,437 1163,436 1168,436 1172,436 1177,436 1181,436 1186,436 1190,436 1195,436 1199,436 1204,436 1208,436 1213,436 1217,436 1222,436 1226,436 1231,436 1235,436 1240,436 1244,436 1249,436 1253,436 1258,436 1262,436 1267,436 1271,436 1276,436 1280,436 1285,436 1289,436 1294,436 1298,436 1303,436 1307,436 1312,436 1316,436 1321,436 1325,436 1330,436 1334,436 1339,436 1343,436 1348,436 1352,436 1357,436 1361,436 1366,436 1370,436 1375,436 1379,436 1384,436 1388,436 1393,436 1397,436 1402,436 1406,436 1411,436 1415,436 1420,436 1424,436 1429,436 1433,436 1438,436 1442,436 1447,435 1451,435 1456,435 1460,435 1465,435 1469,435 1474,435 1478,435 1483,435 1487,435 1492,435 1496,435 1501,435 1505,435 1510,435 1514,435 1519,435 1523,435 1528,435 1532,435 1537,435 1541,435 1546,435 1550,435 1555,435 1559,435 1564,435 1568,435 1573,435 1577,435 1582,435 1586,435 1591,435 1595,435 1600,435 1604,435 1609,435 1613,435 1618,435 1622,435 1626,435 1631,435 1635,435 1640,435 1644,435 1649,435 1653,435 1658,435 1662,435 1667,435 1671,435 1676,435 1680,435 1685,435 1689,435 1694,435 1698,435 1703,435 1707,435 1712,435 1716,435 1721,435 1725,435 1730,435 1734,435 1739,435 1743,435 1748,435 1752,435 1757,435 1761,435 1766,435 1770,435 1775,435 1779,435 1784,435 1788,435 1793,435 1797,435 1802,435 1806,435 1811,435 1815,435 1820,435 1824,435 1829,435 1833,435 1838,435 1842,435 1847,435 1851,435 1856,435 1860,435 1865,435 1869,435 1874,435 1878,435 1883,435 1887,435 1892,435 1896,435 1901,435 1905,435 1910,435 1914,435 1919,435 1923,435 1928,435 1932,435 1937,435 1941,435 1946,435 1950,435 1955,435 1959,435 1964,435 1968,435 1973,435 1977,435 1982,435 1986,435 1991,435 1995,435 2000,435 2004,435 2009,435 2013,435 2018,435 2022,435 2027,435 2031,435 2036,435 2040,435 2045,435 2049,435 2054,435 2058,435 2063,435 2067,435 2072,435 2076,435 2081,435 2085,435 2090,435 2094,435 2099,435 2103,435 2108,435 2112,435 2117,435 2121,435 2126,435 2130,435 2135,435 2139,435 2144,435 2148,435 2153,435 2157,435 2162,435 2166,435 2171,435 2175,435 2180,435 2184,435 2189,435 2193,435 2198,435 2202,435 2207,435 2211,435 2216,435 2220,435 2225,435 2229,435 2234,435 2238,435 2243,435 2247,435 2252,435 2256,435 2261,435 2265,435 2270,435 2274,435 2279,435 2283,435 2288,435 2292,435 2297,435 2301,435 2306,435 2310,435 2315,435 2319,435 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2204" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2204 74,2204 "/>
+<text x="65" y="2084" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2084 74,2084 "/>
+<text x="65" y="1963" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1963 74,1963 "/>
+<text x="65" y="1843" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1843 74,1843 "/>
+<text x="65" y="1722" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1722 74,1722 "/>
+<text x="65" y="1602" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1602 74,1602 "/>
+<text x="65" y="1481" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1481 74,1481 "/>
+<text x="65" y="1361" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1361 74,1361 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2016 151,2004 156,1992 160,1981 165,1970 169,1958 174,1947 178,1936 183,1925 187,1915 192,1905 196,1895 201,1885 205,1875 210,1866 214,1857 219,1848 223,1840 228,1832 232,1824 237,1817 241,1810 246,1803 250,1796 255,1790 259,1784 264,1778 268,1773 273,1767 277,1762 282,1758 286,1753 291,1749 295,1745 300,1741 304,1737 309,1733 313,1730 318,1727 322,1724 327,1721 331,1718 336,1715 340,1713 345,1710 349,1708 354,1706 358,1703 363,1701 367,1699 372,1697 376,1696 381,1694 385,1692 390,1690 394,1689 399,1687 403,1686 408,1684 412,1683 417,1682 421,1680 426,1679 430,1678 435,1677 439,1676 444,1674 448,1673 453,1672 457,1671 462,1670 466,1669 471,1668 475,1667 480,1666 484,1665 489,1664 493,1663 498,1662 502,1661 506,1660 511,1659 515,1658 520,1657 524,1657 529,1656 533,1655 538,1654 542,1653 547,1652 551,1651 556,1650 560,1650 565,1649 569,1648 574,1647 578,1646 583,1645 587,1645 592,1644 596,1643 601,1642 605,1641 610,1641 614,1640 619,1639 623,1638 628,1637 632,1636 637,1636 641,1635 646,1634 650,1633 655,1632 659,1632 664,1631 668,1630 673,1629 677,1628 682,1628 686,1627 691,1626 695,1625 700,1624 704,1624 709,1623 713,1622 718,1621 722,1620 727,1620 731,1619 736,1618 740,1617 745,1616 749,1616 754,1615 758,1614 763,1613 767,1612 772,1612 776,1611 781,1610 785,1609 790,1609 794,1608 799,1607 803,1606 808,1605 812,1605 817,1604 821,1603 826,1602 830,1601 835,1601 839,1600 844,1599 848,1598 853,1597 857,1597 862,1596 866,1595 871,1594 875,1593 880,1593 884,1592 889,1591 893,1590 898,1589 902,1589 907,1588 911,1587 916,1586 920,1586 925,1585 929,1584 934,1583 938,1582 943,1582 947,1581 952,1580 956,1579 961,1578 965,1578 970,1577 974,1576 979,1575 983,1574 988,1574 992,1573 997,1572 1001,1571 1006,1570 1010,1570 1015,1569 1019,1568 1024,1567 1028,1567 1033,1566 1037,1565 1042,1564 1046,1563 1051,1563 1055,1562 1060,1561 1064,1560 1069,1559 1073,1559 1078,1558 1082,1557 1087,1556 1091,1555 1096,1555 1100,1554 1105,1553 1109,1552 1114,1551 1118,1551 1123,1550 1127,1549 1132,1548 1136,1548 1141,1547 1145,1546 1150,1545 1154,1544 1159,1544 1163,1543 1168,1542 1172,1541 1177,1540 1181,1540 1186,1539 1190,1538 1195,1537 1199,1536 1204,1536 1208,1535 1213,1534 1217,1533 1222,1532 1226,1532 1231,1531 1235,1530 1240,1529 1244,1529 1249,1528 1253,1527 1258,1526 1262,1525 1267,1525 1271,1524 1276,1523 1280,1522 1285,1521 1289,1521 1294,1520 1298,1519 1303,1518 1307,1517 1312,1517 1316,1516 1321,1515 1325,1514 1330,1513 1334,1513 1339,1512 1343,1511 1348,1510 1352,1510 1357,1509 1361,1508 1366,1507 1370,1506 1375,1506 1379,1505 1384,1504 1388,1503 1393,1502 1397,1502 1402,1501 1406,1500 1411,1499 1415,1498 1420,1498 1424,1497 1429,1496 1433,1495 1438,1494 1442,1494 1447,1493 1451,1492 1456,1491 1460,1491 1465,1490 1469,1489 1474,1488 1478,1487 1483,1487 1487,1486 1492,1485 1496,1484 1501,1483 1505,1483 1510,1482 1514,1481 1519,1480 1523,1479 1528,1479 1532,1478 1537,1477 1541,1476 1546,1475 1550,1475 1555,1474 1559,1473 1564,1472 1568,1471 1573,1471 1577,1470 1582,1469 1586,1468 1591,1468 1595,1467 1600,1466 1604,1465 1609,1464 1613,1464 1618,1463 1622,1462 1626,1461 1631,1460 1635,1460 1640,1459 1644,1458 1649,1457 1653,1456 1658,1456 1662,1455 1667,1454 1671,1453 1676,1452 1680,1452 1685,1451 1689,1450 1694,1449 1698,1449 1703,1448 1707,1447 1712,1446 1716,1445 1721,1445 1725,1444 1730,1443 1734,1442 1739,1441 1743,1441 1748,1440 1752,1439 1757,1438 1761,1437 1766,1437 1770,1436 1775,1435 1779,1434 1784,1433 1788,1433 1793,1432 1797,1431 1802,1430 1806,1430 1811,1429 1815,1428 1820,1427 1824,1426 1829,1426 1833,1425 1838,1424 1842,1423 1847,1422 1851,1422 1856,1421 1860,1420 1865,1419 1869,1418 1874,1418 1878,1417 1883,1416 1887,1415 1892,1414 1896,1414 1901,1413 1905,1412 1910,1411 1914,1411 1919,1410 1923,1409 1928,1408 1932,1407 1937,1407 1941,1406 1946,1405 1950,1404 1955,1403 1959,1403 1964,1402 1968,1401 1973,1400 1977,1399 1982,1399 1986,1398 1991,1397 1995,1396 2000,1395 2004,1395 2009,1394 2013,1393 2018,1392 2022,1392 2027,1391 2031,1390 2036,1389 2040,1388 2045,1388 2049,1387 2054,1386 2058,1385 2063,1384 2067,1384 2072,1383 2076,1382 2081,1381 2085,1380 2090,1380 2094,1379 2099,1378 2103,1377 2108,1376 2112,1376 2117,1375 2121,1374 2126,1373 2130,1373 2135,1372 2139,1371 2144,1370 2148,1369 2153,1369 2157,1368 2162,1367 2166,1366 2171,1365 2175,1365 2180,1364 2184,1363 2189,1362 2193,1361 2198,1361 2202,1360 2207,1359 2211,1358 2216,1357 2220,1357 2225,1356 2229,1355 2234,1354 2238,1354 2243,1353 2247,1352 2252,1351 2256,1350 2261,1350 2265,1349 2270,1348 2274,1347 2279,1346 2283,1346 2288,1345 2292,1344 2297,1343 2301,1342 2306,1342 2310,1341 2315,1340 2319,1339 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2273 561,2270 565,2268 570,2266 574,2264 579,2262 583,2260 588,2258 592,2256 597,2255 601,2253 606,2252 610,2251 615,2249 619,2249 624,2247 628,2246 633,2246 637,2245 642,2244 646,2244 651,2243 655,2242 660,2242 664,2241 669,2241 673,2241 678,2241 682,2241 687,2241 691,2240 696,2241 700,2241 705,2241 709,2240 714,2241 718,2241 723,2241 727,2241 732,2241 736,2242 741,2242 745,2242 750,2243 754,2243 759,2243 763,2244 768,2244 772,2245 777,2245 781,2246 786,2246 790,2246 795,2247 799,2247 804,2248 808,2249 813,2250 817,2250 822,2251 826,2251 831,2252 835,2252 840,2253 844,2254 849,2254 853,2255 858,2255 862,2256 867,2257 871,2258 876,2258 880,2259 885,2260 889,2260 894,2261 898,2262 903,2262 907,2263 912,2264 916,2264 921,2263 925,2262 930,2261 934,2261 939,2260 943,2260 948,2259 952,2258 957,2258 961,2258 966,2257 970,2257 975,2256 979,2256 984,2254 988,2254 993,2254 997,2253 1002,2253 1006,2253 1011,2252 1015,2252 1020,2252 1024,2251 1029,2251 1033,2251 1038,2251 1042,2250 1047,2250 1051,2249 1056,2249 1060,2249 1065,2248 1069,2248 1074,2248 1078,2248 1083,2248 1087,2247 1092,2247 1096,2247 1101,2247 1105,2247 1110,2247 1114,2247 1119,2247 1123,2246 1128,2246 1132,2246 1137,2245 1141,2245 1146,2245 1150,2245 1155,2244 1159,2245 1164,2245 1168,2245 1173,2245 1177,2244 1182,2244 1186,2245 1191,2243 1195,2243 1200,2244 1204,2244 1209,2243 1213,2243 1218,2243 1222,2244 1227,2244 1231,2243 1236,2243 1240,2243 1245,2243 1249,2243 1254,2243 1258,2242 1263,2242 1267,2242 1272,2242 1276,2242 1281,2243 1285,2243 1290,2243 1294,2243 1299,2243 1303,2243 1308,2244 1312,2244 1317,2244 1321,2244 1326,2243 1330,2243 1335,2243 1339,2243 1344,2243 1348,2243 1353,2244 1357,2244 1362,2243 1366,2243 1371,2244 1375,2244 1380,2243 1384,2243 1389,2243 1393,2244 1398,2243 1402,2242 1407,2243 1411,2243 1416,2243 1420,2243 1425,2243 1429,2242 1434,2243 1438,2243 1443,2243 1447,2243 1452,2243 1456,2243 1461,2243 1465,2242 1470,2242 1474,2242 1479,2242 1483,2242 1488,2242 1492,2242 1497,2242 1501,2242 1506,2242 1510,2242 1515,2242 1519,2243 1524,2243 1528,2243 1533,2242 1537,2242 1542,2242 1546,2242 1551,2242 1555,2242 1560,2242 1564,2242 1569,2242 1573,2242 1578,2243 1582,2243 1587,2243 1591,2243 1596,2243 1600,2242 1605,2241 1609,2242 1614,2242 1618,2242 1623,2242 1627,2242 1632,2242 1636,2242 1641,2242 1645,2242 1650,2242 1654,2242 1659,2242 1663,2242 1668,2243 1672,2242 1677,2242 1681,2242 1686,2242 1690,2242 1695,2242 1699,2242 1704,2242 1708,2243 1713,2243 1717,2242 1722,2243 1726,2243 1731,2243 1735,2243 1740,2242 1744,2242 1749,2242 1753,2242 1758,2242 1762,2242 1767,2243 1771,2243 1776,2243 1780,2243 1785,2243 1789,2243 1794,2243 1798,2243 1803,2243 1807,2242 1812,2243 1816,2243 1821,2243 1825,2243 1830,2243 1834,2243 1839,2243 1843,2243 1848,2243 1852,2243 1857,2243 1861,2243 1866,2243 1870,2243 1875,2243 1879,2243 1884,2243 1888,2243 1893,2243 1897,2243 1902,2243 1906,2243 1911,2243 1915,2243 1920,2243 1924,2243 1929,2243 1933,2244 1938,2244 1942,2244 1947,2243 1951,2243 1956,2243 1960,2243 1965,2243 1969,2244 1974,2243 1978,2243 1983,2244 1987,2244 1992,2244 1996,2244 2001,2244 2005,2244 2010,2244 2014,2243 2019,2243 2023,2243 2028,2243 2032,2243 2037,2243 2041,2244 2046,2244 2050,2244 2055,2244 2059,2244 2064,2244 2068,2244 2073,2244 2077,2244 2082,2243 2086,2243 2091,2244 2095,2244 2100,2244 2104,2244 2109,2244 2113,2244 2118,2244 2122,2244 2127,2244 2131,2244 2136,2244 2140,2244 2145,2244 2149,2244 2154,2244 2158,2244 2163,2244 2167,2244 2172,2244 2176,2244 2181,2244 2185,2244 2190,2244 2194,2244 2199,2244 2203,2244 2208,2244 2212,2245 2217,2245 2221,2244 2226,2244 2230,2244 2235,2244 2239,2244 2244,2244 2248,2244 2253,2244 2257,2244 2262,2245 2266,2245 2271,2245 2275,2245 2280,2245 2284,2245 2289,2244 2293,2244 2298,2244 2302,2244 2307,2245 2311,2245 2316,2245 2320,2245 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, high frequency_0.000100.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, high frequency_0.000100.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, high frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,921 88,913 93,905 97,897 102,890 106,882 111,874 115,867 120,860 124,853 129,846 133,839 138,832 142,825 147,819 151,812 156,806 160,800 165,794 169,788 174,782 178,776 183,770 187,764 192,759 196,753 201,748 205,743 210,738 214,732 219,727 223,722 228,718 232,713 237,708 241,703 246,699 250,694 255,690 259,686 264,681 268,677 273,673 277,669 282,665 286,661 291,657 295,653 300,650 304,646 309,642 313,639 318,635 322,632 327,629 331,625 336,622 340,619 345,616 349,613 354,610 358,607 363,604 367,601 372,598 376,595 381,593 385,590 390,587 394,585 399,582 403,580 408,577 412,575 417,573 421,570 426,568 430,566 435,564 439,561 444,559 448,557 453,555 457,553 462,551 466,549 471,548 475,546 480,544 484,542 489,540 493,539 498,537 502,535 506,534 511,532 515,531 520,529 524,528 529,526 533,525 538,523 542,522 547,521 551,519 556,518 560,517 565,515 569,514 574,513 578,512 583,511 587,510 592,509 596,508 601,507 605,506 610,505 614,504 619,503 623,502 628,501 632,500 637,499 641,498 646,497 650,497 655,496 659,495 664,494 668,494 673,493 677,492 682,491 686,491 691,490 695,490 700,489 704,488 709,488 713,487 718,487 722,486 727,486 731,485 736,485 740,484 745,484 749,483 754,483 758,482 763,482 767,482 772,481 776,481 781,481 785,480 790,480 794,480 799,479 803,479 808,479 812,478 817,478 821,478 826,478 830,477 835,477 839,477 844,477 848,477 853,477 857,476 862,476 866,476 871,476 875,476 880,476 884,476 889,475 893,475 898,475 902,475 907,475 911,475 916,475 920,475 925,475 929,475 934,475 938,475 943,475 947,475 952,475 956,475 961,475 965,475 970,474 974,474 979,474 983,474 988,474 992,474 997,474 1001,474 1006,474 1010,474 1015,474 1019,474 1024,474 1028,474 1033,474 1037,474 1042,474 1046,474 1051,474 1055,473 1060,473 1064,473 1069,473 1073,473 1078,473 1082,473 1087,473 1091,473 1096,473 1100,473 1105,473 1109,473 1114,473 1118,473 1123,473 1127,473 1132,472 1136,472 1141,472 1145,472 1150,472 1154,472 1159,472 1163,472 1168,472 1172,472 1177,472 1181,472 1186,472 1190,472 1195,472 1199,472 1204,471 1208,471 1213,471 1217,471 1222,471 1226,471 1231,471 1235,471 1240,471 1244,471 1249,471 1253,471 1258,471 1262,471 1267,470 1271,470 1276,470 1280,470 1285,470 1289,470 1294,470 1298,470 1303,470 1307,470 1312,470 1316,470 1321,470 1325,469 1330,469 1334,469 1339,469 1343,469 1348,469 1352,469 1357,469 1361,469 1366,469 1370,469 1375,469 1379,469 1384,468 1388,468 1393,468 1397,468 1402,468 1406,468 1411,468 1415,468 1420,468 1424,468 1429,468 1433,467 1438,467 1442,467 1447,467 1451,467 1456,467 1460,467 1465,467 1469,467 1474,467 1478,467 1483,467 1487,466 1492,466 1496,466 1501,466 1505,466 1510,466 1514,466 1519,466 1523,466 1528,466 1532,466 1537,465 1541,465 1546,465 1550,465 1555,465 1559,465 1564,465 1568,465 1573,465 1577,465 1582,464 1586,464 1591,464 1595,464 1600,464 1604,464 1609,464 1613,464 1618,464 1622,464 1626,463 1631,463 1635,463 1640,463 1644,463 1649,463 1653,463 1658,463 1662,463 1667,462 1671,462 1676,462 1680,462 1685,462 1689,462 1694,462 1698,462 1703,462 1707,462 1712,461 1716,461 1721,461 1725,461 1730,461 1734,461 1739,461 1743,461 1748,461 1752,460 1757,460 1761,460 1766,460 1770,460 1775,460 1779,460 1784,460 1788,460 1793,459 1797,459 1802,459 1806,459 1811,459 1815,459 1820,459 1824,459 1829,458 1833,458 1838,458 1842,458 1847,458 1851,458 1856,458 1860,458 1865,458 1869,457 1874,457 1878,457 1883,457 1887,457 1892,457 1896,457 1901,456 1905,456 1910,456 1914,456 1919,456 1923,456 1928,456 1932,456 1937,455 1941,455 1946,455 1950,455 1955,455 1959,455 1964,455 1968,455 1973,454 1977,454 1982,454 1986,454 1991,454 1995,454 2000,454 2004,454 2009,453 2013,453 2018,453 2022,453 2027,453 2031,453 2036,453 2040,452 2045,452 2049,452 2054,452 2058,452 2063,452 2067,452 2072,451 2076,451 2081,451 2085,451 2090,451 2094,451 2099,451 2103,450 2108,450 2112,450 2117,450 2121,450 2126,450 2130,450 2135,449 2139,449 2144,449 2148,449 2153,449 2157,449 2162,449 2166,448 2171,448 2175,448 2180,448 2184,448 2189,448 2193,447 2198,447 2202,447 2207,447 2211,447 2216,447 2220,447 2225,446 2229,446 2234,446 2238,446 2243,446 2247,446 2252,445 2256,445 2261,445 2265,445 2270,445 2274,445 2279,444 2283,444 2288,444 2292,444 2297,444 2301,444 2306,444 2310,443 2315,443 2319,443 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2225 74,2225 "/>
+<text x="65" y="2125" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2125 74,2125 "/>
+<text x="65" y="2025" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2025 74,2025 "/>
+<text x="65" y="1925" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1925 74,1925 "/>
+<text x="65" y="1825" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1825 74,1825 "/>
+<text x="65" y="1725" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1725 74,1725 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+14M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1526" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1526 74,1526 "/>
+<text x="65" y="1426" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+18M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1426 74,1426 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1609 79,2312 84,1825 88,1338 93,2042 97,2216 102,1435 106,1609 111,2312 115,1825 120,1338 124,2042 129,2216 133,1435 138,1609 142,2312 147,1825 151,1338 156,2042 160,2216 165,1435 169,1609 174,2312 178,1825 183,1338 187,2042 192,2216 196,1435 201,1609 205,2312 210,1825 214,1338 219,2042 223,2216 228,1435 232,1609 237,2312 241,1825 246,1338 250,2042 255,2216 259,1435 264,1609 268,2312 273,1825 277,1338 282,2042 286,2216 291,1435 295,1609 300,2312 304,1825 309,1338 313,2042 318,2216 322,1435 327,1609 331,2312 336,1825 340,1338 345,2042 349,2216 354,1435 358,1609 363,2312 367,1825 372,1338 376,2042 381,2216 385,1435 390,1609 394,2312 399,1825 403,1338 408,2042 412,2216 417,1435 421,1609 426,2312 430,1825 435,1338 439,2042 444,2216 448,1435 453,1609 457,2312 462,1825 466,1338 471,2042 475,2216 480,1435 484,1609 489,2312 493,1825 498,1338 502,2042 506,2216 511,1435 515,1609 520,2312 524,1825 529,1338 533,2042 538,2216 542,1435 547,1609 551,2312 556,1825 560,1338 565,2042 569,2216 574,1435 578,1609 583,2312 587,1825 592,1338 596,2042 601,2216 605,1435 610,1609 614,2312 619,1825 623,1338 628,2042 632,2216 637,1435 641,1609 646,2312 650,1825 655,1338 659,2042 664,2216 668,1435 673,1609 677,2312 682,1825 686,1338 691,2042 695,2216 700,1435 704,1609 709,2312 713,1825 718,1338 722,2042 727,2216 731,1435 736,1609 740,2312 745,1825 749,1338 754,2042 758,2216 763,1435 767,1609 772,2312 776,1825 781,1338 785,2042 790,2216 794,1435 799,1609 803,2312 808,1825 812,1338 817,2042 821,2216 826,1435 830,1609 835,2312 839,1825 844,1338 848,2042 853,2216 857,1435 862,1609 866,2312 871,1825 875,1338 880,2042 884,2216 889,1435 893,1609 898,2312 902,1825 907,1338 911,2042 916,2216 920,1435 925,1609 929,2312 934,1825 938,1338 943,2042 947,2216 952,1435 956,1609 961,2312 965,1825 970,1338 974,2042 979,2216 983,1435 988,1609 992,2312 997,1825 1001,1338 1006,2042 1010,2216 1015,1435 1019,1609 1024,2312 1028,1825 1033,1338 1037,2042 1042,2216 1046,1435 1051,1609 1055,2312 1060,1825 1064,1338 1069,2042 1073,2216 1078,1435 1082,1609 1087,2312 1091,1825 1096,1338 1100,2042 1105,2216 1109,1435 1114,1609 1118,2312 1123,1825 1127,1338 1132,2042 1136,2216 1141,1435 1145,1609 1150,2312 1154,1825 1159,1338 1163,2042 1168,2216 1172,1435 1177,1609 1181,2312 1186,1825 1190,1338 1195,2042 1199,2216 1204,1435 1208,1609 1213,2312 1217,1825 1222,1338 1226,2042 1231,2216 1235,1435 1240,1609 1244,2312 1249,1825 1253,1338 1258,2042 1262,2216 1267,1435 1271,1609 1276,2312 1280,1825 1285,1338 1289,2042 1294,2216 1298,1435 1303,1609 1307,2312 1312,1825 1316,1338 1321,2042 1325,2216 1330,1435 1334,1609 1339,2312 1343,1825 1348,1338 1352,2042 1357,2216 1361,1435 1366,1609 1370,2312 1375,1825 1379,1338 1384,2042 1388,2216 1393,1435 1397,1609 1402,2312 1406,1825 1411,1338 1415,2042 1420,2216 1424,1435 1429,1609 1433,2312 1438,1825 1442,1338 1447,2042 1451,2216 1456,1435 1460,1609 1465,2312 1469,1825 1474,1338 1478,2042 1483,2216 1487,1435 1492,1609 1496,2312 1501,1825 1505,1338 1510,2042 1514,2216 1519,1435 1523,1609 1528,2312 1532,1825 1537,1338 1541,2042 1546,2216 1550,1435 1555,1609 1559,2312 1564,1825 1568,1338 1573,2042 1577,2216 1582,1435 1586,1609 1591,2312 1595,1825 1600,1338 1604,2042 1609,2216 1613,1435 1618,1609 1622,2312 1626,1825 1631,1338 1635,2042 1640,2216 1644,1435 1649,1609 1653,2312 1658,1825 1662,1338 1667,2042 1671,2216 1676,1435 1680,1609 1685,2312 1689,1825 1694,1338 1698,2042 1703,2216 1707,1435 1712,1609 1716,2312 1721,1825 1725,1338 1730,2042 1734,2216 1739,1435 1743,1609 1748,2312 1752,1825 1757,1338 1761,2042 1766,2216 1770,1435 1775,1609 1779,2312 1784,1825 1788,1338 1793,2042 1797,2216 1802,1435 1806,1609 1811,2312 1815,1825 1820,1338 1824,2042 1829,2216 1833,1435 1838,1609 1842,2312 1847,1825 1851,1338 1856,2042 1860,2216 1865,1435 1869,1609 1874,2312 1878,1825 1883,1338 1887,2042 1892,2216 1896,1435 1901,1609 1905,2312 1910,1825 1914,1338 1919,2042 1923,2216 1928,1435 1932,1609 1937,2312 1941,1825 1946,1338 1950,2042 1955,2216 1959,1435 1964,1609 1968,2312 1973,1825 1977,1338 1982,2042 1986,2216 1991,1435 1995,1609 2000,2312 2004,1825 2009,1338 2013,2042 2018,2216 2022,1435 2027,1609 2031,2312 2036,1825 2040,1338 2045,2042 2049,2216 2054,1435 2058,1609 2063,2312 2067,1825 2072,1338 2076,2042 2081,2216 2085,1435 2090,1609 2094,2312 2099,1825 2103,1338 2108,2042 2112,2216 2117,1435 2121,1609 2126,2312 2130,1825 2135,1338 2139,2042 2144,2216 2148,1435 2153,1609 2157,2312 2162,1825 2166,1338 2171,2042 2175,2216 2180,1435 2184,1609 2189,2312 2193,1825 2198,1338 2202,2042 2207,2216 2211,1435 2216,1609 2220,2312 2225,1825 2229,1338 2234,2042 2238,2216 2243,1435 2247,1609 2252,2312 2256,1825 2261,1338 2265,2042 2270,2216 2274,1435 2279,1609 2283,2312 2288,1825 2292,1338 2297,2042 2301,2216 2306,1435 2310,1609 2315,2312 2319,1825 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2276 1762,2276 1767,2276 1771,2276 1776,2276 1780,2276 1785,2276 1789,2276 1794,2276 1798,2276 1803,2276 1807,2276 1812,2276 1816,2276 1821,2276 1825,2276 1830,2276 1834,2276 1839,2276 1843,2276 1848,2276 1852,2276 1857,2276 1861,2276 1866,2276 1870,2276 1875,2276 1879,2276 1884,2276 1888,2276 1893,2276 1897,2276 1902,2276 1906,2276 1911,2276 1915,2276 1920,2276 1924,2276 1929,2276 1933,2276 1938,2276 1942,2276 1947,2276 1951,2276 1956,2276 1960,2276 1965,2276 1969,2276 1974,2276 1978,2276 1983,2276 1987,2276 1992,2276 1996,2276 2001,2276 2005,2276 2010,2276 2014,2276 2019,2276 2023,2276 2028,2276 2032,2276 2037,2276 2041,2276 2046,2276 2050,2276 2055,2276 2059,2276 2064,2276 2068,2276 2073,2276 2077,2276 2082,2276 2086,2276 2091,2276 2095,2276 2100,2276 2104,2276 2109,2276 2113,2276 2118,2276 2122,2276 2127,2276 2131,2276 2136,2276 2140,2276 2145,2276 2149,2276 2154,2276 2158,2276 2163,2276 2167,2276 2172,2276 2176,2276 2181,2276 2185,2276 2190,2276 2194,2276 2199,2276 2203,2276 2208,2276 2212,2276 2217,2276 2221,2276 2226,2276 2230,2276 2235,2276 2239,2276 2244,2276 2248,2276 2253,2276 2257,2276 2262,2276 2266,2276 2271,2276 2275,2276 2280,2276 2284,2276 2289,2276 2293,2276 2298,2276 2302,2276 2307,2276 2311,2276 2316,2276 2320,2276 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, high frequency_0.000200.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, high frequency_0.000200.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, high frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,921 88,913 93,905 97,897 102,890 106,882 111,874 115,867 120,860 124,853 129,846 133,839 138,832 142,825 147,819 151,812 156,806 160,800 165,794 169,788 174,782 178,776 183,770 187,764 192,759 196,753 201,748 205,743 210,738 214,732 219,727 223,722 228,718 232,713 237,708 241,703 246,699 250,694 255,690 259,686 264,681 268,677 273,673 277,669 282,665 286,661 291,657 295,653 300,650 304,646 309,642 313,639 318,635 322,632 327,629 331,625 336,622 340,619 345,616 349,613 354,610 358,607 363,604 367,601 372,598 376,595 381,593 385,590 390,587 394,585 399,582 403,580 408,577 412,575 417,573 421,570 426,568 430,566 435,564 439,561 444,559 448,557 453,555 457,553 462,551 466,549 471,548 475,546 480,544 484,542 489,540 493,539 498,537 502,535 506,534 511,532 515,531 520,529 524,528 529,526 533,525 538,523 542,522 547,521 551,519 556,518 560,517 565,515 569,514 574,513 578,512 583,511 587,510 592,509 596,508 601,507 605,506 610,505 614,504 619,503 623,502 628,501 632,500 637,499 641,498 646,497 650,497 655,496 659,495 664,494 668,494 673,493 677,492 682,491 686,491 691,490 695,490 700,489 704,488 709,488 713,487 718,487 722,486 727,486 731,485 736,485 740,484 745,484 749,483 754,483 758,482 763,482 767,482 772,481 776,481 781,481 785,480 790,480 794,480 799,479 803,479 808,479 812,478 817,478 821,478 826,478 830,477 835,477 839,477 844,477 848,477 853,477 857,476 862,476 866,476 871,476 875,476 880,476 884,476 889,475 893,475 898,475 902,475 907,475 911,475 916,475 920,475 925,475 929,475 934,475 938,475 943,475 947,475 952,475 956,475 961,475 965,475 970,474 974,474 979,474 983,474 988,474 992,474 997,474 1001,474 1006,474 1010,474 1015,474 1019,474 1024,474 1028,474 1033,474 1037,474 1042,474 1046,474 1051,474 1055,473 1060,473 1064,473 1069,473 1073,473 1078,473 1082,473 1087,473 1091,473 1096,473 1100,473 1105,473 1109,473 1114,473 1118,473 1123,473 1127,473 1132,472 1136,472 1141,472 1145,472 1150,472 1154,472 1159,472 1163,472 1168,472 1172,472 1177,472 1181,472 1186,472 1190,472 1195,472 1199,472 1204,471 1208,471 1213,471 1217,471 1222,471 1226,471 1231,471 1235,471 1240,471 1244,471 1249,471 1253,471 1258,471 1262,471 1267,470 1271,470 1276,470 1280,470 1285,470 1289,470 1294,470 1298,470 1303,470 1307,470 1312,470 1316,470 1321,470 1325,469 1330,469 1334,469 1339,469 1343,469 1348,469 1352,469 1357,469 1361,469 1366,469 1370,469 1375,469 1379,469 1384,468 1388,468 1393,468 1397,468 1402,468 1406,468 1411,468 1415,468 1420,468 1424,468 1429,468 1433,467 1438,467 1442,467 1447,467 1451,467 1456,467 1460,467 1465,467 1469,467 1474,467 1478,467 1483,467 1487,466 1492,466 1496,466 1501,466 1505,466 1510,466 1514,466 1519,466 1523,466 1528,466 1532,466 1537,465 1541,465 1546,465 1550,465 1555,465 1559,465 1564,465 1568,465 1573,465 1577,465 1582,464 1586,464 1591,464 1595,464 1600,464 1604,464 1609,464 1613,464 1618,464 1622,464 1626,463 1631,463 1635,463 1640,463 1644,463 1649,463 1653,463 1658,463 1662,463 1667,462 1671,462 1676,462 1680,462 1685,462 1689,462 1694,462 1698,462 1703,462 1707,462 1712,461 1716,461 1721,461 1725,461 1730,461 1734,461 1739,461 1743,461 1748,461 1752,460 1757,460 1761,460 1766,460 1770,460 1775,460 1779,460 1784,460 1788,460 1793,459 1797,459 1802,459 1806,459 1811,459 1815,459 1820,459 1824,459 1829,458 1833,458 1838,458 1842,458 1847,458 1851,458 1856,458 1860,458 1865,458 1869,457 1874,457 1878,457 1883,457 1887,457 1892,457 1896,457 1901,456 1905,456 1910,456 1914,456 1919,456 1923,456 1928,456 1932,456 1937,455 1941,455 1946,455 1950,455 1955,455 1959,455 1964,455 1968,455 1973,454 1977,454 1982,454 1986,454 1991,454 1995,454 2000,454 2004,454 2009,453 2013,453 2018,453 2022,453 2027,453 2031,453 2036,453 2040,452 2045,452 2049,452 2054,452 2058,452 2063,452 2067,452 2072,451 2076,451 2081,451 2085,451 2090,451 2094,451 2099,451 2103,450 2108,450 2112,450 2117,450 2121,450 2126,450 2130,450 2135,449 2139,449 2144,449 2148,449 2153,449 2157,449 2162,449 2166,448 2171,448 2175,448 2180,448 2184,448 2189,448 2193,448 2198,447 2202,447 2207,447 2211,447 2216,447 2220,447 2225,447 2229,447 2234,446 2238,446 2243,446 2247,446 2252,446 2256,446 2261,446 2265,446 2270,445 2274,445 2279,445 2283,445 2288,445 2292,445 2297,445 2301,445 2306,445 2310,444 2315,444 2319,444 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2225 74,2225 "/>
+<text x="65" y="2125" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2125 74,2125 "/>
+<text x="65" y="2025" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2025 74,2025 "/>
+<text x="65" y="1925" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1925 74,1925 "/>
+<text x="65" y="1825" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1825 74,1825 "/>
+<text x="65" y="1725" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1725 74,1725 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+14M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1526" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1526 74,1526 "/>
+<text x="65" y="1426" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+18M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1426 74,1426 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1609 79,2312 84,1825 88,1338 93,2042 97,2216 102,1435 106,1609 111,2312 115,1825 120,1338 124,2042 129,2216 133,1435 138,1609 142,2312 147,1825 151,1338 156,2042 160,2216 165,1435 169,1609 174,2312 178,1825 183,1338 187,2042 192,2216 196,1435 201,1609 205,2312 210,1825 214,1338 219,2042 223,2216 228,1435 232,1609 237,2312 241,1825 246,1338 250,2042 255,2216 259,1435 264,1609 268,2312 273,1825 277,1338 282,2042 286,2216 291,1435 295,1609 300,2312 304,1825 309,1338 313,2042 318,2216 322,1435 327,1609 331,2312 336,1825 340,1338 345,2042 349,2216 354,1435 358,1609 363,2312 367,1825 372,1338 376,2042 381,2216 385,1435 390,1609 394,2312 399,1825 403,1338 408,2042 412,2216 417,1435 421,1609 426,2312 430,1825 435,1338 439,2042 444,2216 448,1435 453,1609 457,2312 462,1825 466,1338 471,2042 475,2216 480,1435 484,1609 489,2312 493,1825 498,1338 502,2042 506,2216 511,1435 515,1609 520,2312 524,1825 529,1338 533,2042 538,2216 542,1435 547,1609 551,2312 556,1825 560,1338 565,2042 569,2216 574,1435 578,1609 583,2312 587,1825 592,1338 596,2042 601,2216 605,1435 610,1609 614,2312 619,1825 623,1338 628,2042 632,2216 637,1435 641,1609 646,2312 650,1825 655,1338 659,2042 664,2216 668,1435 673,1609 677,2312 682,1825 686,1338 691,2042 695,2216 700,1435 704,1609 709,2312 713,1825 718,1338 722,2042 727,2216 731,1435 736,1609 740,2312 745,1825 749,1338 754,2042 758,2216 763,1435 767,1609 772,2312 776,1825 781,1338 785,2042 790,2216 794,1435 799,1609 803,2312 808,1825 812,1338 817,2042 821,2216 826,1435 830,1609 835,2312 839,1825 844,1338 848,2042 853,2216 857,1435 862,1609 866,2312 871,1825 875,1338 880,2042 884,2216 889,1435 893,1609 898,2312 902,1825 907,1338 911,2042 916,2216 920,1435 925,1609 929,2312 934,1825 938,1338 943,2042 947,2216 952,1435 956,1609 961,2312 965,1825 970,1338 974,2042 979,2216 983,1435 988,1609 992,2312 997,1825 1001,1338 1006,2042 1010,2216 1015,1435 1019,1609 1024,2312 1028,1825 1033,1338 1037,2042 1042,2216 1046,1435 1051,1609 1055,2312 1060,1825 1064,1338 1069,2042 1073,2216 1078,1435 1082,1609 1087,2312 1091,1825 1096,1338 1100,2042 1105,2216 1109,1435 1114,1609 1118,2312 1123,1825 1127,1338 1132,2042 1136,2216 1141,1435 1145,1609 1150,2312 1154,1825 1159,1338 1163,2042 1168,2216 1172,1435 1177,1609 1181,2312 1186,1825 1190,1338 1195,2042 1199,2216 1204,1435 1208,1609 1213,2312 1217,1825 1222,1338 1226,2042 1231,2216 1235,1435 1240,1609 1244,2312 1249,1825 1253,1338 1258,2042 1262,2216 1267,1435 1271,1609 1276,2312 1280,1825 1285,1338 1289,2042 1294,2216 1298,1435 1303,1609 1307,2312 1312,1825 1316,1338 1321,2042 1325,2216 1330,1435 1334,1609 1339,2312 1343,1825 1348,1338 1352,2042 1357,2216 1361,1435 1366,1609 1370,2312 1375,1825 1379,1338 1384,2042 1388,2216 1393,1435 1397,1609 1402,2312 1406,1825 1411,1338 1415,2042 1420,2216 1424,1435 1429,1609 1433,2312 1438,1825 1442,1338 1447,2042 1451,2216 1456,1435 1460,1609 1465,2312 1469,1825 1474,1338 1478,2042 1483,2216 1487,1435 1492,1609 1496,2312 1501,1825 1505,1338 1510,2042 1514,2216 1519,1435 1523,1609 1528,2312 1532,1825 1537,1338 1541,2042 1546,2216 1550,1435 1555,1609 1559,2312 1564,1825 1568,1338 1573,2042 1577,2216 1582,1435 1586,1609 1591,2312 1595,1825 1600,1338 1604,2042 1609,2216 1613,1435 1618,1609 1622,2312 1626,1825 1631,1338 1635,2042 1640,2216 1644,1435 1649,1609 1653,2312 1658,1825 1662,1338 1667,2042 1671,2216 1676,1435 1680,1609 1685,2312 1689,1825 1694,1338 1698,2042 1703,2216 1707,1435 1712,1609 1716,2312 1721,1825 1725,1338 1730,2042 1734,2216 1739,1435 1743,1609 1748,2312 1752,1825 1757,1338 1761,2042 1766,2216 1770,1435 1775,1609 1779,2312 1784,1825 1788,1338 1793,2042 1797,2216 1802,1435 1806,1609 1811,2312 1815,1825 1820,1338 1824,2042 1829,2216 1833,1435 1838,1609 1842,2312 1847,1825 1851,1338 1856,2042 1860,2216 1865,1435 1869,1609 1874,2312 1878,1825 1883,1338 1887,2042 1892,2216 1896,1435 1901,1609 1905,2312 1910,1825 1914,1338 1919,2042 1923,2216 1928,1435 1932,1609 1937,2312 1941,1825 1946,1338 1950,2042 1955,2216 1959,1435 1964,1609 1968,2312 1973,1825 1977,1338 1982,2042 1986,2216 1991,1435 1995,1609 2000,2312 2004,1825 2009,1338 2013,2042 2018,2216 2022,1435 2027,1609 2031,2312 2036,1825 2040,1338 2045,2042 2049,2216 2054,1435 2058,1609 2063,2312 2067,1825 2072,1338 2076,2042 2081,2216 2085,1435 2090,1609 2094,2312 2099,1825 2103,1338 2108,2042 2112,2216 2117,1435 2121,1609 2126,2312 2130,1825 2135,1338 2139,2042 2144,2216 2148,1435 2153,1609 2157,2312 2162,1825 2166,1338 2171,2042 2175,2216 2180,1435 2184,1609 2189,2312 2193,1825 2198,1338 2202,2042 2207,2216 2211,1435 2216,1609 2220,2312 2225,1825 2229,1338 2234,2042 2238,2216 2243,1435 2247,1609 2252,2312 2256,1825 2261,1338 2265,2042 2270,2216 2274,1435 2279,1609 2283,2312 2288,1825 2292,1338 2297,2042 2301,2216 2306,1435 2310,1609 2315,2312 2319,1825 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2276 1762,2276 1767,2276 1771,2276 1776,2276 1780,2276 1785,2276 1789,2276 1794,2276 1798,2276 1803,2276 1807,2276 1812,2276 1816,2276 1821,2276 1825,2276 1830,2276 1834,2276 1839,2276 1843,2276 1848,2276 1852,2276 1857,2276 1861,2276 1866,2276 1870,2276 1875,2276 1879,2276 1884,2276 1888,2276 1893,2276 1897,2276 1902,2276 1906,2276 1911,2276 1915,2276 1920,2276 1924,2276 1929,2276 1933,2276 1938,2276 1942,2276 1947,2276 1951,2276 1956,2276 1960,2276 1965,2276 1969,2276 1974,2276 1978,2276 1983,2276 1987,2276 1992,2276 1996,2276 2001,2276 2005,2276 2010,2276 2014,2276 2019,2276 2023,2276 2028,2276 2032,2276 2037,2276 2041,2276 2046,2276 2050,2276 2055,2276 2059,2276 2064,2276 2068,2276 2073,2276 2077,2276 2082,2276 2086,2276 2091,2276 2095,2276 2100,2276 2104,2276 2109,2276 2113,2276 2118,2276 2122,2276 2127,2273 2131,2276 2136,2276 2140,2276 2145,2276 2149,2276 2154,2276 2158,2254 2163,2276 2167,2276 2172,2276 2176,2276 2181,2276 2185,2276 2190,2236 2194,2276 2199,2276 2203,2276 2208,2271 2212,2276 2217,2276 2221,2210 2226,2276 2230,2276 2235,2276 2239,2262 2244,2276 2248,2276 2253,2189 2257,2276 2262,2276 2266,2276 2271,2255 2275,2276 2280,2276 2284,2170 2289,2276 2293,2276 2298,2276 2302,2247 2307,2276 2311,2276 2316,2148 2320,2276 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, high frequency_0.000300.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, high frequency_0.000300.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, high frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,921 88,913 93,905 97,897 102,890 106,882 111,874 115,867 120,860 124,853 129,846 133,839 138,832 142,825 147,819 151,812 156,806 160,800 165,794 169,788 174,782 178,776 183,770 187,764 192,759 196,753 201,748 205,743 210,738 214,732 219,727 223,722 228,718 232,713 237,708 241,703 246,699 250,694 255,690 259,686 264,681 268,677 273,673 277,669 282,665 286,661 291,657 295,653 300,650 304,646 309,642 313,639 318,635 322,632 327,629 331,625 336,622 340,619 345,616 349,613 354,610 358,607 363,604 367,601 372,598 376,595 381,593 385,590 390,587 394,585 399,582 403,580 408,577 412,575 417,573 421,570 426,568 430,566 435,564 439,561 444,559 448,557 453,555 457,553 462,551 466,549 471,548 475,546 480,544 484,542 489,540 493,539 498,537 502,535 506,534 511,532 515,531 520,529 524,528 529,526 533,525 538,523 542,522 547,521 551,519 556,518 560,517 565,515 569,514 574,513 578,512 583,511 587,510 592,509 596,508 601,507 605,506 610,505 614,504 619,503 623,502 628,501 632,500 637,499 641,498 646,497 650,497 655,496 659,495 664,494 668,494 673,493 677,492 682,491 686,491 691,490 695,490 700,489 704,488 709,488 713,487 718,487 722,486 727,486 731,485 736,485 740,484 745,484 749,483 754,483 758,482 763,482 767,482 772,481 776,481 781,481 785,480 790,480 794,480 799,479 803,479 808,479 812,478 817,478 821,478 826,478 830,477 835,477 839,477 844,477 848,477 853,477 857,476 862,476 866,476 871,476 875,476 880,476 884,476 889,475 893,475 898,475 902,475 907,475 911,475 916,475 920,475 925,475 929,475 934,475 938,475 943,475 947,475 952,475 956,475 961,475 965,475 970,474 974,474 979,474 983,474 988,474 992,474 997,474 1001,474 1006,474 1010,474 1015,474 1019,474 1024,474 1028,474 1033,474 1037,474 1042,474 1046,474 1051,474 1055,473 1060,473 1064,473 1069,473 1073,473 1078,473 1082,473 1087,473 1091,473 1096,473 1100,473 1105,473 1109,473 1114,473 1118,473 1123,473 1127,473 1132,472 1136,472 1141,472 1145,472 1150,472 1154,472 1159,472 1163,472 1168,472 1172,472 1177,472 1181,472 1186,472 1190,472 1195,472 1199,472 1204,471 1208,471 1213,471 1217,471 1222,471 1226,471 1231,471 1235,471 1240,471 1244,471 1249,471 1253,471 1258,471 1262,471 1267,470 1271,470 1276,470 1280,470 1285,470 1289,470 1294,470 1298,470 1303,470 1307,470 1312,470 1316,470 1321,470 1325,469 1330,469 1334,469 1339,469 1343,469 1348,469 1352,469 1357,469 1361,469 1366,469 1370,469 1375,469 1379,469 1384,468 1388,468 1393,468 1397,468 1402,468 1406,468 1411,468 1415,468 1420,468 1424,468 1429,468 1433,467 1438,467 1442,467 1447,467 1451,467 1456,467 1460,467 1465,467 1469,467 1474,467 1478,467 1483,467 1487,466 1492,466 1496,466 1501,466 1505,466 1510,466 1514,466 1519,466 1523,466 1528,466 1532,466 1537,465 1541,465 1546,465 1550,465 1555,465 1559,465 1564,465 1568,465 1573,465 1577,465 1582,464 1586,464 1591,464 1595,464 1600,464 1604,464 1609,464 1613,464 1618,464 1622,464 1626,463 1631,463 1635,463 1640,463 1644,463 1649,463 1653,463 1658,463 1662,463 1667,462 1671,462 1676,462 1680,462 1685,462 1689,462 1694,462 1698,462 1703,462 1707,462 1712,461 1716,461 1721,461 1725,461 1730,461 1734,461 1739,461 1743,461 1748,461 1752,460 1757,460 1761,460 1766,460 1770,460 1775,460 1779,460 1784,460 1788,460 1793,459 1797,459 1802,459 1806,459 1811,459 1815,459 1820,459 1824,459 1829,458 1833,458 1838,458 1842,458 1847,458 1851,458 1856,458 1860,458 1865,458 1869,457 1874,457 1878,457 1883,457 1887,457 1892,457 1896,457 1901,456 1905,456 1910,456 1914,456 1919,456 1923,456 1928,456 1932,456 1937,455 1941,455 1946,455 1950,455 1955,455 1959,455 1964,455 1968,455 1973,455 1977,454 1982,454 1986,454 1991,454 1995,454 2000,454 2004,454 2009,453 2013,453 2018,453 2022,453 2027,453 2031,453 2036,453 2040,453 2045,453 2049,452 2054,452 2058,452 2063,452 2067,452 2072,452 2076,452 2081,452 2085,452 2090,451 2094,451 2099,451 2103,451 2108,451 2112,451 2117,451 2121,451 2126,451 2130,451 2135,451 2139,450 2144,450 2148,450 2153,450 2157,450 2162,450 2166,450 2171,450 2175,450 2180,450 2184,449 2189,449 2193,449 2198,449 2202,449 2207,449 2211,449 2216,449 2220,449 2225,449 2229,449 2234,449 2238,449 2243,448 2247,448 2252,448 2256,448 2261,448 2265,448 2270,448 2274,448 2279,448 2283,448 2288,448 2292,448 2297,448 2301,447 2306,447 2310,447 2315,447 2319,447 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2225 74,2225 "/>
+<text x="65" y="2125" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2125 74,2125 "/>
+<text x="65" y="2025" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2025 74,2025 "/>
+<text x="65" y="1925" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1925 74,1925 "/>
+<text x="65" y="1825" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1825 74,1825 "/>
+<text x="65" y="1725" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1725 74,1725 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+14M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1526" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1526 74,1526 "/>
+<text x="65" y="1426" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+18M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1426 74,1426 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1609 79,2312 84,1825 88,1338 93,2042 97,2216 102,1435 106,1609 111,2312 115,1825 120,1338 124,2042 129,2216 133,1435 138,1609 142,2312 147,1825 151,1338 156,2042 160,2216 165,1435 169,1609 174,2312 178,1825 183,1338 187,2042 192,2216 196,1435 201,1609 205,2312 210,1825 214,1338 219,2042 223,2216 228,1435 232,1609 237,2312 241,1825 246,1338 250,2042 255,2216 259,1435 264,1609 268,2312 273,1825 277,1338 282,2042 286,2216 291,1435 295,1609 300,2312 304,1825 309,1338 313,2042 318,2216 322,1435 327,1609 331,2312 336,1825 340,1338 345,2042 349,2216 354,1435 358,1609 363,2312 367,1825 372,1338 376,2042 381,2216 385,1435 390,1609 394,2312 399,1825 403,1338 408,2042 412,2216 417,1435 421,1609 426,2312 430,1825 435,1338 439,2042 444,2216 448,1435 453,1609 457,2312 462,1825 466,1338 471,2042 475,2216 480,1435 484,1609 489,2312 493,1825 498,1338 502,2042 506,2216 511,1435 515,1609 520,2312 524,1825 529,1338 533,2042 538,2216 542,1435 547,1609 551,2312 556,1825 560,1338 565,2042 569,2216 574,1435 578,1609 583,2312 587,1825 592,1338 596,2042 601,2216 605,1435 610,1609 614,2312 619,1825 623,1338 628,2042 632,2216 637,1435 641,1609 646,2312 650,1825 655,1338 659,2042 664,2216 668,1435 673,1609 677,2312 682,1825 686,1338 691,2042 695,2216 700,1435 704,1609 709,2312 713,1825 718,1338 722,2042 727,2216 731,1435 736,1609 740,2312 745,1825 749,1338 754,2042 758,2216 763,1435 767,1609 772,2312 776,1825 781,1338 785,2042 790,2216 794,1435 799,1609 803,2312 808,1825 812,1338 817,2042 821,2216 826,1435 830,1609 835,2312 839,1825 844,1338 848,2042 853,2216 857,1435 862,1609 866,2312 871,1825 875,1338 880,2042 884,2216 889,1435 893,1609 898,2312 902,1825 907,1338 911,2042 916,2216 920,1435 925,1609 929,2312 934,1825 938,1338 943,2042 947,2216 952,1435 956,1609 961,2312 965,1825 970,1338 974,2042 979,2216 983,1435 988,1609 992,2312 997,1825 1001,1338 1006,2042 1010,2216 1015,1435 1019,1609 1024,2312 1028,1825 1033,1338 1037,2042 1042,2216 1046,1435 1051,1609 1055,2312 1060,1825 1064,1338 1069,2042 1073,2216 1078,1435 1082,1609 1087,2312 1091,1825 1096,1338 1100,2042 1105,2216 1109,1435 1114,1609 1118,2312 1123,1825 1127,1338 1132,2042 1136,2216 1141,1435 1145,1609 1150,2312 1154,1825 1159,1338 1163,2042 1168,2216 1172,1435 1177,1609 1181,2312 1186,1825 1190,1338 1195,2042 1199,2216 1204,1435 1208,1609 1213,2312 1217,1825 1222,1338 1226,2042 1231,2216 1235,1435 1240,1609 1244,2312 1249,1825 1253,1338 1258,2042 1262,2216 1267,1435 1271,1609 1276,2312 1280,1825 1285,1338 1289,2042 1294,2216 1298,1435 1303,1609 1307,2312 1312,1825 1316,1338 1321,2042 1325,2216 1330,1435 1334,1609 1339,2312 1343,1825 1348,1338 1352,2042 1357,2216 1361,1435 1366,1609 1370,2312 1375,1825 1379,1338 1384,2042 1388,2216 1393,1435 1397,1609 1402,2312 1406,1825 1411,1338 1415,2042 1420,2216 1424,1435 1429,1609 1433,2312 1438,1825 1442,1338 1447,2042 1451,2216 1456,1435 1460,1609 1465,2312 1469,1825 1474,1338 1478,2042 1483,2216 1487,1435 1492,1609 1496,2312 1501,1825 1505,1338 1510,2042 1514,2216 1519,1435 1523,1609 1528,2312 1532,1825 1537,1338 1541,2042 1546,2216 1550,1435 1555,1609 1559,2312 1564,1825 1568,1338 1573,2042 1577,2216 1582,1435 1586,1609 1591,2312 1595,1825 1600,1338 1604,2042 1609,2216 1613,1435 1618,1609 1622,2312 1626,1825 1631,1338 1635,2042 1640,2216 1644,1435 1649,1609 1653,2312 1658,1825 1662,1338 1667,2042 1671,2216 1676,1435 1680,1609 1685,2312 1689,1825 1694,1338 1698,2042 1703,2216 1707,1435 1712,1609 1716,2312 1721,1825 1725,1338 1730,2042 1734,2216 1739,1435 1743,1609 1748,2312 1752,1825 1757,1338 1761,2042 1766,2216 1770,1435 1775,1609 1779,2312 1784,1825 1788,1338 1793,2042 1797,2216 1802,1435 1806,1609 1811,2312 1815,1825 1820,1338 1824,2042 1829,2216 1833,1435 1838,1609 1842,2312 1847,1825 1851,1338 1856,2042 1860,2216 1865,1435 1869,1609 1874,2312 1878,1825 1883,1338 1887,2042 1892,2216 1896,1435 1901,1609 1905,2312 1910,1825 1914,1338 1919,2042 1923,2216 1928,1435 1932,1609 1937,2312 1941,1825 1946,1338 1950,2042 1955,2216 1959,1435 1964,1609 1968,2312 1973,1825 1977,1338 1982,2042 1986,2216 1991,1435 1995,1609 2000,2312 2004,1825 2009,1338 2013,2042 2018,2216 2022,1435 2027,1609 2031,2312 2036,1825 2040,1338 2045,2042 2049,2216 2054,1435 2058,1609 2063,2312 2067,1825 2072,1338 2076,2042 2081,2216 2085,1435 2090,1609 2094,2312 2099,1825 2103,1338 2108,2042 2112,2216 2117,1435 2121,1609 2126,2312 2130,1825 2135,1338 2139,2042 2144,2216 2148,1435 2153,1609 2157,2312 2162,1825 2166,1338 2171,2042 2175,2216 2180,1435 2184,1609 2189,2312 2193,1825 2198,1338 2202,2042 2207,2216 2211,1435 2216,1609 2220,2312 2225,1825 2229,1338 2234,2042 2238,2216 2243,1435 2247,1609 2252,2312 2256,1825 2261,1338 2265,2042 2270,2216 2274,1435 2279,1609 2283,2312 2288,1825 2292,1338 2297,2042 2301,2216 2306,1435 2310,1609 2315,2312 2319,1825 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2276 1762,2276 1767,2276 1771,2276 1776,2276 1780,2276 1785,2276 1789,2276 1794,2276 1798,2276 1803,2276 1807,2276 1812,2276 1816,2276 1821,2276 1825,2276 1830,2276 1834,2276 1839,2276 1843,2276 1848,2276 1852,2276 1857,2276 1861,2276 1866,2276 1870,2276 1875,2276 1879,2276 1884,2276 1888,2276 1893,2276 1897,2276 1902,2276 1906,2274 1911,2276 1915,2276 1920,2276 1924,2276 1929,2276 1933,2276 1938,2260 1942,2276 1947,2276 1951,2276 1956,2276 1960,2276 1965,2276 1969,2241 1974,2276 1978,2276 1983,2276 1987,2276 1992,2276 1996,2276 2001,2227 2005,2276 2010,2276 2014,2276 2019,2273 2023,2276 2028,2276 2032,2204 2037,2276 2041,2276 2046,2276 2050,2266 2055,2276 2059,2276 2064,2186 2068,2276 2073,2276 2077,2276 2082,2258 2086,2276 2091,2276 2095,2163 2100,2276 2104,2276 2109,2276 2113,2252 2118,2276 2122,2276 2127,2146 2131,2276 2136,2276 2140,2276 2145,2246 2149,2276 2154,2276 2158,2125 2163,2276 2167,2276 2172,2276 2176,2239 2181,2276 2185,2276 2190,2110 2194,2276 2199,2276 2203,2276 2208,2233 2212,2276 2217,2276 2221,2090 2226,2276 2230,2276 2235,2276 2239,2227 2244,2276 2248,2276 2253,2077 2257,2276 2262,2276 2266,2276 2271,2221 2275,2276 2280,2276 2284,2063 2289,2276 2293,2276 2298,2276 2302,2212 2307,2276 2311,2276 2316,2045 2320,2276 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, low frequency_0.000100.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, low frequency_0.000100.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, low frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,921 88,912 93,904 97,896 102,888 106,880 111,873 115,865 120,858 124,850 129,843 133,836 138,829 142,822 147,815 151,809 156,802 160,795 165,789 169,783 174,776 178,770 183,765 187,759 192,753 196,747 201,742 205,736 210,730 214,725 219,720 223,715 228,709 232,705 237,700 241,694 246,690 250,685 255,680 259,676 264,671 268,667 273,663 277,658 282,654 286,650 291,646 295,642 300,638 304,634 309,630 313,626 318,623 322,619 327,615 331,612 336,608 340,605 345,601 349,598 354,595 358,592 363,588 367,586 372,583 376,579 381,576 385,574 390,571 394,568 399,565 403,563 408,560 412,557 417,555 421,552 426,549 430,547 435,545 439,542 444,540 448,537 453,535 457,533 462,531 466,529 471,527 475,525 480,522 484,520 489,519 493,516 498,514 502,513 506,511 511,509 515,507 520,506 524,504 529,502 533,500 538,499 542,497 547,495 551,494 556,493 560,491 565,489 569,488 574,487 578,485 583,484 587,483 592,481 596,480 601,479 605,478 610,476 614,475 619,474 623,473 628,471 632,470 637,469 641,468 646,467 650,466 655,465 659,464 664,463 668,462 673,461 677,460 682,459 686,458 691,458 695,456 700,456 704,455 709,454 713,453 718,452 722,452 727,451 731,450 736,449 740,449 745,448 749,447 754,447 758,446 763,445 767,445 772,444 776,444 781,443 785,442 790,442 794,442 799,441 803,441 808,440 812,440 817,440 821,439 826,439 830,438 835,438 839,438 844,438 848,437 853,437 857,437 862,437 866,437 871,437 875,436 880,436 884,436 889,436 893,436 898,436 902,436 907,436 911,436 916,435 920,435 925,435 929,435 934,435 938,435 943,435 947,435 952,435 956,435 961,435 965,435 970,435 974,435 979,435 983,435 988,435 992,435 997,435 1001,435 1006,435 1010,435 1015,435 1019,435 1024,435 1028,435 1033,434 1037,435 1042,435 1046,435 1051,434 1055,435 1060,435 1064,434 1069,434 1073,434 1078,435 1082,434 1087,434 1091,434 1096,435 1100,434 1105,434 1109,434 1114,434 1118,434 1123,434 1127,434 1132,434 1136,434 1141,434 1145,434 1150,434 1154,434 1159,434 1163,434 1168,434 1172,434 1177,434 1181,434 1186,434 1190,434 1195,434 1199,434 1204,434 1208,434 1213,434 1217,434 1222,434 1226,434 1231,434 1235,434 1240,434 1244,434 1249,434 1253,434 1258,434 1262,434 1267,434 1271,434 1276,434 1280,434 1285,434 1289,434 1294,434 1298,434 1303,434 1307,434 1312,434 1316,434 1321,434 1325,434 1330,434 1334,434 1339,434 1343,434 1348,434 1352,434 1357,434 1361,434 1366,434 1370,434 1375,434 1379,434 1384,434 1388,434 1393,434 1397,434 1402,434 1406,434 1411,434 1415,434 1420,434 1424,434 1429,434 1433,434 1438,434 1442,434 1447,434 1451,434 1456,434 1460,434 1465,434 1469,434 1474,434 1478,434 1483,434 1487,434 1492,434 1496,434 1501,434 1505,434 1510,434 1514,434 1519,434 1523,434 1528,434 1532,434 1537,434 1541,434 1546,434 1550,434 1555,434 1559,434 1564,434 1568,434 1573,434 1577,434 1582,434 1586,434 1591,434 1595,434 1600,434 1604,434 1609,434 1613,434 1618,434 1622,434 1626,434 1631,434 1635,434 1640,434 1644,434 1649,434 1653,434 1658,434 1662,434 1667,434 1671,434 1676,434 1680,434 1685,434 1689,434 1694,434 1698,434 1703,434 1707,434 1712,434 1716,434 1721,434 1725,434 1730,434 1734,434 1739,434 1743,434 1748,434 1752,434 1757,434 1761,434 1766,434 1770,434 1775,434 1779,434 1784,434 1788,434 1793,434 1797,434 1802,434 1806,434 1811,434 1815,434 1820,434 1824,434 1829,434 1833,434 1838,434 1842,434 1847,434 1851,434 1856,434 1860,434 1865,434 1869,434 1874,434 1878,434 1883,434 1887,434 1892,434 1896,434 1901,434 1905,434 1910,434 1914,434 1919,434 1923,434 1928,434 1932,434 1937,434 1941,434 1946,434 1950,434 1955,434 1959,434 1964,434 1968,434 1973,434 1977,434 1982,434 1986,434 1991,434 1995,434 2000,434 2004,434 2009,434 2013,434 2018,434 2022,434 2027,434 2031,434 2036,434 2040,434 2045,434 2049,434 2054,434 2058,434 2063,434 2067,434 2072,434 2076,434 2081,434 2085,434 2090,434 2094,434 2099,434 2103,434 2108,434 2112,434 2117,434 2121,434 2126,434 2130,434 2135,434 2139,434 2144,434 2148,434 2153,434 2157,434 2162,434 2166,434 2171,434 2175,434 2180,434 2184,434 2189,434 2193,434 2198,434 2202,434 2207,434 2211,434 2216,434 2220,434 2225,434 2229,434 2234,434 2238,434 2243,434 2247,434 2252,434 2256,434 2261,434 2265,434 2270,434 2274,434 2279,434 2283,434 2288,434 2292,434 2297,434 2301,434 2306,434 2310,434 2315,434 2319,434 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2226 74,2226 "/>
+<text x="65" y="2127" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2127 74,2127 "/>
+<text x="65" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2029 74,2029 "/>
+<text x="65" y="1930" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1930 74,1930 "/>
+<text x="65" y="1831" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1831 74,1831 "/>
+<text x="65" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1733 74,1733 "/>
+<text x="65" y="1634" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1634 74,1634 "/>
+<text x="65" y="1535" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1535 74,1535 "/>
+<text x="65" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+9M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1437 74,1437 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1797 79,1346 84,1967 88,2289 93,1600 97,1423 102,2148 106,2174 111,1443 115,1570 120,2275 124,2000 129,1353 133,1763 138,2324 142,1797 147,1346 151,1967 156,2289 160,1600 165,1423 169,2148 174,2174 178,1443 183,1570 187,2275 192,2000 196,1353 201,1763 205,2324 210,1797 214,1346 219,1967 223,2289 228,1600 232,1423 237,2148 241,2174 246,1443 250,1570 255,2275 259,2000 264,1353 268,1763 273,2324 277,1797 282,1346 286,1967 291,2289 295,1600 300,1423 304,2148 309,2174 313,1443 318,1570 322,2275 327,2000 331,1353 336,1763 340,2324 345,1797 349,1346 354,1967 358,2289 363,1600 367,1423 372,2148 376,2174 381,1443 385,1570 390,2275 394,2000 399,1353 403,1763 408,2324 412,1797 417,1346 421,1967 426,2289 430,1600 435,1423 439,2148 444,2174 448,1443 453,1570 457,2275 462,2000 466,1353 471,1763 475,2324 480,1797 484,1346 489,1967 493,2289 498,1600 502,1423 506,2148 511,2174 515,1443 520,1570 524,2275 529,2000 533,1353 538,1763 542,2324 547,1797 551,1346 556,1967 560,2289 565,1600 569,1423 574,2148 578,2174 583,1443 587,1570 592,2275 596,2000 601,1353 605,1763 610,2324 614,1797 619,1346 623,1967 628,2289 632,1600 637,1423 641,2148 646,2174 650,1443 655,1570 659,2275 664,2000 668,1353 673,1763 677,2324 682,1797 686,1346 691,1967 695,2289 700,1600 704,1423 709,2148 713,2174 718,1443 722,1570 727,2275 731,2000 736,1353 740,1763 745,2324 749,1797 754,1346 758,1967 763,2289 767,1600 772,1423 776,2148 781,2174 785,1443 790,1570 794,2275 799,2000 803,1353 808,1763 812,2324 817,1797 821,1346 826,1967 830,2289 835,1600 839,1423 844,2148 848,2174 853,1443 857,1570 862,2275 866,2000 871,1353 875,1763 880,2324 884,1797 889,1346 893,1967 898,2289 902,1600 907,1423 911,2148 916,2174 920,1443 925,1570 929,2275 934,2000 938,1353 943,1763 947,2324 952,1797 956,1346 961,1967 965,2289 970,1600 974,1423 979,2148 983,2174 988,1443 992,1570 997,2275 1001,2000 1006,1353 1010,1763 1015,2324 1019,1797 1024,1346 1028,1967 1033,2289 1037,1600 1042,1423 1046,2148 1051,2174 1055,1443 1060,1570 1064,2275 1069,2000 1073,1353 1078,1763 1082,2324 1087,1797 1091,1346 1096,1967 1100,2289 1105,1600 1109,1423 1114,2148 1118,2174 1123,1443 1127,1570 1132,2275 1136,2000 1141,1353 1145,1763 1150,2324 1154,1797 1159,1346 1163,1967 1168,2289 1172,1600 1177,1423 1181,2148 1186,2174 1190,1443 1195,1570 1199,2275 1204,2000 1208,1353 1213,1763 1217,2324 1222,1797 1226,1346 1231,1967 1235,2289 1240,1600 1244,1423 1249,2148 1253,2174 1258,1443 1262,1570 1267,2275 1271,2000 1276,1353 1280,1763 1285,2324 1289,1797 1294,1346 1298,1967 1303,2289 1307,1600 1312,1423 1316,2148 1321,2174 1325,1443 1330,1570 1334,2275 1339,2000 1343,1353 1348,1763 1352,2324 1357,1797 1361,1346 1366,1967 1370,2289 1375,1600 1379,1423 1384,2148 1388,2174 1393,1443 1397,1570 1402,2275 1406,2000 1411,1353 1415,1763 1420,2324 1424,1797 1429,1346 1433,1967 1438,2289 1442,1600 1447,1423 1451,2148 1456,2174 1460,1443 1465,1570 1469,2275 1474,2000 1478,1353 1483,1763 1487,2324 1492,1797 1496,1346 1501,1967 1505,2289 1510,1600 1514,1423 1519,2148 1523,2174 1528,1443 1532,1570 1537,2275 1541,2000 1546,1353 1550,1763 1555,2324 1559,1797 1564,1346 1568,1967 1573,2289 1577,1600 1582,1423 1586,2148 1591,2174 1595,1443 1600,1570 1604,2275 1609,2000 1613,1353 1618,1763 1622,2324 1626,1797 1631,1346 1635,1967 1640,2289 1644,1600 1649,1423 1653,2148 1658,2174 1662,1443 1667,1570 1671,2275 1676,2000 1680,1353 1685,1763 1689,2324 1694,1797 1698,1346 1703,1967 1707,2289 1712,1600 1716,1423 1721,2148 1725,2174 1730,1443 1734,1570 1739,2275 1743,2000 1748,1353 1752,1763 1757,2324 1761,1797 1766,1346 1770,1967 1775,2289 1779,1600 1784,1423 1788,2148 1793,2174 1797,1443 1802,1570 1806,2275 1811,2000 1815,1353 1820,1763 1824,2324 1829,1797 1833,1346 1838,1967 1842,2289 1847,1600 1851,1423 1856,2148 1860,2174 1865,1443 1869,1570 1874,2275 1878,2000 1883,1353 1887,1763 1892,2324 1896,1797 1901,1346 1905,1967 1910,2289 1914,1600 1919,1423 1923,2148 1928,2174 1932,1443 1937,1570 1941,2275 1946,2000 1950,1353 1955,1763 1959,2324 1964,1797 1968,1346 1973,1967 1977,2289 1982,1600 1986,1423 1991,2148 1995,2174 2000,1443 2004,1570 2009,2275 2013,2000 2018,1353 2022,1763 2027,2324 2031,1797 2036,1346 2040,1967 2045,2289 2049,1600 2054,1423 2058,2148 2063,2174 2067,1443 2072,1570 2076,2275 2081,2000 2085,1353 2090,1763 2094,2324 2099,1797 2103,1346 2108,1967 2112,2289 2117,1600 2121,1423 2126,2148 2130,2174 2135,1443 2139,1570 2144,2275 2148,2000 2153,1353 2157,1763 2162,2324 2166,1797 2171,1346 2175,1967 2180,2289 2184,1600 2189,1423 2193,2148 2198,2174 2202,1443 2207,1570 2211,2275 2216,2000 2220,1353 2225,1763 2229,2324 2234,1797 2238,1346 2243,1967 2247,2289 2252,1600 2256,1423 2261,2148 2265,2174 2270,1443 2274,1570 2279,2275 2283,2000 2288,1353 2292,1763 2297,2324 2301,1797 2306,1346 2310,1967 2315,2289 2319,1600 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2269 768,2276 772,2276 777,2269 781,2108 786,2276 790,2276 795,2141 799,2171 804,2276 808,2269 813,1879 817,2246 822,2276 826,2224 831,1832 835,2264 840,2276 844,2137 849,1870 853,2270 858,2261 862,1966 867,2090 871,2273 876,2238 880,1832 885,2216 889,2273 894,2197 898,1832 903,2252 907,2269 912,2117 916,1861 921,2266 925,2257 930,1940 934,2079 939,2270 943,2233 948,1832 952,2209 957,2269 961,2187 966,1832 970,2245 975,2263 979,2094 984,1848 988,2259 993,2250 997,1903 1002,2061 1006,2265 1011,2225 1015,1832 1020,2200 1024,2265 1029,2178 1033,1832 1038,2241 1042,2259 1047,2082 1051,1843 1056,2256 1060,2246 1065,1885 1069,2052 1074,2263 1078,2221 1083,1832 1087,2196 1092,2263 1096,2173 1101,1832 1105,2238 1110,2257 1114,2075 1119,1842 1123,2254 1128,2244 1132,1874 1137,2048 1141,2261 1146,2219 1150,1832 1155,2193 1159,2261 1164,2170 1168,1832 1173,2236 1177,2256 1182,2071 1186,1841 1191,2253 1195,2243 1200,1867 1204,2045 1209,2260 1213,2217 1218,1832 1222,2191 1227,2261 1231,2168 1236,1832 1240,2235 1245,2255 1249,2068 1254,1840 1258,2252 1263,2242 1267,1861 1272,2042 1276,2259 1281,2216 1285,1832 1290,2189 1294,2260 1299,2165 1303,1832 1308,2234 1312,2255 1317,2064 1321,1839 1326,2251 1330,2241 1335,1855 1339,2039 1344,2258 1348,2215 1353,1832 1357,2188 1362,2259 1366,2164 1371,1832 1375,2233 1380,2253 1384,2061 1389,1839 1393,2251 1398,2239 1402,1849 1407,2037 1411,2258 1416,2213 1420,1832 1425,2186 1429,2258 1434,2162 1438,1832 1443,2232 1447,2253 1452,2058 1456,1838 1461,2250 1465,2239 1470,1844 1474,2034 1479,2257 1483,2212 1488,1832 1492,2184 1497,2257 1501,2160 1506,1832 1510,2231 1515,2252 1519,2055 1524,1837 1528,2249 1533,2238 1537,1838 1542,2031 1546,2256 1551,2211 1555,1832 1560,2183 1564,2257 1569,2158 1573,1832 1578,2230 1582,2251 1587,2052 1591,1836 1596,2248 1600,2237 1605,1832 1609,2029 1614,2255 1618,2209 1623,1832 1627,2181 1632,2256 1636,2156 1641,1832 1645,2228 1650,2250 1654,2048 1659,1835 1663,2247 1668,2236 1672,1832 1677,2026 1681,2254 1686,2208 1690,1832 1695,2179 1699,2255 1704,2154 1708,1832 1713,2227 1717,2249 1722,2046 1726,1834 1731,2246 1735,2235 1740,1832 1744,2023 1749,2254 1753,2206 1758,1832 1762,2178 1767,2254 1771,2152 1776,1832 1780,2226 1785,2248 1789,2042 1794,1834 1798,2245 1803,2234 1807,1832 1812,2021 1816,2253 1821,2205 1825,1832 1830,2176 1834,2253 1839,2150 1843,1832 1848,2225 1852,2247 1857,2039 1861,1833 1866,2245 1870,2233 1875,1832 1879,2018 1884,2252 1888,2204 1893,1832 1897,2174 1902,2252 1906,2148 1911,1832 1915,2224 1920,2246 1924,2036 1929,1832 1933,2243 1938,2232 1942,1832 1947,2015 1951,2251 1956,2202 1960,1832 1965,2172 1969,2251 1974,2146 1978,1832 1983,2223 1987,2246 1992,2032 1996,1832 2001,2242 2005,2231 2010,1832 2014,2013 2019,2250 2023,2201 2028,1832 2032,2170 2037,2250 2041,2144 2046,1832 2050,2221 2055,2245 2059,2029 2064,1832 2068,2242 2073,2230 2077,1832 2082,2010 2086,2249 2091,2199 2095,1832 2100,2169 2104,2250 2109,2141 2113,1832 2118,2220 2122,2244 2127,2025 2131,1832 2136,2241 2140,2229 2145,1832 2149,2008 2154,2248 2158,2198 2163,1832 2167,2167 2172,2249 2176,2140 2181,1832 2185,2219 2190,2243 2194,2022 2199,1832 2203,2239 2208,2228 2212,1832 2217,2007 2221,2247 2226,2196 2230,1832 2235,2165 2239,2248 2244,2138 2248,1832 2253,2218 2257,2242 2262,2019 2266,1832 2271,2239 2275,2226 2280,1832 2284,2004 2289,2246 2293,2195 2298,1832 2302,2163 2307,2247 2311,2135 2316,1832 2320,2216 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, low frequency_0.000200.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, low frequency_0.000200.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, low frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,921 88,912 93,904 97,896 102,888 106,880 111,873 115,865 120,858 124,850 129,843 133,836 138,829 142,822 147,815 151,809 156,802 160,795 165,789 169,783 174,776 178,770 183,765 187,759 192,753 196,747 201,742 205,736 210,730 214,725 219,720 223,715 228,709 232,705 237,700 241,694 246,690 250,685 255,680 259,676 264,671 268,667 273,663 277,658 282,654 286,650 291,646 295,642 300,638 304,634 309,630 313,626 318,623 322,619 327,615 331,612 336,608 340,605 345,601 349,598 354,595 358,592 363,588 367,586 372,583 376,579 381,576 385,574 390,571 394,568 399,565 403,563 408,560 412,557 417,555 421,552 426,549 430,547 435,545 439,542 444,540 448,537 453,535 457,533 462,531 466,529 471,527 475,525 480,522 484,520 489,519 493,516 498,514 502,513 506,511 511,509 515,507 520,506 524,504 529,502 533,500 538,499 542,497 547,495 551,494 556,493 560,491 565,489 569,488 574,487 578,485 583,484 587,483 592,481 596,480 601,479 605,478 610,476 614,475 619,474 623,473 628,471 632,470 637,469 641,468 646,467 650,466 655,465 659,464 664,463 668,462 673,461 677,460 682,459 686,458 691,458 695,457 700,456 704,455 709,454 713,454 718,453 722,452 727,452 731,451 736,450 740,450 745,449 749,449 754,448 758,448 763,447 767,446 772,446 776,446 781,445 785,445 790,444 794,444 799,443 803,443 808,443 812,442 817,442 821,442 826,441 830,441 835,441 839,441 844,440 848,440 853,440 857,440 862,439 866,439 871,439 875,439 880,438 884,438 889,438 893,438 898,438 902,438 907,438 911,437 916,437 920,437 925,437 929,437 934,437 938,437 943,437 947,436 952,436 956,436 961,436 965,436 970,436 974,436 979,436 983,436 988,436 992,436 997,435 1001,435 1006,435 1010,435 1015,435 1019,435 1024,435 1028,435 1033,435 1037,435 1042,435 1046,435 1051,434 1055,435 1060,435 1064,435 1069,434 1073,434 1078,434 1082,434 1087,434 1091,434 1096,434 1100,434 1105,434 1109,434 1114,434 1118,434 1123,434 1127,434 1132,434 1136,434 1141,434 1145,434 1150,434 1154,434 1159,434 1163,434 1168,434 1172,434 1177,434 1181,434 1186,433 1190,434 1195,434 1199,434 1204,433 1208,434 1213,434 1217,433 1222,433 1226,433 1231,434 1235,433 1240,433 1244,433 1249,433 1253,433 1258,433 1262,433 1267,433 1271,433 1276,433 1280,433 1285,433 1289,433 1294,433 1298,433 1303,433 1307,433 1312,433 1316,433 1321,433 1325,433 1330,433 1334,433 1339,433 1343,433 1348,433 1352,433 1357,433 1361,433 1366,433 1370,433 1375,433 1379,433 1384,433 1388,433 1393,433 1397,433 1402,433 1406,433 1411,433 1415,433 1420,433 1424,433 1429,433 1433,433 1438,433 1442,433 1447,433 1451,433 1456,433 1460,433 1465,433 1469,433 1474,433 1478,433 1483,433 1487,433 1492,433 1496,433 1501,433 1505,433 1510,433 1514,433 1519,433 1523,433 1528,433 1532,433 1537,433 1541,433 1546,433 1550,433 1555,433 1559,433 1564,433 1568,433 1573,433 1577,433 1582,433 1586,433 1591,433 1595,433 1600,433 1604,433 1609,433 1613,433 1618,433 1622,433 1626,433 1631,433 1635,433 1640,433 1644,433 1649,433 1653,433 1658,433 1662,433 1667,433 1671,433 1676,433 1680,433 1685,433 1689,433 1694,433 1698,433 1703,433 1707,433 1712,433 1716,433 1721,433 1725,432 1730,433 1734,433 1739,433 1743,433 1748,433 1752,433 1757,433 1761,433 1766,433 1770,433 1775,432 1779,433 1784,433 1788,433 1793,432 1797,433 1802,433 1806,433 1811,433 1815,433 1820,433 1824,433 1829,433 1833,433 1838,433 1842,432 1847,433 1851,433 1856,433 1860,432 1865,433 1869,433 1874,433 1878,432 1883,433 1887,433 1892,433 1896,432 1901,433 1905,433 1910,432 1914,433 1919,433 1923,433 1928,432 1932,433 1937,433 1941,433 1946,432 1950,433 1955,433 1959,432 1964,432 1968,433 1973,433 1977,432 1982,432 1986,433 1991,433 1995,432 2000,432 2004,433 2009,433 2013,432 2018,433 2022,433 2027,432 2031,432 2036,433 2040,433 2045,432 2049,432 2054,433 2058,433 2063,432 2067,432 2072,433 2076,433 2081,432 2085,432 2090,433 2094,432 2099,432 2103,432 2108,433 2112,432 2117,432 2121,432 2126,433 2130,432 2135,432 2139,432 2144,432 2148,432 2153,432 2157,433 2162,432 2166,432 2171,432 2175,433 2180,432 2184,432 2189,432 2193,432 2198,432 2202,432 2207,432 2211,432 2216,432 2220,432 2225,432 2229,432 2234,432 2238,432 2243,432 2247,432 2252,432 2256,432 2261,432 2265,432 2270,432 2274,432 2279,432 2283,432 2288,432 2292,432 2297,432 2301,432 2306,432 2310,432 2315,432 2319,432 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2226 74,2226 "/>
+<text x="65" y="2127" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2127 74,2127 "/>
+<text x="65" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2029 74,2029 "/>
+<text x="65" y="1930" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1930 74,1930 "/>
+<text x="65" y="1831" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1831 74,1831 "/>
+<text x="65" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1733 74,1733 "/>
+<text x="65" y="1634" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1634 74,1634 "/>
+<text x="65" y="1535" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1535 74,1535 "/>
+<text x="65" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+9M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1437 74,1437 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1797 79,1346 84,1967 88,2289 93,1600 97,1423 102,2148 106,2174 111,1443 115,1570 120,2275 124,2000 129,1353 133,1763 138,2324 142,1797 147,1346 151,1967 156,2289 160,1600 165,1423 169,2148 174,2174 178,1443 183,1570 187,2275 192,2000 196,1353 201,1763 205,2324 210,1797 214,1346 219,1967 223,2289 228,1600 232,1423 237,2148 241,2174 246,1443 250,1570 255,2275 259,2000 264,1353 268,1763 273,2324 277,1797 282,1346 286,1967 291,2289 295,1600 300,1423 304,2148 309,2174 313,1443 318,1570 322,2275 327,2000 331,1353 336,1763 340,2324 345,1797 349,1346 354,1967 358,2289 363,1600 367,1423 372,2148 376,2174 381,1443 385,1570 390,2275 394,2000 399,1353 403,1763 408,2324 412,1797 417,1346 421,1967 426,2289 430,1600 435,1423 439,2148 444,2174 448,1443 453,1570 457,2275 462,2000 466,1353 471,1763 475,2324 480,1797 484,1346 489,1967 493,2289 498,1600 502,1423 506,2148 511,2174 515,1443 520,1570 524,2275 529,2000 533,1353 538,1763 542,2324 547,1797 551,1346 556,1967 560,2289 565,1600 569,1423 574,2148 578,2174 583,1443 587,1570 592,2275 596,2000 601,1353 605,1763 610,2324 614,1797 619,1346 623,1967 628,2289 632,1600 637,1423 641,2148 646,2174 650,1443 655,1570 659,2275 664,2000 668,1353 673,1763 677,2324 682,1797 686,1346 691,1967 695,2289 700,1600 704,1423 709,2148 713,2174 718,1443 722,1570 727,2275 731,2000 736,1353 740,1763 745,2324 749,1797 754,1346 758,1967 763,2289 767,1600 772,1423 776,2148 781,2174 785,1443 790,1570 794,2275 799,2000 803,1353 808,1763 812,2324 817,1797 821,1346 826,1967 830,2289 835,1600 839,1423 844,2148 848,2174 853,1443 857,1570 862,2275 866,2000 871,1353 875,1763 880,2324 884,1797 889,1346 893,1967 898,2289 902,1600 907,1423 911,2148 916,2174 920,1443 925,1570 929,2275 934,2000 938,1353 943,1763 947,2324 952,1797 956,1346 961,1967 965,2289 970,1600 974,1423 979,2148 983,2174 988,1443 992,1570 997,2275 1001,2000 1006,1353 1010,1763 1015,2324 1019,1797 1024,1346 1028,1967 1033,2289 1037,1600 1042,1423 1046,2148 1051,2174 1055,1443 1060,1570 1064,2275 1069,2000 1073,1353 1078,1763 1082,2324 1087,1797 1091,1346 1096,1967 1100,2289 1105,1600 1109,1423 1114,2148 1118,2174 1123,1443 1127,1570 1132,2275 1136,2000 1141,1353 1145,1763 1150,2324 1154,1797 1159,1346 1163,1967 1168,2289 1172,1600 1177,1423 1181,2148 1186,2174 1190,1443 1195,1570 1199,2275 1204,2000 1208,1353 1213,1763 1217,2324 1222,1797 1226,1346 1231,1967 1235,2289 1240,1600 1244,1423 1249,2148 1253,2174 1258,1443 1262,1570 1267,2275 1271,2000 1276,1353 1280,1763 1285,2324 1289,1797 1294,1346 1298,1967 1303,2289 1307,1600 1312,1423 1316,2148 1321,2174 1325,1443 1330,1570 1334,2275 1339,2000 1343,1353 1348,1763 1352,2324 1357,1797 1361,1346 1366,1967 1370,2289 1375,1600 1379,1423 1384,2148 1388,2174 1393,1443 1397,1570 1402,2275 1406,2000 1411,1353 1415,1763 1420,2324 1424,1797 1429,1346 1433,1967 1438,2289 1442,1600 1447,1423 1451,2148 1456,2174 1460,1443 1465,1570 1469,2275 1474,2000 1478,1353 1483,1763 1487,2324 1492,1797 1496,1346 1501,1967 1505,2289 1510,1600 1514,1423 1519,2148 1523,2174 1528,1443 1532,1570 1537,2275 1541,2000 1546,1353 1550,1763 1555,2324 1559,1797 1564,1346 1568,1967 1573,2289 1577,1600 1582,1423 1586,2148 1591,2174 1595,1443 1600,1570 1604,2275 1609,2000 1613,1353 1618,1763 1622,2324 1626,1797 1631,1346 1635,1967 1640,2289 1644,1600 1649,1423 1653,2148 1658,2174 1662,1443 1667,1570 1671,2275 1676,2000 1680,1353 1685,1763 1689,2324 1694,1797 1698,1346 1703,1967 1707,2289 1712,1600 1716,1423 1721,2148 1725,2174 1730,1443 1734,1570 1739,2275 1743,2000 1748,1353 1752,1763 1757,2324 1761,1797 1766,1346 1770,1967 1775,2289 1779,1600 1784,1423 1788,2148 1793,2174 1797,1443 1802,1570 1806,2275 1811,2000 1815,1353 1820,1763 1824,2324 1829,1797 1833,1346 1838,1967 1842,2289 1847,1600 1851,1423 1856,2148 1860,2174 1865,1443 1869,1570 1874,2275 1878,2000 1883,1353 1887,1763 1892,2324 1896,1797 1901,1346 1905,1967 1910,2289 1914,1600 1919,1423 1923,2148 1928,2174 1932,1443 1937,1570 1941,2275 1946,2000 1950,1353 1955,1763 1959,2324 1964,1797 1968,1346 1973,1967 1977,2289 1982,1600 1986,1423 1991,2148 1995,2174 2000,1443 2004,1570 2009,2275 2013,2000 2018,1353 2022,1763 2027,2324 2031,1797 2036,1346 2040,1967 2045,2289 2049,1600 2054,1423 2058,2148 2063,2174 2067,1443 2072,1570 2076,2275 2081,2000 2085,1353 2090,1763 2094,2324 2099,1797 2103,1346 2108,1967 2112,2289 2117,1600 2121,1423 2126,2148 2130,2174 2135,1443 2139,1570 2144,2275 2148,2000 2153,1353 2157,1763 2162,2324 2166,1797 2171,1346 2175,1967 2180,2289 2184,1600 2189,1423 2193,2148 2198,2174 2202,1443 2207,1570 2211,2275 2216,2000 2220,1353 2225,1763 2229,2324 2234,1797 2238,1346 2243,1967 2247,2289 2252,1600 2256,1423 2261,2148 2265,2174 2270,1443 2274,1570 2279,2275 2283,2000 2288,1353 2292,1763 2297,2324 2301,1797 2306,1346 2310,1967 2315,2289 2319,1600 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2275 664,2276 669,2276 673,2276 678,2094 682,2276 687,2276 691,2276 696,1832 700,2276 705,2276 709,2209 714,2022 718,2276 723,2276 727,2031 732,2218 736,2276 741,2265 745,1832 750,2257 754,2276 759,2223 763,1832 768,2271 772,2276 777,2129 781,1935 786,2276 790,2268 795,1902 799,2177 804,2276 808,2246 813,1832 817,2240 822,2276 826,2201 831,1832 835,2262 840,2274 844,2103 849,1913 853,2273 858,2263 862,1870 867,2167 871,2276 876,2243 880,1832 885,2238 889,2276 894,2201 898,1832 903,2264 907,2275 912,2110 916,1919 921,2274 925,2264 930,1869 934,2165 939,2276 943,2239 948,1832 952,2232 957,2275 961,2190 966,1832 970,2256 975,2268 979,2079 984,1888 988,2266 993,2254 997,1832 1002,2144 1006,2270 1011,2229 1015,1832 1020,2221 1024,2269 1029,2176 1033,1832 1038,2249 1042,2263 1047,2056 1051,1872 1056,2261 1060,2248 1065,1832 1069,2129 1074,2266 1078,2221 1083,1832 1087,2214 1092,2265 1096,2166 1101,1832 1105,2244 1110,2259 1114,2040 1119,1862 1123,2257 1128,2244 1132,1832 1137,2120 1141,2263 1146,2217 1150,1832 1155,2209 1159,2263 1164,2159 1168,1832 1173,2241 1177,2256 1182,2029 1186,1855 1191,2255 1195,2242 1200,1832 1204,2113 1209,2261 1213,2213 1218,1832 1222,2205 1227,2261 1231,2154 1236,1832 1240,2239 1245,2255 1249,2022 1254,1852 1258,2253 1263,2239 1267,1832 1272,2108 1276,2259 1281,2210 1285,1832 1290,2202 1294,2259 1299,2150 1303,1832 1308,2237 1312,2253 1317,2015 1321,1849 1326,2251 1330,2237 1335,1832 1339,2103 1344,2258 1348,2208 1353,1832 1357,2200 1362,2258 1366,2147 1371,1832 1375,2235 1380,2252 1384,2010 1389,1847 1393,2251 1398,2236 1402,1832 1407,2100 1411,2257 1416,2206 1420,1832 1425,2198 1429,2257 1434,2144 1438,1832 1443,2234 1447,2250 1452,2005 1456,1844 1461,2250 1465,2235 1470,1832 1474,2096 1479,2256 1483,2204 1488,1832 1492,2197 1497,2256 1501,2142 1506,1832 1510,2232 1515,2249 1519,2000 1524,1843 1528,2249 1533,2234 1537,1832 1542,2094 1546,2255 1551,2203 1555,1832 1560,2195 1564,2255 1569,2139 1573,1832 1578,2231 1582,2248 1587,1997 1591,1841 1596,2248 1600,2232 1605,1832 1609,2091 1614,2254 1618,2201 1623,1832 1627,2193 1632,2254 1636,2137 1641,1832 1645,2230 1650,2248 1654,1992 1659,1839 1663,2247 1668,2232 1672,1832 1677,2088 1681,2253 1686,2200 1690,1832 1695,2192 1699,2253 1704,2135 1708,1832 1713,2229 1717,2247 1722,1989 1726,1837 1731,2246 1735,2231 1740,1832 1744,2085 1749,2252 1753,2198 1758,1832 1762,2190 1767,2253 1771,2133 1776,1832 1780,2228 1785,2245 1789,1985 1794,1836 1798,2245 1803,2230 1807,1832 1812,2082 1816,2252 1821,2197 1825,1832 1830,2189 1834,2252 1839,2130 1843,1832 1848,2227 1852,2244 1857,1981 1861,1834 1866,2244 1870,2229 1875,1832 1879,2080 1884,2251 1888,2196 1893,1832 1897,2187 1902,2251 1906,2128 1911,1832 1915,2226 1920,2244 1924,1977 1929,1832 1933,2243 1938,2228 1942,1832 1947,2077 1951,2250 1956,2194 1960,1832 1965,2185 1969,2250 1974,2126 1978,1832 1983,2225 1987,2243 1992,1973 1996,1832 2001,2242 2005,2227 2010,1832 2014,2074 2019,2249 2023,2193 2028,1832 2032,2184 2037,2249 2041,2124 2046,1832 2050,2223 2055,2242 2059,1969 2064,1832 2068,2241 2073,2226 2077,1832 2082,2071 2086,2248 2091,2191 2095,1832 2100,2182 2104,2249 2109,2121 2113,1832 2118,2222 2122,2241 2127,1965 2131,1832 2136,2241 2140,2225 2145,1832 2149,2069 2154,2247 2158,2190 2163,1832 2167,2180 2172,2248 2176,2119 2181,1832 2185,2221 2190,2240 2194,1961 2199,1832 2203,2239 2208,2223 2212,1832 2217,2068 2221,2246 2226,2188 2230,1832 2235,2179 2239,2246 2244,2117 2248,1832 2253,2220 2257,2239 2262,1957 2266,1832 2271,2238 2275,2222 2280,1832 2284,2065 2289,2246 2293,2186 2298,1832 2302,2177 2307,2246 2311,2114 2316,1832 2320,2219 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, low frequency_0.000300.svg
+++ b/src/assets/rfc-323/throttle_18000000000.000000 T_Unstable fees, low frequency_0.000300.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, low frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 18.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,938 79,929 84,921 88,912 93,904 97,896 102,888 106,880 111,873 115,865 120,858 124,850 129,843 133,836 138,829 142,822 147,815 151,809 156,802 160,795 165,789 169,783 174,776 178,770 183,765 187,759 192,753 196,747 201,742 205,736 210,730 214,725 219,720 223,715 228,709 232,705 237,700 241,694 246,690 250,685 255,680 259,676 264,671 268,667 273,663 277,658 282,654 286,650 291,646 295,642 300,638 304,634 309,630 313,626 318,623 322,619 327,615 331,612 336,608 340,605 345,601 349,598 354,595 358,592 363,588 367,586 372,583 376,579 381,576 385,574 390,571 394,568 399,565 403,563 408,560 412,557 417,555 421,552 426,549 430,547 435,545 439,542 444,540 448,537 453,535 457,533 462,531 466,529 471,527 475,525 480,522 484,520 489,519 493,516 498,514 502,513 506,511 511,509 515,507 520,506 524,504 529,502 533,500 538,499 542,497 547,496 551,494 556,493 560,491 565,490 569,488 574,487 578,486 583,484 587,483 592,482 596,480 601,479 605,478 610,477 614,476 619,475 623,474 628,472 632,471 637,471 641,470 646,469 650,468 655,467 659,466 664,465 668,464 673,463 677,462 682,462 686,461 691,460 695,459 700,459 704,458 709,457 713,457 718,456 722,456 727,455 731,454 736,454 740,453 745,453 749,452 754,452 758,451 763,450 767,450 772,450 776,449 781,449 785,448 790,448 794,448 799,447 803,447 808,446 812,446 817,446 821,445 826,445 830,445 835,444 839,444 844,444 848,443 853,443 857,443 862,443 866,442 871,442 875,442 880,442 884,442 889,441 893,441 898,441 902,441 907,441 911,441 916,440 920,440 925,440 929,440 934,440 938,440 943,439 947,439 952,439 956,439 961,439 965,439 970,438 974,438 979,438 983,438 988,438 992,438 997,438 1001,438 1006,437 1010,437 1015,437 1019,437 1024,437 1028,437 1033,437 1037,437 1042,437 1046,437 1051,436 1055,436 1060,436 1064,436 1069,436 1073,436 1078,436 1082,436 1087,436 1091,436 1096,436 1100,435 1105,435 1109,435 1114,435 1118,435 1123,435 1127,435 1132,435 1136,435 1141,435 1145,435 1150,435 1154,435 1159,435 1163,435 1168,434 1172,434 1177,434 1181,434 1186,434 1190,434 1195,434 1199,434 1204,434 1208,434 1213,434 1217,434 1222,434 1226,434 1231,434 1235,434 1240,434 1244,434 1249,434 1253,434 1258,434 1262,434 1267,434 1271,433 1276,434 1280,434 1285,433 1289,433 1294,433 1298,434 1303,433 1307,433 1312,433 1316,433 1321,433 1325,433 1330,433 1334,433 1339,433 1343,433 1348,433 1352,433 1357,433 1361,433 1366,433 1370,433 1375,433 1379,433 1384,433 1388,433 1393,433 1397,433 1402,433 1406,433 1411,433 1415,433 1420,433 1424,433 1429,433 1433,433 1438,433 1442,433 1447,433 1451,433 1456,433 1460,433 1465,433 1469,433 1474,433 1478,433 1483,433 1487,433 1492,433 1496,433 1501,433 1505,432 1510,433 1514,433 1519,433 1523,432 1528,433 1532,433 1537,433 1541,432 1546,433 1550,433 1555,432 1559,432 1564,433 1568,433 1573,432 1577,432 1582,433 1586,433 1591,432 1595,432 1600,433 1604,433 1609,432 1613,432 1618,433 1622,432 1626,432 1631,432 1635,433 1640,432 1644,432 1649,432 1653,432 1658,432 1662,432 1667,432 1671,432 1676,432 1680,432 1685,432 1689,432 1694,432 1698,432 1703,432 1707,432 1712,432 1716,432 1721,432 1725,432 1730,432 1734,432 1739,432 1743,432 1748,432 1752,432 1757,432 1761,432 1766,432 1770,432 1775,432 1779,432 1784,432 1788,432 1793,432 1797,432 1802,432 1806,432 1811,432 1815,432 1820,432 1824,432 1829,432 1833,432 1838,432 1842,432 1847,432 1851,432 1856,432 1860,432 1865,432 1869,432 1874,432 1878,432 1883,432 1887,432 1892,432 1896,432 1901,432 1905,432 1910,432 1914,432 1919,432 1923,432 1928,432 1932,432 1937,432 1941,432 1946,432 1950,432 1955,432 1959,432 1964,432 1968,432 1973,432 1977,432 1982,432 1986,432 1991,432 1995,432 2000,432 2004,432 2009,432 2013,432 2018,432 2022,432 2027,432 2031,432 2036,432 2040,432 2045,432 2049,432 2054,432 2058,432 2063,432 2067,432 2072,432 2076,432 2081,432 2085,432 2090,432 2094,432 2099,432 2103,432 2108,432 2112,432 2117,432 2121,432 2126,432 2130,432 2135,432 2139,432 2144,432 2148,432 2153,432 2157,432 2162,432 2166,432 2171,432 2175,432 2180,432 2184,432 2189,432 2193,432 2198,432 2202,432 2207,432 2211,432 2216,432 2220,432 2225,432 2229,432 2234,432 2238,432 2243,432 2247,432 2252,432 2256,432 2261,432 2265,432 2270,432 2274,432 2279,432 2283,432 2288,432 2292,432 2297,432 2301,432 2306,432 2310,432 2315,432 2319,432 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2226 74,2226 "/>
+<text x="65" y="2127" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2127 74,2127 "/>
+<text x="65" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2029 74,2029 "/>
+<text x="65" y="1930" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1930 74,1930 "/>
+<text x="65" y="1831" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1831 74,1831 "/>
+<text x="65" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1733 74,1733 "/>
+<text x="65" y="1634" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1634 74,1634 "/>
+<text x="65" y="1535" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1535 74,1535 "/>
+<text x="65" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+9M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1437 74,1437 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1797 79,1346 84,1967 88,2289 93,1600 97,1423 102,2148 106,2174 111,1443 115,1570 120,2275 124,2000 129,1353 133,1763 138,2324 142,1797 147,1346 151,1967 156,2289 160,1600 165,1423 169,2148 174,2174 178,1443 183,1570 187,2275 192,2000 196,1353 201,1763 205,2324 210,1797 214,1346 219,1967 223,2289 228,1600 232,1423 237,2148 241,2174 246,1443 250,1570 255,2275 259,2000 264,1353 268,1763 273,2324 277,1797 282,1346 286,1967 291,2289 295,1600 300,1423 304,2148 309,2174 313,1443 318,1570 322,2275 327,2000 331,1353 336,1763 340,2324 345,1797 349,1346 354,1967 358,2289 363,1600 367,1423 372,2148 376,2174 381,1443 385,1570 390,2275 394,2000 399,1353 403,1763 408,2324 412,1797 417,1346 421,1967 426,2289 430,1600 435,1423 439,2148 444,2174 448,1443 453,1570 457,2275 462,2000 466,1353 471,1763 475,2324 480,1797 484,1346 489,1967 493,2289 498,1600 502,1423 506,2148 511,2174 515,1443 520,1570 524,2275 529,2000 533,1353 538,1763 542,2324 547,1797 551,1346 556,1967 560,2289 565,1600 569,1423 574,2148 578,2174 583,1443 587,1570 592,2275 596,2000 601,1353 605,1763 610,2324 614,1797 619,1346 623,1967 628,2289 632,1600 637,1423 641,2148 646,2174 650,1443 655,1570 659,2275 664,2000 668,1353 673,1763 677,2324 682,1797 686,1346 691,1967 695,2289 700,1600 704,1423 709,2148 713,2174 718,1443 722,1570 727,2275 731,2000 736,1353 740,1763 745,2324 749,1797 754,1346 758,1967 763,2289 767,1600 772,1423 776,2148 781,2174 785,1443 790,1570 794,2275 799,2000 803,1353 808,1763 812,2324 817,1797 821,1346 826,1967 830,2289 835,1600 839,1423 844,2148 848,2174 853,1443 857,1570 862,2275 866,2000 871,1353 875,1763 880,2324 884,1797 889,1346 893,1967 898,2289 902,1600 907,1423 911,2148 916,2174 920,1443 925,1570 929,2275 934,2000 938,1353 943,1763 947,2324 952,1797 956,1346 961,1967 965,2289 970,1600 974,1423 979,2148 983,2174 988,1443 992,1570 997,2275 1001,2000 1006,1353 1010,1763 1015,2324 1019,1797 1024,1346 1028,1967 1033,2289 1037,1600 1042,1423 1046,2148 1051,2174 1055,1443 1060,1570 1064,2275 1069,2000 1073,1353 1078,1763 1082,2324 1087,1797 1091,1346 1096,1967 1100,2289 1105,1600 1109,1423 1114,2148 1118,2174 1123,1443 1127,1570 1132,2275 1136,2000 1141,1353 1145,1763 1150,2324 1154,1797 1159,1346 1163,1967 1168,2289 1172,1600 1177,1423 1181,2148 1186,2174 1190,1443 1195,1570 1199,2275 1204,2000 1208,1353 1213,1763 1217,2324 1222,1797 1226,1346 1231,1967 1235,2289 1240,1600 1244,1423 1249,2148 1253,2174 1258,1443 1262,1570 1267,2275 1271,2000 1276,1353 1280,1763 1285,2324 1289,1797 1294,1346 1298,1967 1303,2289 1307,1600 1312,1423 1316,2148 1321,2174 1325,1443 1330,1570 1334,2275 1339,2000 1343,1353 1348,1763 1352,2324 1357,1797 1361,1346 1366,1967 1370,2289 1375,1600 1379,1423 1384,2148 1388,2174 1393,1443 1397,1570 1402,2275 1406,2000 1411,1353 1415,1763 1420,2324 1424,1797 1429,1346 1433,1967 1438,2289 1442,1600 1447,1423 1451,2148 1456,2174 1460,1443 1465,1570 1469,2275 1474,2000 1478,1353 1483,1763 1487,2324 1492,1797 1496,1346 1501,1967 1505,2289 1510,1600 1514,1423 1519,2148 1523,2174 1528,1443 1532,1570 1537,2275 1541,2000 1546,1353 1550,1763 1555,2324 1559,1797 1564,1346 1568,1967 1573,2289 1577,1600 1582,1423 1586,2148 1591,2174 1595,1443 1600,1570 1604,2275 1609,2000 1613,1353 1618,1763 1622,2324 1626,1797 1631,1346 1635,1967 1640,2289 1644,1600 1649,1423 1653,2148 1658,2174 1662,1443 1667,1570 1671,2275 1676,2000 1680,1353 1685,1763 1689,2324 1694,1797 1698,1346 1703,1967 1707,2289 1712,1600 1716,1423 1721,2148 1725,2174 1730,1443 1734,1570 1739,2275 1743,2000 1748,1353 1752,1763 1757,2324 1761,1797 1766,1346 1770,1967 1775,2289 1779,1600 1784,1423 1788,2148 1793,2174 1797,1443 1802,1570 1806,2275 1811,2000 1815,1353 1820,1763 1824,2324 1829,1797 1833,1346 1838,1967 1842,2289 1847,1600 1851,1423 1856,2148 1860,2174 1865,1443 1869,1570 1874,2275 1878,2000 1883,1353 1887,1763 1892,2324 1896,1797 1901,1346 1905,1967 1910,2289 1914,1600 1919,1423 1923,2148 1928,2174 1932,1443 1937,1570 1941,2275 1946,2000 1950,1353 1955,1763 1959,2324 1964,1797 1968,1346 1973,1967 1977,2289 1982,1600 1986,1423 1991,2148 1995,2174 2000,1443 2004,1570 2009,2275 2013,2000 2018,1353 2022,1763 2027,2324 2031,1797 2036,1346 2040,1967 2045,2289 2049,1600 2054,1423 2058,2148 2063,2174 2067,1443 2072,1570 2076,2275 2081,2000 2085,1353 2090,1763 2094,2324 2099,1797 2103,1346 2108,1967 2112,2289 2117,1600 2121,1423 2126,2148 2130,2174 2135,1443 2139,1570 2144,2275 2148,2000 2153,1353 2157,1763 2162,2324 2166,1797 2171,1346 2175,1967 2180,2289 2184,1600 2189,1423 2193,2148 2198,2174 2202,1443 2207,1570 2211,2275 2216,2000 2220,1353 2225,1763 2229,2324 2234,1797 2238,1346 2243,1967 2247,2289 2252,1600 2256,1423 2261,2148 2265,2174 2270,1443 2274,1570 2279,2275 2283,2000 2288,1353 2292,1763 2297,2324 2301,1797 2306,1346 2310,1967 2315,2289 2319,1600 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2275 529,2276 534,2276 538,2276 543,2067 547,2276 552,2276 556,2276 561,1835 565,2276 570,2276 574,2219 579,2107 583,2276 588,2276 592,2033 597,2242 601,2276 606,2273 610,1832 615,2268 619,2276 624,2233 628,1832 633,2276 637,2276 642,2140 646,2005 651,2276 655,2274 660,1883 664,2203 669,2276 673,2253 678,1832 682,2249 687,2276 691,2207 696,1832 700,2267 705,2276 709,2101 714,1962 718,2276 723,2266 727,1832 732,2188 736,2276 741,2245 745,1832 750,2242 754,2276 759,2199 763,1832 768,2265 772,2274 777,2092 781,1954 786,2276 790,2263 795,1832 799,2187 804,2276 808,2250 813,1832 817,2243 822,2276 826,2202 831,1832 835,2267 840,2276 844,2103 849,1967 853,2276 858,2272 862,1841 867,2195 871,2276 876,2249 880,1832 885,2250 889,2276 894,2213 898,1832 903,2272 907,2276 912,2124 916,1989 921,2276 925,2273 930,1861 934,2198 939,2276 943,2249 948,1832 952,2247 957,2276 961,2203 966,1832 970,2266 975,2276 979,2092 984,1948 988,2276 993,2260 997,1832 1002,2178 1006,2276 1011,2228 1015,1832 1020,2235 1024,2274 1029,2187 1033,1832 1038,2258 1042,2259 1047,2064 1051,1918 1056,2265 1060,2232 1065,1832 1069,2162 1074,2276 1078,2244 1083,1832 1087,2227 1092,2276 1096,2175 1101,1832 1105,2252 1110,2246 1114,2044 1119,1902 1123,2264 1128,2276 1132,1832 1137,2152 1141,2251 1146,2206 1150,1832 1155,2220 1159,2250 1164,2166 1168,1832 1173,2248 1177,2276 1182,2028 1186,1888 1191,2261 1195,2276 1200,1832 1204,2143 1209,2243 1213,2199 1218,1832 1222,2215 1227,2243 1231,2159 1236,1832 1240,2245 1245,2230 1249,2016 1254,1877 1258,2259 1263,2276 1267,1832 1272,2136 1276,2236 1281,2194 1285,1832 1290,2212 1294,2276 1299,2153 1303,1832 1308,2242 1312,2224 1317,2007 1321,1868 1326,2257 1330,2276 1335,1832 1339,2131 1344,2231 1348,2189 1353,1832 1357,2209 1362,2276 1366,2149 1371,1832 1375,2240 1380,2220 1384,2000 1389,1864 1393,2255 1398,2276 1402,1832 1407,2126 1411,2276 1416,2233 1420,1832 1425,2206 1429,2228 1434,2145 1438,1832 1443,2239 1447,2276 1452,1993 1456,1860 1461,2250 1465,2192 1470,1832 1474,2123 1479,2224 1483,2183 1488,1832 1492,2204 1497,2276 1501,2142 1506,1832 1510,2237 1515,2276 1519,1987 1524,1857 1528,2255 1533,2276 1537,1832 1542,2120 1546,2220 1551,2180 1555,1832 1560,2202 1564,2276 1569,2139 1573,1832 1578,2235 1582,2210 1587,1982 1591,1854 1596,2249 1600,2186 1605,1832 1609,2117 1614,2276 1618,2229 1623,1832 1627,2201 1632,2218 1636,2137 1641,1832 1645,2234 1650,2207 1654,1978 1659,1851 1663,2246 1668,2185 1672,1832 1677,2114 1681,2276 1686,2228 1690,1832 1695,2199 1699,2216 1704,2134 1708,1832 1713,2233 1717,2205 1722,1973 1726,1848 1731,2249 1735,2183 1740,1832 1744,2111 1749,2212 1753,2173 1758,1832 1762,2197 1767,2213 1771,2132 1776,1832 1780,2232 1785,2276 1789,1969 1794,1846 1798,2249 1803,2276 1807,1832 1812,2108 1816,2276 1821,2227 1825,1832 1830,2196 1834,2211 1839,2130 1843,1832 1848,2231 1852,2276 1857,1965 1861,1843 1866,2250 1870,2276 1875,1832 1879,2106 1884,2217 1888,2168 1893,1832 1897,2194 1902,2276 1906,2127 1911,1832 1915,2231 1920,2276 1924,1961 1929,1841 1933,2251 1938,2276 1942,1832 1947,2104 1951,2276 1956,2225 1960,1832 1965,2193 1969,2276 1974,2125 1978,1832 1983,2229 1987,2276 1992,1957 1996,1839 2001,2250 2005,2276 2010,1832 2014,2101 2019,2276 2023,2224 2028,1832 2032,2191 2037,2276 2041,2123 2046,1832 2050,2228 2055,2193 2059,1953 2064,1837 2068,2245 2073,2276 2077,1832 2082,2099 2086,2200 2091,2163 2095,1832 2100,2190 2104,2276 2109,2121 2113,1832 2118,2226 2122,2190 2127,1949 2131,1834 2136,2250 2140,2276 2145,1832 2149,2097 2154,2255 2158,2223 2163,1832 2167,2189 2172,2199 2176,2119 2181,1832 2185,2226 2190,2276 2194,1945 2199,1832 2203,2245 2208,2276 2212,1832 2217,2096 2221,2196 2226,2159 2230,1832 2235,2187 2239,2276 2244,2117 2248,1832 2253,2224 2257,2185 2262,1941 2266,1832 2271,2241 2275,2164 2280,1832 2284,2094 2289,2276 2293,2221 2298,1832 2302,2186 2307,2195 2311,2114 2316,1832 2320,2224 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_10% annual fee growth_0.000100.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_10% annual fee growth_0.000100.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+10% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,498 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,470 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,435 551,433 556,431 560,429 565,427 569,426 574,424 578,423 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,388 700,387 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,377 749,376 754,375 758,374 763,373 767,372 772,371 776,370 781,370 785,369 790,368 794,367 799,366 803,366 808,365 812,364 817,363 821,363 826,362 830,361 835,361 839,360 844,359 848,359 853,358 857,357 862,357 866,356 871,355 875,355 880,354 884,354 889,353 893,353 898,352 902,351 907,351 911,350 916,350 920,349 925,349 929,348 934,348 938,347 943,347 947,346 952,346 956,345 961,345 965,344 970,344 974,343 979,343 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,339 1015,338 1019,338 1024,337 1028,337 1033,336 1037,336 1042,335 1046,335 1051,334 1055,334 1060,333 1064,332 1069,332 1073,331 1078,331 1082,330 1087,330 1091,329 1096,329 1100,328 1105,328 1109,327 1114,327 1118,326 1123,326 1127,325 1132,324 1136,324 1141,323 1145,323 1150,322 1154,322 1159,321 1163,321 1168,320 1172,320 1177,319 1181,319 1186,318 1190,318 1195,317 1199,317 1204,316 1208,316 1213,315 1217,315 1222,314 1226,314 1231,313 1235,313 1240,312 1244,312 1249,311 1253,311 1258,310 1262,310 1267,309 1271,309 1276,308 1280,308 1285,307 1289,307 1294,306 1298,306 1303,305 1307,305 1312,304 1316,304 1321,303 1325,302 1330,302 1334,301 1339,301 1343,300 1348,300 1352,299 1357,299 1361,298 1366,298 1370,297 1375,297 1379,296 1384,296 1388,295 1393,295 1397,294 1402,294 1406,293 1411,293 1415,292 1420,292 1424,291 1429,291 1433,290 1438,290 1442,289 1447,289 1451,288 1456,288 1460,287 1465,287 1469,286 1474,286 1478,285 1483,285 1487,284 1492,284 1496,283 1501,283 1505,282 1510,282 1514,281 1519,281 1523,280 1528,280 1532,279 1537,279 1541,278 1546,278 1550,277 1555,277 1559,276 1564,276 1568,275 1573,275 1577,274 1582,274 1586,273 1591,273 1595,272 1600,272 1604,271 1609,271 1613,270 1618,270 1622,269 1626,269 1631,268 1635,268 1640,267 1644,267 1649,266 1653,265 1658,265 1662,264 1667,264 1671,263 1676,263 1680,262 1685,262 1689,261 1694,261 1698,260 1703,260 1707,259 1712,259 1716,258 1721,258 1725,257 1730,257 1734,256 1739,256 1743,255 1748,255 1752,254 1757,254 1761,253 1766,253 1770,252 1775,252 1779,251 1784,251 1788,250 1793,250 1797,249 1802,249 1806,248 1811,248 1815,247 1820,247 1824,246 1829,246 1833,245 1838,245 1842,244 1847,244 1851,243 1856,243 1860,242 1865,242 1869,241 1874,241 1878,240 1883,240 1887,239 1892,239 1896,238 1901,238 1905,237 1910,237 1914,236 1919,236 1923,236 1928,235 1932,235 1937,234 1941,234 1946,233 1950,233 1955,232 1959,232 1964,231 1968,231 1973,230 1977,230 1982,229 1986,229 1991,228 1995,228 2000,227 2004,227 2009,226 2013,226 2018,225 2022,225 2027,224 2031,224 2036,223 2040,223 2045,222 2049,222 2054,221 2058,221 2063,220 2067,220 2072,219 2076,219 2081,219 2085,218 2090,218 2094,217 2099,217 2103,216 2108,216 2112,215 2117,215 2121,214 2126,214 2130,213 2135,213 2139,212 2144,212 2148,211 2153,211 2157,210 2162,210 2166,210 2171,209 2175,209 2180,208 2184,208 2189,207 2193,207 2198,206 2202,206 2207,205 2211,205 2216,204 2220,204 2225,203 2229,203 2234,203 2238,202 2243,202 2247,201 2252,201 2256,200 2261,200 2265,199 2270,199 2274,198 2279,198 2283,198 2288,197 2292,197 2297,196 2301,196 2306,195 2310,195 2315,194 2319,194 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2206" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2206 74,2206 "/>
+<text x="65" y="2088" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2088 74,2088 "/>
+<text x="65" y="1970" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1970 74,1970 "/>
+<text x="65" y="1852" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1852 74,1852 "/>
+<text x="65" y="1734" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1734 74,1734 "/>
+<text x="65" y="1616" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1616 74,1616 "/>
+<text x="65" y="1497" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1497 74,1497 "/>
+<text x="65" y="1379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1379 74,1379 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2277 151,2277 156,2276 160,2276 165,2276 169,2275 174,2275 178,2275 183,2275 187,2274 192,2274 196,2274 201,2273 205,2273 210,2273 214,2272 219,2272 223,2272 228,2271 232,2271 237,2271 241,2270 246,2270 250,2270 255,2269 259,2269 264,2269 268,2268 273,2268 277,2268 282,2267 286,2267 291,2266 295,2266 300,2266 304,2265 309,2265 313,2265 318,2264 322,2264 327,2263 331,2263 336,2263 340,2262 345,2262 349,2262 354,2261 358,2261 363,2260 367,2260 372,2260 376,2259 381,2259 385,2258 390,2258 394,2257 399,2257 403,2257 408,2256 412,2256 417,2255 421,2255 426,2254 430,2254 435,2254 439,2253 444,2253 448,2252 453,2252 457,2251 462,2251 466,2250 471,2250 475,2249 480,2249 484,2249 489,2248 493,2248 498,2247 502,2247 506,2246 511,2246 515,2245 520,2245 524,2244 529,2244 533,2243 538,2243 542,2242 547,2242 551,2241 556,2240 560,2240 565,2239 569,2239 574,2238 578,2238 583,2237 587,2237 592,2236 596,2236 601,2235 605,2234 610,2234 614,2233 619,2233 623,2232 628,2232 632,2231 637,2230 641,2230 646,2229 650,2229 655,2228 659,2227 664,2227 668,2226 673,2226 677,2225 682,2224 686,2224 691,2223 695,2222 700,2222 704,2221 709,2221 713,2220 718,2219 722,2219 727,2218 731,2217 736,2217 740,2216 745,2215 749,2214 754,2214 758,2213 763,2212 767,2212 772,2211 776,2210 781,2210 785,2209 790,2208 794,2207 799,2207 803,2206 808,2205 812,2204 817,2204 821,2203 826,2202 830,2201 835,2201 839,2200 844,2199 848,2198 853,2197 857,2197 862,2196 866,2195 871,2194 875,2193 880,2193 884,2192 889,2191 893,2190 898,2189 902,2188 907,2188 911,2187 916,2186 920,2185 925,2184 929,2183 934,2182 938,2181 943,2180 947,2180 952,2179 956,2178 961,2177 965,2176 970,2175 974,2174 979,2173 983,2172 988,2171 992,2170 997,2169 1001,2168 1006,2167 1010,2166 1015,2165 1019,2164 1024,2163 1028,2162 1033,2161 1037,2160 1042,2159 1046,2158 1051,2157 1055,2156 1060,2155 1064,2154 1069,2153 1073,2152 1078,2151 1082,2150 1087,2148 1091,2147 1096,2146 1100,2145 1105,2144 1109,2143 1114,2142 1118,2141 1123,2139 1127,2138 1132,2137 1136,2136 1141,2135 1145,2134 1150,2132 1154,2131 1159,2130 1163,2129 1168,2127 1172,2126 1177,2125 1181,2124 1186,2122 1190,2121 1195,2120 1199,2119 1204,2117 1208,2116 1213,2115 1217,2113 1222,2112 1226,2111 1231,2109 1235,2108 1240,2107 1244,2105 1249,2104 1253,2103 1258,2101 1262,2100 1267,2098 1271,2097 1276,2096 1280,2094 1285,2093 1289,2091 1294,2090 1298,2088 1303,2087 1307,2085 1312,2084 1316,2082 1321,2081 1325,2079 1330,2078 1334,2076 1339,2075 1343,2073 1348,2071 1352,2070 1357,2068 1361,2067 1366,2065 1370,2063 1375,2062 1379,2060 1384,2058 1388,2057 1393,2055 1397,2053 1402,2052 1406,2050 1411,2048 1415,2046 1420,2045 1424,2043 1429,2041 1433,2039 1438,2038 1442,2036 1447,2034 1451,2032 1456,2030 1460,2028 1465,2027 1469,2025 1474,2023 1478,2021 1483,2019 1487,2017 1492,2015 1496,2013 1501,2011 1505,2009 1510,2007 1514,2005 1519,2003 1523,2001 1528,1999 1532,1997 1537,1995 1541,1993 1546,1991 1550,1989 1555,1987 1559,1985 1564,1983 1568,1980 1573,1978 1577,1976 1582,1974 1586,1972 1591,1969 1595,1967 1600,1965 1604,1963 1609,1960 1613,1958 1618,1956 1622,1953 1626,1951 1631,1949 1635,1946 1640,1944 1644,1942 1649,1939 1653,1937 1658,1934 1662,1932 1667,1929 1671,1927 1676,1924 1680,1922 1685,1919 1689,1917 1694,1914 1698,1912 1703,1909 1707,1907 1712,1904 1716,1901 1721,1899 1725,1896 1730,1893 1734,1891 1739,1888 1743,1885 1748,1882 1752,1880 1757,1877 1761,1874 1766,1871 1770,1868 1775,1865 1779,1862 1784,1860 1788,1857 1793,1854 1797,1851 1802,1848 1806,1845 1811,1842 1815,1839 1820,1836 1824,1833 1829,1830 1833,1826 1838,1823 1842,1820 1847,1817 1851,1814 1856,1811 1860,1807 1865,1804 1869,1801 1874,1797 1878,1794 1883,1791 1887,1787 1892,1784 1896,1781 1901,1777 1905,1774 1910,1770 1914,1767 1919,1763 1923,1760 1928,1756 1932,1753 1937,1749 1941,1746 1946,1742 1950,1738 1955,1735 1959,1731 1964,1727 1968,1723 1973,1720 1977,1716 1982,1712 1986,1708 1991,1704 1995,1700 2000,1696 2004,1692 2009,1688 2013,1684 2018,1680 2022,1676 2027,1672 2031,1668 2036,1664 2040,1660 2045,1656 2049,1652 2054,1647 2058,1643 2063,1639 2067,1634 2072,1630 2076,1626 2081,1621 2085,1617 2090,1613 2094,1608 2099,1604 2103,1599 2108,1594 2112,1590 2117,1585 2121,1581 2126,1576 2130,1571 2135,1566 2139,1562 2144,1557 2148,1552 2153,1547 2157,1542 2162,1537 2166,1532 2171,1528 2175,1522 2180,1517 2184,1512 2189,1507 2193,1502 2198,1497 2202,1492 2207,1487 2211,1481 2216,1476 2220,1471 2225,1465 2229,1460 2234,1454 2238,1449 2243,1443 2247,1438 2252,1432 2256,1427 2261,1421 2265,1415 2270,1410 2274,1404 2279,1398 2283,1392 2288,1386 2292,1381 2297,1375 2301,1369 2306,1363 2310,1357 2315,1351 2319,1344 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2264 1159,2165 1164,1983 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_10% annual fee growth_0.000200.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_10% annual fee growth_0.000200.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+10% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,498 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,470 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,435 551,433 556,431 560,429 565,427 569,426 574,424 578,423 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,388 700,387 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,377 749,376 754,375 758,374 763,373 767,372 772,371 776,370 781,370 785,369 790,368 794,367 799,366 803,366 808,365 812,364 817,363 821,363 826,362 830,361 835,361 839,360 844,359 848,359 853,358 857,357 862,357 866,356 871,355 875,355 880,354 884,354 889,353 893,353 898,352 902,351 907,351 911,350 916,350 920,349 925,349 929,348 934,348 938,347 943,347 947,346 952,346 956,345 961,345 965,344 970,344 974,343 979,343 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,339 1015,338 1019,338 1024,337 1028,337 1033,336 1037,336 1042,335 1046,335 1051,334 1055,334 1060,333 1064,332 1069,332 1073,331 1078,331 1082,330 1087,330 1091,329 1096,329 1100,328 1105,328 1109,327 1114,327 1118,326 1123,326 1127,325 1132,325 1136,324 1141,324 1145,323 1150,323 1154,322 1159,322 1163,321 1168,321 1172,320 1177,320 1181,319 1186,319 1190,318 1195,318 1199,317 1204,317 1208,316 1213,316 1217,315 1222,315 1226,314 1231,314 1235,313 1240,312 1244,312 1249,311 1253,311 1258,310 1262,310 1267,309 1271,309 1276,308 1280,308 1285,307 1289,307 1294,306 1298,306 1303,305 1307,305 1312,304 1316,304 1321,303 1325,303 1330,302 1334,302 1339,301 1343,301 1348,300 1352,300 1357,299 1361,299 1366,298 1370,298 1375,297 1379,297 1384,296 1388,296 1393,295 1397,295 1402,294 1406,294 1411,293 1415,293 1420,292 1424,292 1429,291 1433,291 1438,290 1442,290 1447,289 1451,289 1456,288 1460,288 1465,287 1469,287 1474,286 1478,286 1483,285 1487,285 1492,284 1496,284 1501,283 1505,283 1510,282 1514,282 1519,281 1523,281 1528,280 1532,280 1537,279 1541,279 1546,278 1550,278 1555,277 1559,277 1564,276 1568,275 1573,275 1577,274 1582,274 1586,273 1591,273 1595,272 1600,272 1604,271 1609,271 1613,270 1618,270 1622,269 1626,269 1631,268 1635,268 1640,267 1644,267 1649,266 1653,266 1658,265 1662,265 1667,264 1671,264 1676,263 1680,263 1685,262 1689,262 1694,261 1698,261 1703,260 1707,260 1712,259 1716,259 1721,258 1725,258 1730,257 1734,257 1739,256 1743,256 1748,255 1752,255 1757,254 1761,254 1766,253 1770,253 1775,252 1779,252 1784,251 1788,251 1793,250 1797,250 1802,249 1806,249 1811,248 1815,248 1820,247 1824,247 1829,246 1833,246 1838,245 1842,245 1847,244 1851,244 1856,243 1860,243 1865,242 1869,242 1874,241 1878,241 1883,240 1887,240 1892,239 1896,239 1901,238 1905,238 1910,237 1914,237 1919,236 1923,236 1928,235 1932,235 1937,234 1941,234 1946,233 1950,233 1955,232 1959,232 1964,231 1968,231 1973,231 1977,230 1982,230 1986,229 1991,229 1995,228 2000,228 2004,227 2009,227 2013,226 2018,226 2022,225 2027,225 2031,224 2036,224 2040,223 2045,223 2049,222 2054,222 2058,221 2063,221 2067,220 2072,220 2076,219 2081,219 2085,218 2090,218 2094,217 2099,217 2103,217 2108,216 2112,216 2117,215 2121,215 2126,214 2130,214 2135,213 2139,213 2144,212 2148,212 2153,211 2157,211 2162,210 2166,210 2171,209 2175,209 2180,208 2184,208 2189,208 2193,207 2198,207 2202,206 2207,206 2211,205 2216,205 2220,204 2225,204 2229,203 2234,203 2238,202 2243,202 2247,202 2252,201 2256,201 2261,200 2265,200 2270,199 2274,199 2279,198 2283,198 2288,198 2292,197 2297,197 2301,196 2306,196 2310,195 2315,195 2319,194 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2206" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2206 74,2206 "/>
+<text x="65" y="2088" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2088 74,2088 "/>
+<text x="65" y="1970" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1970 74,1970 "/>
+<text x="65" y="1852" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1852 74,1852 "/>
+<text x="65" y="1734" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1734 74,1734 "/>
+<text x="65" y="1616" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1616 74,1616 "/>
+<text x="65" y="1497" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1497 74,1497 "/>
+<text x="65" y="1379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1379 74,1379 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2277 151,2277 156,2276 160,2276 165,2276 169,2275 174,2275 178,2275 183,2275 187,2274 192,2274 196,2274 201,2273 205,2273 210,2273 214,2272 219,2272 223,2272 228,2271 232,2271 237,2271 241,2270 246,2270 250,2270 255,2269 259,2269 264,2269 268,2268 273,2268 277,2268 282,2267 286,2267 291,2266 295,2266 300,2266 304,2265 309,2265 313,2265 318,2264 322,2264 327,2263 331,2263 336,2263 340,2262 345,2262 349,2262 354,2261 358,2261 363,2260 367,2260 372,2260 376,2259 381,2259 385,2258 390,2258 394,2257 399,2257 403,2257 408,2256 412,2256 417,2255 421,2255 426,2254 430,2254 435,2254 439,2253 444,2253 448,2252 453,2252 457,2251 462,2251 466,2250 471,2250 475,2249 480,2249 484,2249 489,2248 493,2248 498,2247 502,2247 506,2246 511,2246 515,2245 520,2245 524,2244 529,2244 533,2243 538,2243 542,2242 547,2242 551,2241 556,2240 560,2240 565,2239 569,2239 574,2238 578,2238 583,2237 587,2237 592,2236 596,2236 601,2235 605,2234 610,2234 614,2233 619,2233 623,2232 628,2232 632,2231 637,2230 641,2230 646,2229 650,2229 655,2228 659,2227 664,2227 668,2226 673,2226 677,2225 682,2224 686,2224 691,2223 695,2222 700,2222 704,2221 709,2221 713,2220 718,2219 722,2219 727,2218 731,2217 736,2217 740,2216 745,2215 749,2214 754,2214 758,2213 763,2212 767,2212 772,2211 776,2210 781,2210 785,2209 790,2208 794,2207 799,2207 803,2206 808,2205 812,2204 817,2204 821,2203 826,2202 830,2201 835,2201 839,2200 844,2199 848,2198 853,2197 857,2197 862,2196 866,2195 871,2194 875,2193 880,2193 884,2192 889,2191 893,2190 898,2189 902,2188 907,2188 911,2187 916,2186 920,2185 925,2184 929,2183 934,2182 938,2181 943,2180 947,2180 952,2179 956,2178 961,2177 965,2176 970,2175 974,2174 979,2173 983,2172 988,2171 992,2170 997,2169 1001,2168 1006,2167 1010,2166 1015,2165 1019,2164 1024,2163 1028,2162 1033,2161 1037,2160 1042,2159 1046,2158 1051,2157 1055,2156 1060,2155 1064,2154 1069,2153 1073,2152 1078,2151 1082,2150 1087,2148 1091,2147 1096,2146 1100,2145 1105,2144 1109,2143 1114,2142 1118,2141 1123,2139 1127,2138 1132,2137 1136,2136 1141,2135 1145,2134 1150,2132 1154,2131 1159,2130 1163,2129 1168,2127 1172,2126 1177,2125 1181,2124 1186,2122 1190,2121 1195,2120 1199,2119 1204,2117 1208,2116 1213,2115 1217,2113 1222,2112 1226,2111 1231,2109 1235,2108 1240,2107 1244,2105 1249,2104 1253,2103 1258,2101 1262,2100 1267,2098 1271,2097 1276,2096 1280,2094 1285,2093 1289,2091 1294,2090 1298,2088 1303,2087 1307,2085 1312,2084 1316,2082 1321,2081 1325,2079 1330,2078 1334,2076 1339,2075 1343,2073 1348,2071 1352,2070 1357,2068 1361,2067 1366,2065 1370,2063 1375,2062 1379,2060 1384,2058 1388,2057 1393,2055 1397,2053 1402,2052 1406,2050 1411,2048 1415,2046 1420,2045 1424,2043 1429,2041 1433,2039 1438,2038 1442,2036 1447,2034 1451,2032 1456,2030 1460,2028 1465,2027 1469,2025 1474,2023 1478,2021 1483,2019 1487,2017 1492,2015 1496,2013 1501,2011 1505,2009 1510,2007 1514,2005 1519,2003 1523,2001 1528,1999 1532,1997 1537,1995 1541,1993 1546,1991 1550,1989 1555,1987 1559,1985 1564,1983 1568,1980 1573,1978 1577,1976 1582,1974 1586,1972 1591,1969 1595,1967 1600,1965 1604,1963 1609,1960 1613,1958 1618,1956 1622,1953 1626,1951 1631,1949 1635,1946 1640,1944 1644,1942 1649,1939 1653,1937 1658,1934 1662,1932 1667,1929 1671,1927 1676,1924 1680,1922 1685,1919 1689,1917 1694,1914 1698,1912 1703,1909 1707,1907 1712,1904 1716,1901 1721,1899 1725,1896 1730,1893 1734,1891 1739,1888 1743,1885 1748,1882 1752,1880 1757,1877 1761,1874 1766,1871 1770,1868 1775,1865 1779,1862 1784,1860 1788,1857 1793,1854 1797,1851 1802,1848 1806,1845 1811,1842 1815,1839 1820,1836 1824,1833 1829,1830 1833,1826 1838,1823 1842,1820 1847,1817 1851,1814 1856,1811 1860,1807 1865,1804 1869,1801 1874,1797 1878,1794 1883,1791 1887,1787 1892,1784 1896,1781 1901,1777 1905,1774 1910,1770 1914,1767 1919,1763 1923,1760 1928,1756 1932,1753 1937,1749 1941,1746 1946,1742 1950,1738 1955,1735 1959,1731 1964,1727 1968,1723 1973,1720 1977,1716 1982,1712 1986,1708 1991,1704 1995,1700 2000,1696 2004,1692 2009,1688 2013,1684 2018,1680 2022,1676 2027,1672 2031,1668 2036,1664 2040,1660 2045,1656 2049,1652 2054,1647 2058,1643 2063,1639 2067,1634 2072,1630 2076,1626 2081,1621 2085,1617 2090,1613 2094,1608 2099,1604 2103,1599 2108,1594 2112,1590 2117,1585 2121,1581 2126,1576 2130,1571 2135,1566 2139,1562 2144,1557 2148,1552 2153,1547 2157,1542 2162,1537 2166,1532 2171,1528 2175,1522 2180,1517 2184,1512 2189,1507 2193,1502 2198,1497 2202,1492 2207,1487 2211,1481 2216,1476 2220,1471 2225,1465 2229,1460 2234,1454 2238,1449 2243,1443 2247,1438 2252,1432 2256,1427 2261,1421 2265,1415 2270,1410 2274,1404 2279,1398 2283,1392 2288,1386 2292,1381 2297,1375 2301,1369 2306,1363 2310,1357 2315,1351 2319,1344 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2274 1105,2209 1110,2071 1114,1886 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_10% annual fee growth_0.000300.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_10% annual fee growth_0.000300.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+10% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,498 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,470 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,435 551,433 556,431 560,429 565,427 569,426 574,424 578,423 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,388 700,387 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,377 749,376 754,375 758,374 763,373 767,372 772,371 776,370 781,370 785,369 790,368 794,367 799,366 803,366 808,365 812,364 817,363 821,363 826,362 830,361 835,361 839,360 844,359 848,359 853,358 857,357 862,357 866,356 871,355 875,355 880,354 884,354 889,353 893,353 898,352 902,351 907,351 911,350 916,350 920,349 925,349 929,348 934,348 938,347 943,347 947,346 952,346 956,345 961,345 965,344 970,344 974,343 979,343 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,339 1015,338 1019,338 1024,337 1028,337 1033,336 1037,336 1042,335 1046,335 1051,334 1055,334 1060,333 1064,333 1069,332 1073,331 1078,331 1082,330 1087,330 1091,329 1096,329 1100,328 1105,328 1109,327 1114,327 1118,326 1123,326 1127,325 1132,325 1136,324 1141,324 1145,323 1150,323 1154,322 1159,322 1163,321 1168,321 1172,320 1177,320 1181,319 1186,319 1190,318 1195,318 1199,317 1204,317 1208,316 1213,316 1217,315 1222,315 1226,314 1231,314 1235,313 1240,313 1244,312 1249,312 1253,311 1258,311 1262,310 1267,310 1271,309 1276,309 1280,308 1285,308 1289,307 1294,307 1298,306 1303,306 1307,305 1312,305 1316,304 1321,304 1325,303 1330,303 1334,302 1339,302 1343,301 1348,301 1352,300 1357,300 1361,299 1366,299 1370,298 1375,298 1379,297 1384,297 1388,296 1393,296 1397,295 1402,295 1406,294 1411,294 1415,293 1420,293 1424,292 1429,292 1433,291 1438,291 1442,290 1447,290 1451,289 1456,289 1460,288 1465,288 1469,287 1474,287 1478,286 1483,286 1487,285 1492,284 1496,284 1501,283 1505,283 1510,282 1514,282 1519,281 1523,281 1528,280 1532,280 1537,279 1541,279 1546,278 1550,278 1555,277 1559,277 1564,276 1568,276 1573,275 1577,275 1582,274 1586,274 1591,273 1595,273 1600,272 1604,272 1609,271 1613,271 1618,270 1622,270 1626,269 1631,269 1635,268 1640,268 1644,267 1649,267 1653,266 1658,266 1662,265 1667,265 1671,264 1676,264 1680,263 1685,263 1689,262 1694,262 1698,261 1703,261 1707,260 1712,260 1716,259 1721,259 1725,258 1730,258 1734,257 1739,257 1743,256 1748,256 1752,255 1757,255 1761,254 1766,254 1770,253 1775,253 1779,252 1784,252 1788,251 1793,251 1797,250 1802,250 1806,249 1811,249 1815,248 1820,248 1824,247 1829,247 1833,246 1838,246 1842,245 1847,245 1851,244 1856,244 1860,243 1865,243 1869,242 1874,242 1878,241 1883,241 1887,240 1892,240 1896,239 1901,239 1905,238 1910,238 1914,237 1919,237 1923,236 1928,236 1932,235 1937,235 1941,234 1946,234 1950,233 1955,233 1959,232 1964,232 1968,231 1973,231 1977,230 1982,230 1986,229 1991,229 1995,228 2000,228 2004,227 2009,227 2013,227 2018,226 2022,226 2027,225 2031,225 2036,224 2040,224 2045,223 2049,223 2054,222 2058,222 2063,221 2067,221 2072,220 2076,220 2081,219 2085,219 2090,218 2094,218 2099,217 2103,217 2108,216 2112,216 2117,215 2121,215 2126,215 2130,214 2135,214 2139,213 2144,213 2148,212 2153,212 2157,211 2162,211 2166,210 2171,210 2175,209 2180,209 2184,208 2189,208 2193,207 2198,207 2202,207 2207,206 2211,206 2216,205 2220,205 2225,204 2229,204 2234,203 2238,203 2243,202 2247,202 2252,201 2256,201 2261,201 2265,200 2270,200 2274,199 2279,199 2283,198 2288,198 2292,197 2297,197 2301,197 2306,196 2310,196 2315,195 2319,195 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2206" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2206 74,2206 "/>
+<text x="65" y="2088" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2088 74,2088 "/>
+<text x="65" y="1970" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1970 74,1970 "/>
+<text x="65" y="1852" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1852 74,1852 "/>
+<text x="65" y="1734" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1734 74,1734 "/>
+<text x="65" y="1616" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1616 74,1616 "/>
+<text x="65" y="1497" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1497 74,1497 "/>
+<text x="65" y="1379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1379 74,1379 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2277 151,2277 156,2276 160,2276 165,2276 169,2275 174,2275 178,2275 183,2275 187,2274 192,2274 196,2274 201,2273 205,2273 210,2273 214,2272 219,2272 223,2272 228,2271 232,2271 237,2271 241,2270 246,2270 250,2270 255,2269 259,2269 264,2269 268,2268 273,2268 277,2268 282,2267 286,2267 291,2266 295,2266 300,2266 304,2265 309,2265 313,2265 318,2264 322,2264 327,2263 331,2263 336,2263 340,2262 345,2262 349,2262 354,2261 358,2261 363,2260 367,2260 372,2260 376,2259 381,2259 385,2258 390,2258 394,2257 399,2257 403,2257 408,2256 412,2256 417,2255 421,2255 426,2254 430,2254 435,2254 439,2253 444,2253 448,2252 453,2252 457,2251 462,2251 466,2250 471,2250 475,2249 480,2249 484,2249 489,2248 493,2248 498,2247 502,2247 506,2246 511,2246 515,2245 520,2245 524,2244 529,2244 533,2243 538,2243 542,2242 547,2242 551,2241 556,2240 560,2240 565,2239 569,2239 574,2238 578,2238 583,2237 587,2237 592,2236 596,2236 601,2235 605,2234 610,2234 614,2233 619,2233 623,2232 628,2232 632,2231 637,2230 641,2230 646,2229 650,2229 655,2228 659,2227 664,2227 668,2226 673,2226 677,2225 682,2224 686,2224 691,2223 695,2222 700,2222 704,2221 709,2221 713,2220 718,2219 722,2219 727,2218 731,2217 736,2217 740,2216 745,2215 749,2214 754,2214 758,2213 763,2212 767,2212 772,2211 776,2210 781,2210 785,2209 790,2208 794,2207 799,2207 803,2206 808,2205 812,2204 817,2204 821,2203 826,2202 830,2201 835,2201 839,2200 844,2199 848,2198 853,2197 857,2197 862,2196 866,2195 871,2194 875,2193 880,2193 884,2192 889,2191 893,2190 898,2189 902,2188 907,2188 911,2187 916,2186 920,2185 925,2184 929,2183 934,2182 938,2181 943,2180 947,2180 952,2179 956,2178 961,2177 965,2176 970,2175 974,2174 979,2173 983,2172 988,2171 992,2170 997,2169 1001,2168 1006,2167 1010,2166 1015,2165 1019,2164 1024,2163 1028,2162 1033,2161 1037,2160 1042,2159 1046,2158 1051,2157 1055,2156 1060,2155 1064,2154 1069,2153 1073,2152 1078,2151 1082,2150 1087,2148 1091,2147 1096,2146 1100,2145 1105,2144 1109,2143 1114,2142 1118,2141 1123,2139 1127,2138 1132,2137 1136,2136 1141,2135 1145,2134 1150,2132 1154,2131 1159,2130 1163,2129 1168,2127 1172,2126 1177,2125 1181,2124 1186,2122 1190,2121 1195,2120 1199,2119 1204,2117 1208,2116 1213,2115 1217,2113 1222,2112 1226,2111 1231,2109 1235,2108 1240,2107 1244,2105 1249,2104 1253,2103 1258,2101 1262,2100 1267,2098 1271,2097 1276,2096 1280,2094 1285,2093 1289,2091 1294,2090 1298,2088 1303,2087 1307,2085 1312,2084 1316,2082 1321,2081 1325,2079 1330,2078 1334,2076 1339,2075 1343,2073 1348,2071 1352,2070 1357,2068 1361,2067 1366,2065 1370,2063 1375,2062 1379,2060 1384,2058 1388,2057 1393,2055 1397,2053 1402,2052 1406,2050 1411,2048 1415,2046 1420,2045 1424,2043 1429,2041 1433,2039 1438,2038 1442,2036 1447,2034 1451,2032 1456,2030 1460,2028 1465,2027 1469,2025 1474,2023 1478,2021 1483,2019 1487,2017 1492,2015 1496,2013 1501,2011 1505,2009 1510,2007 1514,2005 1519,2003 1523,2001 1528,1999 1532,1997 1537,1995 1541,1993 1546,1991 1550,1989 1555,1987 1559,1985 1564,1983 1568,1980 1573,1978 1577,1976 1582,1974 1586,1972 1591,1969 1595,1967 1600,1965 1604,1963 1609,1960 1613,1958 1618,1956 1622,1953 1626,1951 1631,1949 1635,1946 1640,1944 1644,1942 1649,1939 1653,1937 1658,1934 1662,1932 1667,1929 1671,1927 1676,1924 1680,1922 1685,1919 1689,1917 1694,1914 1698,1912 1703,1909 1707,1907 1712,1904 1716,1901 1721,1899 1725,1896 1730,1893 1734,1891 1739,1888 1743,1885 1748,1882 1752,1880 1757,1877 1761,1874 1766,1871 1770,1868 1775,1865 1779,1862 1784,1860 1788,1857 1793,1854 1797,1851 1802,1848 1806,1845 1811,1842 1815,1839 1820,1836 1824,1833 1829,1830 1833,1826 1838,1823 1842,1820 1847,1817 1851,1814 1856,1811 1860,1807 1865,1804 1869,1801 1874,1797 1878,1794 1883,1791 1887,1787 1892,1784 1896,1781 1901,1777 1905,1774 1910,1770 1914,1767 1919,1763 1923,1760 1928,1756 1932,1753 1937,1749 1941,1746 1946,1742 1950,1738 1955,1735 1959,1731 1964,1727 1968,1723 1973,1720 1977,1716 1982,1712 1986,1708 1991,1704 1995,1700 2000,1696 2004,1692 2009,1688 2013,1684 2018,1680 2022,1676 2027,1672 2031,1668 2036,1664 2040,1660 2045,1656 2049,1652 2054,1647 2058,1643 2063,1639 2067,1634 2072,1630 2076,1626 2081,1621 2085,1617 2090,1613 2094,1608 2099,1604 2103,1599 2108,1594 2112,1590 2117,1585 2121,1581 2126,1576 2130,1571 2135,1566 2139,1562 2144,1557 2148,1552 2153,1547 2157,1542 2162,1537 2166,1532 2171,1528 2175,1522 2180,1517 2184,1512 2189,1507 2193,1502 2198,1497 2202,1492 2207,1487 2211,1481 2216,1476 2220,1471 2225,1465 2229,1460 2234,1454 2238,1449 2243,1443 2247,1438 2252,1432 2256,1427 2261,1421 2265,1415 2270,1410 2274,1404 2279,1398 2283,1392 2288,1386 2292,1381 2297,1375 2301,1369 2306,1363 2310,1357 2315,1351 2319,1344 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2245 1056,2115 1060,1954 1065,1832 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1832 2163,1832 2167,1832 2172,1832 2176,1832 2181,1832 2185,1832 2190,1832 2194,1832 2199,1832 2203,1832 2208,1832 2212,1832 2217,1832 2221,1832 2226,1832 2230,1832 2235,1832 2239,1832 2244,1832 2248,1832 2253,1832 2257,1832 2262,1832 2266,1832 2271,1832 2275,1832 2280,1832 2284,1832 2289,1832 2293,1832 2298,1832 2302,1832 2307,1832 2311,1832 2316,1832 2320,1832 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_25% annual fee growth_0.000100.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_25% annual fee growth_0.000100.svg
@@ -1,0 +1,661 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+25% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,498 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,388 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,376 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,366 808,365 812,364 817,363 821,363 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,357 866,356 871,355 875,355 880,354 884,354 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,349 929,348 934,348 938,347 943,347 947,346 952,346 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,339 1015,338 1019,338 1024,337 1028,337 1033,336 1037,336 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,331 1082,330 1087,330 1091,329 1096,329 1100,328 1105,328 1109,327 1114,327 1118,326 1123,325 1127,325 1132,324 1136,324 1141,323 1145,323 1150,322 1154,322 1159,321 1163,321 1168,320 1172,320 1177,319 1181,319 1186,318 1190,318 1195,317 1199,317 1204,316 1208,316 1213,315 1217,315 1222,315 1226,314 1231,314 1235,313 1240,313 1244,312 1249,312 1253,311 1258,311 1262,310 1267,310 1271,309 1276,309 1280,309 1285,308 1289,308 1294,307 1298,307 1303,306 1307,306 1312,305 1316,305 1321,304 1325,304 1330,304 1334,303 1339,303 1343,302 1348,302 1352,301 1357,301 1361,301 1366,300 1370,300 1375,299 1379,299 1384,298 1388,298 1393,298 1397,297 1402,297 1406,296 1411,296 1415,295 1420,295 1424,295 1429,294 1433,294 1438,293 1442,293 1447,293 1451,292 1456,292 1460,291 1465,291 1469,291 1474,290 1478,290 1483,289 1487,289 1492,289 1496,288 1501,288 1505,288 1510,287 1514,287 1519,287 1523,286 1528,286 1532,285 1537,285 1541,285 1546,284 1550,284 1555,284 1559,283 1564,283 1568,283 1573,282 1577,282 1582,282 1586,281 1591,281 1595,281 1600,281 1604,280 1609,280 1613,280 1618,279 1622,279 1626,279 1631,279 1635,278 1640,278 1644,278 1649,277 1653,277 1658,277 1662,277 1667,276 1671,276 1676,276 1680,276 1685,276 1689,275 1694,275 1698,275 1703,275 1707,275 1712,274 1716,274 1721,274 1725,274 1730,274 1734,273 1739,273 1743,273 1748,273 1752,273 1757,273 1761,273 1766,272 1770,272 1775,272 1779,272 1784,272 1788,272 1793,272 1797,272 1802,272 1806,272 1811,272 1815,272 1820,272 1824,272 1829,272 1833,272 1838,272 1842,272 1847,272 1851,272 1856,272 1860,272 1865,272 1869,272 1874,272 1878,272 1883,272 1887,272 1892,272 1896,272 1901,272 1905,273 1910,273 1914,273 1919,273 1923,273 1928,274 1932,274 1937,274 1941,274 1946,274 1950,275 1955,275 1959,275 1964,275 1968,276 1973,276 1977,276 1982,277 1986,277 1991,278 1995,278 2000,278 2004,279 2009,279 2013,280 2018,280 2022,281 2027,281 2031,282 2036,282 2040,283 2045,283 2049,284 2054,284 2058,285 2063,286 2067,286 2072,287 2076,288 2081,288 2085,289 2090,290 2094,290 2099,291 2103,292 2108,293 2112,294 2117,295 2121,295 2126,296 2130,297 2135,298 2139,299 2144,300 2148,301 2153,302 2157,303 2162,304 2166,305 2171,306 2175,307 2180,308 2184,308 2189,309 2193,309 2198,310 2202,310 2207,311 2211,311 2216,312 2220,312 2225,312 2229,312 2234,313 2238,313 2243,313 2247,313 2252,314 2256,314 2261,314 2265,314 2270,314 2274,314 2279,314 2283,314 2288,315 2292,315 2297,315 2301,315 2306,315 2310,315 2315,315 2319,315 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2164" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2164 74,2164 "/>
+<text x="65" y="2003" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2003 74,2003 "/>
+<text x="65" y="1842" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1842 74,1842 "/>
+<text x="65" y="1682" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1682 74,1682 "/>
+<text x="65" y="1521" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1521 74,1521 "/>
+<text x="65" y="1360" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1360 74,1360 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2324 151,2324 156,2324 160,2324 165,2324 169,2324 174,2324 178,2324 183,2324 187,2324 192,2324 196,2324 201,2324 205,2324 210,2324 214,2323 219,2323 223,2323 228,2323 232,2323 237,2323 241,2323 246,2323 250,2323 255,2323 259,2323 264,2323 268,2323 273,2323 277,2323 282,2323 286,2323 291,2323 295,2323 300,2323 304,2323 309,2323 313,2323 318,2323 322,2323 327,2323 331,2323 336,2323 340,2323 345,2323 349,2323 354,2323 358,2323 363,2323 367,2323 372,2323 376,2323 381,2323 385,2323 390,2323 394,2323 399,2323 403,2323 408,2323 412,2323 417,2323 421,2323 426,2322 430,2322 435,2322 439,2322 444,2322 448,2322 453,2322 457,2322 462,2322 466,2322 471,2322 475,2322 480,2322 484,2322 489,2322 493,2322 498,2322 502,2322 506,2322 511,2322 515,2322 520,2322 524,2322 529,2322 533,2322 538,2322 542,2322 547,2321 551,2321 556,2321 560,2321 565,2321 569,2321 574,2321 578,2321 583,2321 587,2321 592,2321 596,2321 601,2321 605,2321 610,2321 614,2321 619,2321 623,2321 628,2321 632,2321 637,2320 641,2320 646,2320 650,2320 655,2320 659,2320 664,2320 668,2320 673,2320 677,2320 682,2320 686,2320 691,2320 695,2320 700,2320 704,2319 709,2319 713,2319 718,2319 722,2319 727,2319 731,2319 736,2319 740,2319 745,2319 749,2319 754,2319 758,2319 763,2318 767,2318 772,2318 776,2318 781,2318 785,2318 790,2318 794,2318 799,2318 803,2318 808,2317 812,2317 817,2317 821,2317 826,2317 830,2317 835,2317 839,2317 844,2317 848,2316 853,2316 857,2316 862,2316 866,2316 871,2316 875,2316 880,2316 884,2315 889,2315 893,2315 898,2315 902,2315 907,2315 911,2315 916,2315 920,2314 925,2314 929,2314 934,2314 938,2314 943,2314 947,2313 952,2313 956,2313 961,2313 965,2313 970,2313 974,2312 979,2312 983,2312 988,2312 992,2312 997,2311 1001,2311 1006,2311 1010,2311 1015,2311 1019,2310 1024,2310 1028,2310 1033,2310 1037,2310 1042,2309 1046,2309 1051,2309 1055,2309 1060,2309 1064,2308 1069,2308 1073,2308 1078,2308 1082,2307 1087,2307 1091,2307 1096,2307 1100,2306 1105,2306 1109,2306 1114,2305 1118,2305 1123,2305 1127,2305 1132,2304 1136,2304 1141,2304 1145,2303 1150,2303 1154,2303 1159,2302 1163,2302 1168,2302 1172,2301 1177,2301 1181,2301 1186,2300 1190,2300 1195,2300 1199,2299 1204,2299 1208,2299 1213,2298 1217,2298 1222,2297 1226,2297 1231,2297 1235,2296 1240,2296 1244,2295 1249,2295 1253,2294 1258,2294 1262,2294 1267,2293 1271,2293 1276,2292 1280,2292 1285,2291 1289,2291 1294,2290 1298,2290 1303,2289 1307,2289 1312,2288 1316,2288 1321,2287 1325,2287 1330,2286 1334,2285 1339,2285 1343,2284 1348,2284 1352,2283 1357,2282 1361,2282 1366,2281 1370,2281 1375,2280 1379,2279 1384,2279 1388,2278 1393,2277 1397,2276 1402,2276 1406,2275 1411,2274 1415,2274 1420,2273 1424,2272 1429,2271 1433,2270 1438,2270 1442,2269 1447,2268 1451,2267 1456,2266 1460,2266 1465,2265 1469,2264 1474,2263 1478,2262 1483,2261 1487,2260 1492,2259 1496,2258 1501,2257 1505,2256 1510,2255 1514,2254 1519,2253 1523,2252 1528,2251 1532,2250 1537,2249 1541,2248 1546,2247 1550,2245 1555,2244 1559,2243 1564,2242 1568,2241 1573,2239 1577,2238 1582,2237 1586,2236 1591,2234 1595,2233 1600,2232 1604,2230 1609,2229 1613,2227 1618,2226 1622,2224 1626,2223 1631,2222 1635,2220 1640,2218 1644,2217 1649,2215 1653,2214 1658,2212 1662,2210 1667,2209 1671,2207 1676,2205 1680,2203 1685,2202 1689,2200 1694,2198 1698,2196 1703,2194 1707,2192 1712,2190 1716,2188 1721,2186 1725,2184 1730,2182 1734,2180 1739,2178 1743,2176 1748,2174 1752,2171 1757,2169 1761,2167 1766,2165 1770,2162 1775,2160 1779,2157 1784,2155 1788,2152 1793,2150 1797,2147 1802,2145 1806,2142 1811,2139 1815,2137 1820,2134 1824,2131 1829,2128 1833,2125 1838,2122 1842,2119 1847,2116 1851,2113 1856,2110 1860,2107 1865,2104 1869,2100 1874,2097 1878,2094 1883,2090 1887,2087 1892,2083 1896,2080 1901,2076 1905,2072 1910,2069 1914,2065 1919,2061 1923,2057 1928,2053 1932,2049 1937,2045 1941,2041 1946,2037 1950,2033 1955,2028 1959,2024 1964,2019 1968,2015 1973,2010 1977,2006 1982,2001 1986,1996 1991,1991 1995,1986 2000,1981 2004,1976 2009,1971 2013,1966 2018,1961 2022,1955 2027,1950 2031,1944 2036,1939 2040,1933 2045,1927 2049,1921 2054,1915 2058,1909 2063,1903 2067,1897 2072,1891 2076,1884 2081,1878 2085,1871 2090,1864 2094,1858 2099,1851 2103,1844 2108,1837 2112,1829 2117,1822 2121,1815 2126,1807 2130,1800 2135,1792 2139,1784 2144,1776 2148,1768 2153,1760 2157,1751 2162,1743 2166,1734 2171,1725 2175,1717 2180,1708 2184,1698 2189,1689 2193,1680 2198,1670 2202,1661 2207,1651 2211,1641 2216,1631 2220,1620 2225,1610 2229,1600 2234,1589 2238,1578 2243,1567 2247,1556 2252,1544 2256,1533 2261,1521 2265,1509 2270,1497 2274,1485 2279,1473 2283,1460 2288,1447 2292,1434 2297,1421 2301,1408 2306,1394 2310,1380 2315,1366 2319,1352 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2262 1159,2168 1164,2007 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1832 2091,1832 2095,1832 2100,1832 2104,1832 2109,1832 2113,1832 2118,1832 2122,1832 2127,1832 2131,1832 2136,1832 2140,1832 2145,1832 2149,1832 2154,1832 2158,1843 2163,1875 2167,1903 2172,1929 2176,1953 2181,1974 2185,1994 2190,2012 2194,2029 2199,2044 2203,2058 2208,2071 2212,2083 2217,2093 2221,2102 2226,2111 2230,2120 2235,2127 2239,2135 2244,2141 2248,2148 2253,2154 2257,2159 2262,2164 2266,2169 2271,2174 2275,2178 2280,2181 2284,2185 2289,2188 2293,2191 2298,2194 2302,2197 2307,2200 2311,2203 2316,2206 2320,2208 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_25% annual fee growth_0.000300.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_25% annual fee growth_0.000300.svg
@@ -1,0 +1,661 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+25% annual fee growth
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,498 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,388 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,376 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,366 808,365 812,364 817,363 821,363 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,357 866,356 871,355 875,355 880,354 884,354 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,349 929,348 934,348 938,347 943,347 947,346 952,346 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,339 1015,338 1019,338 1024,337 1028,337 1033,336 1037,336 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,331 1082,330 1087,330 1091,330 1096,329 1100,329 1105,328 1109,328 1114,327 1118,327 1123,326 1127,326 1132,325 1136,325 1141,324 1145,324 1150,323 1154,323 1159,322 1163,322 1168,321 1172,321 1177,320 1181,320 1186,319 1190,319 1195,319 1199,318 1204,318 1208,317 1213,317 1217,316 1222,316 1226,315 1231,315 1235,314 1240,314 1244,313 1249,313 1253,312 1258,312 1262,312 1267,311 1271,311 1276,310 1280,310 1285,309 1289,309 1294,308 1298,308 1303,307 1307,307 1312,307 1316,306 1321,306 1325,305 1330,305 1334,304 1339,304 1343,303 1348,303 1352,303 1357,302 1361,302 1366,301 1370,301 1375,300 1379,300 1384,300 1388,299 1393,299 1397,298 1402,298 1406,297 1411,297 1415,297 1420,296 1424,296 1429,295 1433,295 1438,295 1442,294 1447,294 1451,293 1456,293 1460,293 1465,292 1469,292 1474,291 1478,291 1483,291 1487,290 1492,290 1496,290 1501,289 1505,289 1510,288 1514,288 1519,288 1523,287 1528,287 1532,287 1537,286 1541,286 1546,286 1550,285 1555,285 1559,285 1564,284 1568,284 1573,284 1577,283 1582,283 1586,283 1591,282 1595,282 1600,282 1604,281 1609,281 1613,281 1618,281 1622,280 1626,280 1631,280 1635,279 1640,279 1644,279 1649,279 1653,278 1658,278 1662,278 1667,278 1671,277 1676,277 1680,277 1685,277 1689,277 1694,276 1698,276 1703,276 1707,276 1712,276 1716,275 1721,275 1725,275 1730,275 1734,275 1739,274 1743,274 1748,274 1752,274 1757,274 1761,274 1766,274 1770,274 1775,273 1779,273 1784,273 1788,273 1793,273 1797,273 1802,273 1806,273 1811,273 1815,273 1820,273 1824,273 1829,273 1833,273 1838,273 1842,273 1847,273 1851,273 1856,273 1860,273 1865,273 1869,273 1874,273 1878,273 1883,273 1887,273 1892,273 1896,274 1901,274 1905,274 1910,274 1914,274 1919,274 1923,274 1928,275 1932,275 1937,275 1941,275 1946,276 1950,276 1955,276 1959,276 1964,277 1968,277 1973,277 1977,278 1982,278 1986,278 1991,279 1995,279 2000,279 2004,280 2009,280 2013,281 2018,281 2022,282 2027,282 2031,283 2036,283 2040,284 2045,284 2049,285 2054,286 2058,286 2063,287 2067,287 2072,288 2076,289 2081,289 2085,290 2090,291 2094,292 2099,292 2103,293 2108,293 2112,294 2117,295 2121,295 2126,296 2130,296 2135,297 2139,297 2144,298 2148,298 2153,299 2157,299 2162,300 2166,300 2171,301 2175,301 2180,301 2184,302 2189,302 2193,303 2198,303 2202,303 2207,304 2211,304 2216,304 2220,305 2225,305 2229,305 2234,306 2238,306 2243,306 2247,306 2252,307 2256,307 2261,307 2265,307 2270,308 2274,308 2279,308 2283,308 2288,308 2292,309 2297,309 2301,309 2306,309 2310,309 2315,310 2319,310 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2164" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2164 74,2164 "/>
+<text x="65" y="2003" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2003 74,2003 "/>
+<text x="65" y="1842" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1842 74,1842 "/>
+<text x="65" y="1682" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1682 74,1682 "/>
+<text x="65" y="1521" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1521 74,1521 "/>
+<text x="65" y="1360" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1360 74,1360 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2324 151,2324 156,2324 160,2324 165,2324 169,2324 174,2324 178,2324 183,2324 187,2324 192,2324 196,2324 201,2324 205,2324 210,2324 214,2323 219,2323 223,2323 228,2323 232,2323 237,2323 241,2323 246,2323 250,2323 255,2323 259,2323 264,2323 268,2323 273,2323 277,2323 282,2323 286,2323 291,2323 295,2323 300,2323 304,2323 309,2323 313,2323 318,2323 322,2323 327,2323 331,2323 336,2323 340,2323 345,2323 349,2323 354,2323 358,2323 363,2323 367,2323 372,2323 376,2323 381,2323 385,2323 390,2323 394,2323 399,2323 403,2323 408,2323 412,2323 417,2323 421,2323 426,2322 430,2322 435,2322 439,2322 444,2322 448,2322 453,2322 457,2322 462,2322 466,2322 471,2322 475,2322 480,2322 484,2322 489,2322 493,2322 498,2322 502,2322 506,2322 511,2322 515,2322 520,2322 524,2322 529,2322 533,2322 538,2322 542,2322 547,2321 551,2321 556,2321 560,2321 565,2321 569,2321 574,2321 578,2321 583,2321 587,2321 592,2321 596,2321 601,2321 605,2321 610,2321 614,2321 619,2321 623,2321 628,2321 632,2321 637,2320 641,2320 646,2320 650,2320 655,2320 659,2320 664,2320 668,2320 673,2320 677,2320 682,2320 686,2320 691,2320 695,2320 700,2320 704,2319 709,2319 713,2319 718,2319 722,2319 727,2319 731,2319 736,2319 740,2319 745,2319 749,2319 754,2319 758,2319 763,2318 767,2318 772,2318 776,2318 781,2318 785,2318 790,2318 794,2318 799,2318 803,2318 808,2317 812,2317 817,2317 821,2317 826,2317 830,2317 835,2317 839,2317 844,2317 848,2316 853,2316 857,2316 862,2316 866,2316 871,2316 875,2316 880,2316 884,2315 889,2315 893,2315 898,2315 902,2315 907,2315 911,2315 916,2315 920,2314 925,2314 929,2314 934,2314 938,2314 943,2314 947,2313 952,2313 956,2313 961,2313 965,2313 970,2313 974,2312 979,2312 983,2312 988,2312 992,2312 997,2311 1001,2311 1006,2311 1010,2311 1015,2311 1019,2310 1024,2310 1028,2310 1033,2310 1037,2310 1042,2309 1046,2309 1051,2309 1055,2309 1060,2309 1064,2308 1069,2308 1073,2308 1078,2308 1082,2307 1087,2307 1091,2307 1096,2307 1100,2306 1105,2306 1109,2306 1114,2305 1118,2305 1123,2305 1127,2305 1132,2304 1136,2304 1141,2304 1145,2303 1150,2303 1154,2303 1159,2302 1163,2302 1168,2302 1172,2301 1177,2301 1181,2301 1186,2300 1190,2300 1195,2300 1199,2299 1204,2299 1208,2299 1213,2298 1217,2298 1222,2297 1226,2297 1231,2297 1235,2296 1240,2296 1244,2295 1249,2295 1253,2294 1258,2294 1262,2294 1267,2293 1271,2293 1276,2292 1280,2292 1285,2291 1289,2291 1294,2290 1298,2290 1303,2289 1307,2289 1312,2288 1316,2288 1321,2287 1325,2287 1330,2286 1334,2285 1339,2285 1343,2284 1348,2284 1352,2283 1357,2282 1361,2282 1366,2281 1370,2281 1375,2280 1379,2279 1384,2279 1388,2278 1393,2277 1397,2276 1402,2276 1406,2275 1411,2274 1415,2274 1420,2273 1424,2272 1429,2271 1433,2270 1438,2270 1442,2269 1447,2268 1451,2267 1456,2266 1460,2266 1465,2265 1469,2264 1474,2263 1478,2262 1483,2261 1487,2260 1492,2259 1496,2258 1501,2257 1505,2256 1510,2255 1514,2254 1519,2253 1523,2252 1528,2251 1532,2250 1537,2249 1541,2248 1546,2247 1550,2245 1555,2244 1559,2243 1564,2242 1568,2241 1573,2239 1577,2238 1582,2237 1586,2236 1591,2234 1595,2233 1600,2232 1604,2230 1609,2229 1613,2227 1618,2226 1622,2224 1626,2223 1631,2222 1635,2220 1640,2218 1644,2217 1649,2215 1653,2214 1658,2212 1662,2210 1667,2209 1671,2207 1676,2205 1680,2203 1685,2202 1689,2200 1694,2198 1698,2196 1703,2194 1707,2192 1712,2190 1716,2188 1721,2186 1725,2184 1730,2182 1734,2180 1739,2178 1743,2176 1748,2174 1752,2171 1757,2169 1761,2167 1766,2165 1770,2162 1775,2160 1779,2157 1784,2155 1788,2152 1793,2150 1797,2147 1802,2145 1806,2142 1811,2139 1815,2137 1820,2134 1824,2131 1829,2128 1833,2125 1838,2122 1842,2119 1847,2116 1851,2113 1856,2110 1860,2107 1865,2104 1869,2100 1874,2097 1878,2094 1883,2090 1887,2087 1892,2083 1896,2080 1901,2076 1905,2072 1910,2069 1914,2065 1919,2061 1923,2057 1928,2053 1932,2049 1937,2045 1941,2041 1946,2037 1950,2033 1955,2028 1959,2024 1964,2019 1968,2015 1973,2010 1977,2006 1982,2001 1986,1996 1991,1991 1995,1986 2000,1981 2004,1976 2009,1971 2013,1966 2018,1961 2022,1955 2027,1950 2031,1944 2036,1939 2040,1933 2045,1927 2049,1921 2054,1915 2058,1909 2063,1903 2067,1897 2072,1891 2076,1884 2081,1878 2085,1871 2090,1864 2094,1858 2099,1851 2103,1844 2108,1837 2112,1829 2117,1822 2121,1815 2126,1807 2130,1800 2135,1792 2139,1784 2144,1776 2148,1768 2153,1760 2157,1751 2162,1743 2166,1734 2171,1725 2175,1717 2180,1708 2184,1698 2189,1689 2193,1680 2198,1670 2202,1661 2207,1651 2211,1641 2216,1631 2220,1620 2225,1610 2229,1600 2234,1589 2238,1578 2243,1567 2247,1556 2252,1544 2256,1533 2261,1521 2265,1509 2270,1497 2274,1485 2279,1473 2283,1460 2288,1447 2292,1434 2297,1421 2301,1408 2306,1394 2310,1380 2315,1366 2319,1352 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2240 1056,2120 1060,1985 1065,1847 1069,1832 1074,1832 1078,1832 1083,1832 1087,1832 1092,1832 1096,1832 1101,1832 1105,1832 1110,1832 1114,1832 1119,1832 1123,1832 1128,1832 1132,1832 1137,1832 1141,1832 1146,1832 1150,1832 1155,1832 1159,1832 1164,1832 1168,1832 1173,1832 1177,1832 1182,1832 1186,1832 1191,1832 1195,1832 1200,1832 1204,1832 1209,1832 1213,1832 1218,1832 1222,1832 1227,1832 1231,1832 1236,1832 1240,1832 1245,1832 1249,1832 1254,1832 1258,1832 1263,1832 1267,1832 1272,1832 1276,1832 1281,1832 1285,1832 1290,1832 1294,1832 1299,1832 1303,1832 1308,1832 1312,1832 1317,1832 1321,1832 1326,1832 1330,1832 1335,1832 1339,1832 1344,1832 1348,1832 1353,1832 1357,1832 1362,1832 1366,1832 1371,1832 1375,1832 1380,1832 1384,1832 1389,1832 1393,1832 1398,1832 1402,1832 1407,1832 1411,1832 1416,1832 1420,1832 1425,1832 1429,1832 1434,1832 1438,1832 1443,1832 1447,1832 1452,1832 1456,1832 1461,1832 1465,1832 1470,1832 1474,1832 1479,1832 1483,1832 1488,1832 1492,1832 1497,1832 1501,1832 1506,1832 1510,1832 1515,1832 1519,1832 1524,1832 1528,1832 1533,1832 1537,1832 1542,1832 1546,1832 1551,1832 1555,1832 1560,1832 1564,1832 1569,1832 1573,1832 1578,1832 1582,1832 1587,1832 1591,1832 1596,1832 1600,1832 1605,1832 1609,1832 1614,1832 1618,1832 1623,1832 1627,1832 1632,1832 1636,1832 1641,1832 1645,1832 1650,1832 1654,1832 1659,1832 1663,1832 1668,1832 1672,1832 1677,1832 1681,1832 1686,1832 1690,1832 1695,1832 1699,1832 1704,1832 1708,1832 1713,1832 1717,1832 1722,1832 1726,1832 1731,1832 1735,1832 1740,1832 1744,1832 1749,1832 1753,1832 1758,1832 1762,1832 1767,1832 1771,1832 1776,1832 1780,1832 1785,1832 1789,1832 1794,1832 1798,1832 1803,1832 1807,1832 1812,1832 1816,1832 1821,1832 1825,1832 1830,1832 1834,1832 1839,1832 1843,1832 1848,1832 1852,1832 1857,1832 1861,1832 1866,1832 1870,1832 1875,1832 1879,1832 1884,1832 1888,1832 1893,1832 1897,1832 1902,1832 1906,1832 1911,1832 1915,1832 1920,1832 1924,1832 1929,1832 1933,1832 1938,1832 1942,1832 1947,1832 1951,1832 1956,1832 1960,1832 1965,1832 1969,1832 1974,1832 1978,1832 1983,1832 1987,1832 1992,1832 1996,1832 2001,1832 2005,1832 2010,1832 2014,1832 2019,1832 2023,1832 2028,1832 2032,1832 2037,1832 2041,1832 2046,1832 2050,1832 2055,1832 2059,1832 2064,1832 2068,1832 2073,1832 2077,1832 2082,1832 2086,1837 2091,1851 2095,1865 2100,1878 2104,1891 2109,1903 2113,1915 2118,1927 2122,1938 2127,1949 2131,1959 2136,1969 2140,1978 2145,1988 2149,1995 2154,2004 2158,2012 2163,2020 2167,2028 2172,2036 2176,2043 2181,2050 2185,2057 2190,2064 2194,2070 2199,2077 2203,2083 2208,2089 2212,2094 2217,2100 2221,2104 2226,2109 2230,2114 2235,2119 2239,2124 2244,2128 2248,2132 2253,2137 2257,2141 2262,2145 2266,2149 2271,2153 2275,2157 2280,2161 2284,2164 2289,2166 2293,2169 2298,2173 2302,2176 2307,2179 2311,2182 2316,2185 2320,2188 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Slower growth, tapering fees_0.000100.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Slower growth, tapering fees_0.000100.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Slower growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,790 142,783 147,776 151,769 156,762 160,755 165,749 169,742 174,736 178,729 183,723 187,717 192,711 196,705 201,699 205,694 210,688 214,682 219,677 223,672 228,666 232,661 237,656 241,651 246,646 250,641 255,636 259,631 264,627 268,622 273,618 277,613 282,609 286,604 291,600 295,596 300,592 304,588 309,584 313,580 318,576 322,572 327,568 331,564 336,561 340,557 345,554 349,550 354,547 358,543 363,540 367,537 372,533 376,530 381,527 385,524 390,521 394,518 399,515 403,512 408,509 412,507 417,504 421,501 426,498 430,496 435,493 439,491 444,488 448,486 453,483 457,481 462,478 466,476 471,474 475,472 480,469 484,467 489,465 493,463 498,461 502,459 506,457 511,455 515,453 520,451 524,449 529,447 533,445 538,444 542,442 547,440 551,438 556,437 560,435 565,433 569,432 574,430 578,429 583,427 587,426 592,424 596,423 601,421 605,420 610,418 614,417 619,416 623,414 628,413 632,412 637,411 641,409 646,408 650,407 655,406 659,405 664,403 668,402 673,401 677,400 682,399 686,398 691,397 695,396 700,395 704,394 709,393 713,392 718,391 722,390 727,389 731,388 736,388 740,387 745,386 749,385 754,384 758,383 763,383 767,382 772,381 776,380 781,380 785,379 790,378 794,377 799,377 803,376 808,375 812,375 817,374 821,374 826,373 830,372 835,372 839,371 844,371 848,370 853,369 857,369 862,368 866,368 871,367 875,367 880,366 884,366 889,365 893,365 898,364 902,364 907,364 911,363 916,363 920,362 925,362 929,361 934,361 938,361 943,360 947,360 952,359 956,359 961,359 965,358 970,358 974,357 979,357 983,356 988,356 992,356 997,355 1001,355 1006,354 1010,354 1015,353 1019,353 1024,353 1028,352 1033,352 1037,351 1042,351 1046,351 1051,350 1055,350 1060,349 1064,349 1069,348 1073,348 1078,348 1082,347 1087,347 1091,346 1096,346 1100,345 1105,345 1109,345 1114,344 1118,344 1123,343 1127,343 1132,343 1136,342 1141,342 1145,341 1150,341 1154,340 1159,340 1163,340 1168,339 1172,339 1177,338 1181,338 1186,337 1190,337 1195,337 1199,336 1204,336 1208,335 1213,335 1217,335 1222,334 1226,334 1231,333 1235,333 1240,332 1244,332 1249,332 1253,331 1258,331 1262,330 1267,330 1271,329 1276,329 1280,329 1285,328 1289,328 1294,327 1298,327 1303,326 1307,326 1312,326 1316,325 1321,325 1325,324 1330,324 1334,324 1339,323 1343,323 1348,322 1352,322 1357,321 1361,321 1366,321 1370,320 1375,320 1379,319 1384,319 1388,319 1393,319 1397,318 1402,318 1406,318 1411,318 1415,318 1420,317 1424,317 1429,317 1433,317 1438,317 1442,317 1447,317 1451,317 1456,317 1460,316 1465,316 1469,316 1474,316 1478,316 1483,316 1487,316 1492,316 1496,316 1501,316 1505,316 1510,316 1514,316 1519,316 1523,316 1528,316 1532,316 1537,316 1541,316 1546,316 1550,316 1555,316 1559,316 1564,316 1568,316 1573,316 1577,316 1582,316 1586,316 1591,316 1595,316 1600,316 1604,316 1609,316 1613,316 1618,316 1622,316 1626,316 1631,316 1635,316 1640,316 1644,316 1649,316 1653,316 1658,316 1662,316 1667,316 1671,316 1676,316 1680,316 1685,316 1689,316 1694,316 1698,316 1703,316 1707,316 1712,316 1716,316 1721,316 1725,316 1730,316 1734,316 1739,316 1743,316 1748,316 1752,316 1757,316 1761,316 1766,316 1770,316 1775,316 1779,316 1784,316 1788,316 1793,316 1797,316 1802,316 1806,316 1811,316 1815,316 1820,316 1824,316 1829,316 1833,316 1838,316 1842,316 1847,316 1851,316 1856,316 1860,316 1865,316 1869,316 1874,316 1878,316 1883,316 1887,316 1892,316 1896,316 1901,316 1905,316 1910,316 1914,316 1919,316 1923,316 1928,316 1932,316 1937,316 1941,316 1946,316 1950,316 1955,316 1959,316 1964,316 1968,316 1973,316 1977,316 1982,316 1986,316 1991,316 1995,316 2000,316 2004,316 2009,316 2013,316 2018,316 2022,316 2027,316 2031,316 2036,316 2040,316 2045,316 2049,316 2054,316 2058,316 2063,316 2067,316 2072,316 2076,316 2081,316 2085,316 2090,316 2094,316 2099,316 2103,316 2108,316 2112,316 2117,316 2121,316 2126,316 2130,316 2135,316 2139,316 2144,316 2148,316 2153,316 2157,316 2162,316 2166,316 2171,316 2175,316 2180,316 2184,316 2189,316 2193,316 2198,316 2202,316 2207,316 2211,316 2216,316 2220,316 2225,316 2229,316 2234,316 2238,316 2243,316 2247,316 2252,316 2256,316 2261,316 2265,316 2270,316 2274,316 2279,316 2283,316 2288,316 2292,316 2297,316 2301,316 2306,316 2310,316 2315,316 2319,316 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2208" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2208 74,2208 "/>
+<text x="65" y="2092" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2092 74,2092 "/>
+<text x="65" y="1975" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1975 74,1975 "/>
+<text x="65" y="1859" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1859 74,1859 "/>
+<text x="65" y="1743" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1743 74,1743 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1510" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1510 74,1510 "/>
+<text x="65" y="1394" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1394 74,1394 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2207 115,2201 120,2195 124,2190 129,2184 133,2178 138,2173 142,2167 147,2162 151,2157 156,2151 160,2146 165,2141 169,2136 174,2131 178,2127 183,2122 187,2117 192,2113 196,2109 201,2105 205,2101 210,2097 214,2093 219,2089 223,2086 228,2082 232,2079 237,2075 241,2072 246,2069 250,2066 255,2063 259,2060 264,2057 268,2055 273,2052 277,2050 282,2047 286,2045 291,2042 295,2040 300,2038 304,2035 309,2033 313,2031 318,2029 322,2027 327,2025 331,2023 336,2021 340,2019 345,2017 349,2015 354,2013 358,2011 363,2009 367,2008 372,2006 376,2004 381,2002 385,2001 390,1999 394,1997 399,1996 403,1994 408,1992 412,1990 417,1989 421,1987 426,1986 430,1984 435,1982 439,1981 444,1979 448,1977 453,1976 457,1974 462,1973 466,1971 471,1970 475,1968 480,1966 484,1965 489,1963 493,1962 498,1960 502,1959 506,1957 511,1955 515,1954 520,1952 524,1951 529,1949 533,1948 538,1946 542,1945 547,1943 551,1941 556,1940 560,1938 565,1937 569,1935 574,1934 578,1932 583,1931 587,1929 592,1928 596,1926 601,1925 605,1923 610,1921 614,1920 619,1918 623,1917 628,1915 632,1914 637,1912 641,1911 646,1909 650,1908 655,1906 659,1905 664,1903 668,1901 673,1900 677,1898 682,1897 686,1895 691,1894 695,1892 700,1891 704,1889 709,1888 713,1886 718,1885 722,1883 727,1882 731,1880 736,1879 740,1877 745,1875 749,1874 754,1872 758,1871 763,1869 767,1868 772,1866 776,1865 781,1863 785,1862 790,1860 794,1859 799,1857 803,1856 808,1854 812,1853 817,1851 821,1849 826,1848 830,1846 835,1845 839,1843 844,1842 848,1840 853,1839 857,1837 862,1836 866,1834 871,1833 875,1831 880,1830 884,1828 889,1826 893,1825 898,1823 902,1822 907,1820 911,1819 916,1817 920,1816 925,1814 929,1813 934,1811 938,1810 943,1808 947,1807 952,1805 956,1804 961,1802 965,1800 970,1799 974,1797 979,1796 983,1794 988,1793 992,1791 997,1790 1001,1788 1006,1787 1010,1785 1015,1784 1019,1782 1024,1781 1028,1779 1033,1778 1037,1776 1042,1774 1046,1773 1051,1771 1055,1770 1060,1768 1064,1767 1069,1765 1073,1764 1078,1762 1082,1761 1087,1759 1091,1758 1096,1756 1100,1755 1105,1753 1109,1752 1114,1750 1118,1748 1123,1747 1127,1745 1132,1744 1136,1742 1141,1741 1145,1739 1150,1738 1154,1736 1159,1735 1163,1733 1168,1732 1172,1730 1177,1729 1181,1727 1186,1726 1190,1724 1195,1722 1199,1721 1204,1719 1208,1718 1213,1716 1217,1715 1222,1713 1226,1712 1231,1710 1235,1709 1240,1707 1244,1706 1249,1704 1253,1703 1258,1701 1262,1700 1267,1698 1271,1696 1276,1695 1280,1693 1285,1692 1289,1690 1294,1689 1298,1687 1303,1686 1307,1684 1312,1683 1316,1681 1321,1680 1325,1678 1330,1677 1334,1675 1339,1673 1343,1672 1348,1670 1352,1669 1357,1667 1361,1666 1366,1664 1370,1663 1375,1661 1379,1660 1384,1658 1388,1657 1393,1655 1397,1654 1402,1652 1406,1651 1411,1649 1415,1647 1420,1646 1424,1644 1429,1643 1433,1641 1438,1640 1442,1638 1447,1637 1451,1635 1456,1634 1460,1632 1465,1631 1469,1629 1474,1628 1478,1626 1483,1625 1487,1623 1492,1621 1496,1620 1501,1618 1505,1617 1510,1615 1514,1614 1519,1612 1523,1611 1528,1609 1532,1608 1537,1606 1541,1605 1546,1603 1550,1602 1555,1600 1559,1599 1564,1597 1568,1595 1573,1594 1577,1592 1582,1591 1586,1589 1591,1588 1595,1586 1600,1585 1604,1583 1609,1582 1613,1580 1618,1579 1622,1577 1626,1576 1631,1574 1635,1573 1640,1571 1644,1569 1649,1568 1653,1566 1658,1565 1662,1563 1667,1562 1671,1560 1676,1559 1680,1557 1685,1556 1689,1554 1694,1553 1698,1551 1703,1550 1707,1548 1712,1547 1716,1545 1721,1543 1725,1542 1730,1540 1734,1539 1739,1537 1743,1536 1748,1534 1752,1533 1757,1531 1761,1530 1766,1528 1770,1527 1775,1525 1779,1524 1784,1522 1788,1521 1793,1519 1797,1517 1802,1516 1806,1514 1811,1513 1815,1511 1820,1510 1824,1508 1829,1507 1833,1505 1838,1504 1842,1502 1847,1501 1851,1499 1856,1498 1860,1496 1865,1494 1869,1493 1874,1491 1878,1490 1883,1488 1887,1487 1892,1485 1896,1484 1901,1482 1905,1481 1910,1479 1914,1478 1919,1476 1923,1475 1928,1473 1932,1472 1937,1470 1941,1468 1946,1467 1950,1465 1955,1464 1959,1462 1964,1461 1968,1459 1973,1458 1977,1456 1982,1455 1986,1453 1991,1452 1995,1450 2000,1449 2004,1447 2009,1446 2013,1444 2018,1442 2022,1441 2027,1439 2031,1438 2036,1436 2040,1435 2045,1433 2049,1432 2054,1430 2058,1429 2063,1427 2067,1426 2072,1424 2076,1423 2081,1421 2085,1420 2090,1418 2094,1416 2099,1415 2103,1413 2108,1412 2112,1410 2117,1409 2121,1407 2126,1406 2130,1404 2135,1403 2139,1401 2144,1400 2148,1398 2153,1397 2157,1395 2162,1394 2166,1392 2171,1390 2175,1389 2180,1387 2184,1386 2189,1384 2193,1383 2198,1381 2202,1380 2207,1378 2211,1377 2216,1375 2220,1374 2225,1372 2229,1371 2234,1369 2238,1368 2243,1366 2247,1364 2252,1363 2256,1361 2261,1360 2265,1358 2270,1357 2274,1355 2279,1354 2283,1352 2288,1351 2292,1349 2297,1348 2301,1346 2306,1345 2310,1343 2315,1341 2319,1340 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2275 1371,2264 1375,2252 1380,2242 1384,2232 1389,2224 1393,2216 1398,2207 1402,2200 1407,2194 1411,2189 1416,2184 1420,2180 1425,2175 1429,2172 1434,2169 1438,2166 1443,2163 1447,2160 1452,2158 1456,2156 1461,2154 1465,2151 1470,2149 1474,2148 1479,2147 1483,2146 1488,2145 1492,2144 1497,2144 1501,2143 1506,2143 1510,2142 1515,2141 1519,2142 1524,2141 1528,2141 1533,2139 1537,2139 1542,2138 1546,2139 1551,2139 1555,2138 1560,2139 1564,2139 1569,2140 1573,2139 1578,2139 1582,2140 1587,2140 1591,2140 1596,2141 1600,2139 1605,2138 1609,2139 1614,2139 1618,2140 1623,2140 1627,2140 1632,2141 1636,2141 1641,2142 1645,2141 1650,2141 1654,2142 1659,2142 1663,2142 1668,2142 1672,2141 1677,2141 1681,2142 1686,2142 1690,2143 1695,2143 1699,2143 1704,2143 1708,2144 1713,2145 1717,2145 1722,2145 1726,2145 1731,2146 1735,2146 1740,2145 1744,2145 1749,2145 1753,2146 1758,2146 1762,2146 1767,2147 1771,2147 1776,2148 1780,2148 1785,2148 1789,2148 1794,2149 1798,2149 1803,2150 1807,2148 1812,2148 1816,2149 1821,2150 1825,2149 1830,2150 1834,2150 1839,2151 1843,2151 1848,2151 1852,2151 1857,2151 1861,2152 1866,2152 1870,2153 1875,2152 1879,2151 1884,2152 1888,2152 1893,2153 1897,2153 1902,2153 1906,2153 1911,2154 1915,2154 1920,2155 1924,2155 1929,2155 1933,2155 1938,2156 1942,2156 1947,2154 1951,2155 1956,2156 1960,2155 1965,2155 1969,2156 1974,2156 1978,2157 1983,2157 1987,2157 1992,2158 1996,2158 2001,2158 2005,2158 2010,2159 2014,2157 2019,2157 2023,2158 2028,2159 2032,2158 2037,2158 2041,2159 2046,2159 2050,2160 2055,2160 2059,2160 2064,2160 2068,2161 2073,2161 2077,2161 2082,2160 2086,2160 2091,2160 2095,2161 2100,2161 2104,2161 2109,2161 2113,2162 2118,2162 2122,2162 2127,2162 2131,2163 2136,2163 2140,2164 2145,2164 2149,2163 2154,2163 2158,2163 2163,2163 2167,2163 2172,2163 2176,2164 2181,2164 2185,2165 2190,2165 2194,2165 2199,2165 2203,2166 2208,2166 2212,2166 2217,2166 2221,2165 2226,2165 2230,2165 2235,2166 2239,2166 2244,2166 2248,2166 2253,2167 2257,2167 2262,2167 2266,2168 2271,2168 2275,2168 2280,2168 2284,2169 2289,2167 2293,2167 2298,2168 2302,2168 2307,2168 2311,2169 2316,2169 2320,2170 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Slower growth, tapering fees_0.000200.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Slower growth, tapering fees_0.000200.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Slower growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,790 142,783 147,776 151,769 156,762 160,755 165,749 169,742 174,736 178,729 183,723 187,717 192,711 196,705 201,699 205,694 210,688 214,682 219,677 223,672 228,666 232,661 237,656 241,651 246,646 250,641 255,636 259,631 264,627 268,622 273,618 277,613 282,609 286,604 291,600 295,596 300,592 304,588 309,584 313,580 318,576 322,572 327,568 331,564 336,561 340,557 345,554 349,550 354,547 358,543 363,540 367,537 372,533 376,530 381,527 385,524 390,521 394,518 399,515 403,512 408,509 412,507 417,504 421,501 426,498 430,496 435,493 439,491 444,488 448,486 453,483 457,481 462,478 466,476 471,474 475,472 480,469 484,467 489,465 493,463 498,461 502,459 506,457 511,455 515,453 520,451 524,449 529,447 533,445 538,444 542,442 547,440 551,438 556,437 560,435 565,433 569,432 574,430 578,429 583,427 587,426 592,424 596,423 601,421 605,420 610,418 614,417 619,416 623,414 628,413 632,412 637,411 641,409 646,408 650,407 655,406 659,405 664,403 668,402 673,401 677,400 682,399 686,398 691,397 695,396 700,395 704,394 709,393 713,392 718,391 722,390 727,389 731,388 736,388 740,387 745,386 749,385 754,384 758,383 763,383 767,382 772,381 776,380 781,380 785,379 790,378 794,377 799,377 803,376 808,375 812,375 817,374 821,374 826,373 830,372 835,372 839,371 844,371 848,370 853,369 857,369 862,368 866,368 871,367 875,367 880,366 884,366 889,365 893,365 898,364 902,364 907,364 911,363 916,363 920,362 925,362 929,361 934,361 938,361 943,360 947,360 952,359 956,359 961,359 965,358 970,358 974,357 979,357 983,356 988,356 992,356 997,355 1001,355 1006,354 1010,354 1015,353 1019,353 1024,353 1028,352 1033,352 1037,351 1042,351 1046,351 1051,350 1055,350 1060,349 1064,349 1069,348 1073,348 1078,348 1082,347 1087,347 1091,346 1096,346 1100,345 1105,345 1109,345 1114,344 1118,344 1123,343 1127,343 1132,343 1136,342 1141,342 1145,341 1150,341 1154,340 1159,340 1163,340 1168,339 1172,339 1177,338 1181,338 1186,337 1190,337 1195,337 1199,336 1204,336 1208,335 1213,335 1217,335 1222,334 1226,334 1231,333 1235,333 1240,332 1244,332 1249,332 1253,331 1258,331 1262,330 1267,330 1271,329 1276,329 1280,329 1285,328 1289,328 1294,327 1298,327 1303,326 1307,326 1312,326 1316,325 1321,325 1325,324 1330,324 1334,324 1339,323 1343,323 1348,323 1352,322 1357,322 1361,322 1366,322 1370,321 1375,321 1379,321 1384,321 1388,321 1393,320 1397,320 1402,320 1406,320 1411,320 1415,319 1420,319 1424,319 1429,319 1433,319 1438,319 1442,319 1447,318 1451,318 1456,318 1460,318 1465,318 1469,318 1474,318 1478,318 1483,318 1487,318 1492,317 1496,317 1501,317 1505,317 1510,317 1514,317 1519,317 1523,317 1528,317 1532,317 1537,317 1541,317 1546,317 1550,317 1555,317 1559,317 1564,317 1568,317 1573,316 1577,316 1582,316 1586,316 1591,316 1595,316 1600,316 1604,316 1609,316 1613,316 1618,316 1622,316 1626,316 1631,316 1635,316 1640,316 1644,316 1649,316 1653,316 1658,316 1662,316 1667,316 1671,316 1676,316 1680,316 1685,316 1689,316 1694,316 1698,316 1703,316 1707,316 1712,316 1716,316 1721,316 1725,316 1730,316 1734,316 1739,316 1743,316 1748,316 1752,316 1757,316 1761,316 1766,316 1770,316 1775,316 1779,316 1784,316 1788,316 1793,316 1797,316 1802,316 1806,316 1811,316 1815,316 1820,316 1824,316 1829,316 1833,316 1838,316 1842,316 1847,316 1851,316 1856,316 1860,316 1865,316 1869,316 1874,316 1878,316 1883,316 1887,316 1892,316 1896,316 1901,316 1905,316 1910,316 1914,316 1919,316 1923,316 1928,316 1932,316 1937,316 1941,316 1946,316 1950,316 1955,316 1959,316 1964,316 1968,316 1973,316 1977,316 1982,316 1986,316 1991,316 1995,316 2000,316 2004,316 2009,316 2013,316 2018,316 2022,316 2027,316 2031,316 2036,316 2040,316 2045,316 2049,316 2054,316 2058,316 2063,316 2067,316 2072,316 2076,316 2081,316 2085,316 2090,316 2094,316 2099,316 2103,316 2108,316 2112,316 2117,316 2121,316 2126,316 2130,316 2135,316 2139,316 2144,316 2148,316 2153,316 2157,316 2162,316 2166,316 2171,316 2175,316 2180,316 2184,316 2189,316 2193,316 2198,316 2202,316 2207,316 2211,316 2216,316 2220,316 2225,316 2229,316 2234,316 2238,316 2243,316 2247,316 2252,316 2256,316 2261,316 2265,316 2270,316 2274,316 2279,316 2283,316 2288,316 2292,316 2297,316 2301,316 2306,316 2310,316 2315,316 2319,316 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2208" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2208 74,2208 "/>
+<text x="65" y="2092" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2092 74,2092 "/>
+<text x="65" y="1975" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1975 74,1975 "/>
+<text x="65" y="1859" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1859 74,1859 "/>
+<text x="65" y="1743" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1743 74,1743 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1510" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1510 74,1510 "/>
+<text x="65" y="1394" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1394 74,1394 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2207 115,2201 120,2195 124,2190 129,2184 133,2178 138,2173 142,2167 147,2162 151,2157 156,2151 160,2146 165,2141 169,2136 174,2131 178,2127 183,2122 187,2117 192,2113 196,2109 201,2105 205,2101 210,2097 214,2093 219,2089 223,2086 228,2082 232,2079 237,2075 241,2072 246,2069 250,2066 255,2063 259,2060 264,2057 268,2055 273,2052 277,2050 282,2047 286,2045 291,2042 295,2040 300,2038 304,2035 309,2033 313,2031 318,2029 322,2027 327,2025 331,2023 336,2021 340,2019 345,2017 349,2015 354,2013 358,2011 363,2009 367,2008 372,2006 376,2004 381,2002 385,2001 390,1999 394,1997 399,1996 403,1994 408,1992 412,1990 417,1989 421,1987 426,1986 430,1984 435,1982 439,1981 444,1979 448,1977 453,1976 457,1974 462,1973 466,1971 471,1970 475,1968 480,1966 484,1965 489,1963 493,1962 498,1960 502,1959 506,1957 511,1955 515,1954 520,1952 524,1951 529,1949 533,1948 538,1946 542,1945 547,1943 551,1941 556,1940 560,1938 565,1937 569,1935 574,1934 578,1932 583,1931 587,1929 592,1928 596,1926 601,1925 605,1923 610,1921 614,1920 619,1918 623,1917 628,1915 632,1914 637,1912 641,1911 646,1909 650,1908 655,1906 659,1905 664,1903 668,1901 673,1900 677,1898 682,1897 686,1895 691,1894 695,1892 700,1891 704,1889 709,1888 713,1886 718,1885 722,1883 727,1882 731,1880 736,1879 740,1877 745,1875 749,1874 754,1872 758,1871 763,1869 767,1868 772,1866 776,1865 781,1863 785,1862 790,1860 794,1859 799,1857 803,1856 808,1854 812,1853 817,1851 821,1849 826,1848 830,1846 835,1845 839,1843 844,1842 848,1840 853,1839 857,1837 862,1836 866,1834 871,1833 875,1831 880,1830 884,1828 889,1826 893,1825 898,1823 902,1822 907,1820 911,1819 916,1817 920,1816 925,1814 929,1813 934,1811 938,1810 943,1808 947,1807 952,1805 956,1804 961,1802 965,1800 970,1799 974,1797 979,1796 983,1794 988,1793 992,1791 997,1790 1001,1788 1006,1787 1010,1785 1015,1784 1019,1782 1024,1781 1028,1779 1033,1778 1037,1776 1042,1774 1046,1773 1051,1771 1055,1770 1060,1768 1064,1767 1069,1765 1073,1764 1078,1762 1082,1761 1087,1759 1091,1758 1096,1756 1100,1755 1105,1753 1109,1752 1114,1750 1118,1748 1123,1747 1127,1745 1132,1744 1136,1742 1141,1741 1145,1739 1150,1738 1154,1736 1159,1735 1163,1733 1168,1732 1172,1730 1177,1729 1181,1727 1186,1726 1190,1724 1195,1722 1199,1721 1204,1719 1208,1718 1213,1716 1217,1715 1222,1713 1226,1712 1231,1710 1235,1709 1240,1707 1244,1706 1249,1704 1253,1703 1258,1701 1262,1700 1267,1698 1271,1696 1276,1695 1280,1693 1285,1692 1289,1690 1294,1689 1298,1687 1303,1686 1307,1684 1312,1683 1316,1681 1321,1680 1325,1678 1330,1677 1334,1675 1339,1673 1343,1672 1348,1670 1352,1669 1357,1667 1361,1666 1366,1664 1370,1663 1375,1661 1379,1660 1384,1658 1388,1657 1393,1655 1397,1654 1402,1652 1406,1651 1411,1649 1415,1647 1420,1646 1424,1644 1429,1643 1433,1641 1438,1640 1442,1638 1447,1637 1451,1635 1456,1634 1460,1632 1465,1631 1469,1629 1474,1628 1478,1626 1483,1625 1487,1623 1492,1621 1496,1620 1501,1618 1505,1617 1510,1615 1514,1614 1519,1612 1523,1611 1528,1609 1532,1608 1537,1606 1541,1605 1546,1603 1550,1602 1555,1600 1559,1599 1564,1597 1568,1595 1573,1594 1577,1592 1582,1591 1586,1589 1591,1588 1595,1586 1600,1585 1604,1583 1609,1582 1613,1580 1618,1579 1622,1577 1626,1576 1631,1574 1635,1573 1640,1571 1644,1569 1649,1568 1653,1566 1658,1565 1662,1563 1667,1562 1671,1560 1676,1559 1680,1557 1685,1556 1689,1554 1694,1553 1698,1551 1703,1550 1707,1548 1712,1547 1716,1545 1721,1543 1725,1542 1730,1540 1734,1539 1739,1537 1743,1536 1748,1534 1752,1533 1757,1531 1761,1530 1766,1528 1770,1527 1775,1525 1779,1524 1784,1522 1788,1521 1793,1519 1797,1517 1802,1516 1806,1514 1811,1513 1815,1511 1820,1510 1824,1508 1829,1507 1833,1505 1838,1504 1842,1502 1847,1501 1851,1499 1856,1498 1860,1496 1865,1494 1869,1493 1874,1491 1878,1490 1883,1488 1887,1487 1892,1485 1896,1484 1901,1482 1905,1481 1910,1479 1914,1478 1919,1476 1923,1475 1928,1473 1932,1472 1937,1470 1941,1468 1946,1467 1950,1465 1955,1464 1959,1462 1964,1461 1968,1459 1973,1458 1977,1456 1982,1455 1986,1453 1991,1452 1995,1450 2000,1449 2004,1447 2009,1446 2013,1444 2018,1442 2022,1441 2027,1439 2031,1438 2036,1436 2040,1435 2045,1433 2049,1432 2054,1430 2058,1429 2063,1427 2067,1426 2072,1424 2076,1423 2081,1421 2085,1420 2090,1418 2094,1416 2099,1415 2103,1413 2108,1412 2112,1410 2117,1409 2121,1407 2126,1406 2130,1404 2135,1403 2139,1401 2144,1400 2148,1398 2153,1397 2157,1395 2162,1394 2166,1392 2171,1390 2175,1389 2180,1387 2184,1386 2189,1384 2193,1383 2198,1381 2202,1380 2207,1378 2211,1377 2216,1375 2220,1374 2225,1372 2229,1371 2234,1369 2238,1368 2243,1366 2247,1364 2252,1363 2256,1361 2261,1360 2265,1358 2270,1357 2274,1355 2279,1354 2283,1352 2288,1351 2292,1349 2297,1348 2301,1346 2306,1345 2310,1343 2315,1341 2319,1340 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2271 1321,2265 1326,2257 1330,2251 1335,2246 1339,2241 1344,2236 1348,2231 1353,2227 1357,2223 1362,2219 1366,2215 1371,2212 1375,2208 1380,2205 1384,2202 1389,2199 1393,2196 1398,2192 1402,2189 1407,2187 1411,2185 1416,2183 1420,2181 1425,2179 1429,2177 1434,2175 1438,2173 1443,2172 1447,2170 1452,2169 1456,2167 1461,2167 1465,2163 1470,2162 1474,2161 1479,2160 1483,2160 1488,2159 1492,2158 1497,2157 1501,2157 1506,2156 1510,2155 1515,2155 1519,2154 1524,2154 1528,2153 1533,2151 1537,2150 1542,2150 1546,2150 1551,2150 1555,2150 1560,2149 1564,2149 1569,2149 1573,2149 1578,2148 1582,2148 1587,2148 1591,2148 1596,2148 1600,2146 1605,2146 1609,2146 1614,2146 1618,2146 1623,2146 1627,2146 1632,2146 1636,2147 1641,2146 1645,2147 1650,2146 1654,2147 1659,2147 1663,2147 1668,2147 1672,2146 1677,2146 1681,2146 1686,2146 1690,2146 1695,2147 1699,2147 1704,2147 1708,2147 1713,2148 1717,2147 1722,2148 1726,2148 1731,2148 1735,2149 1740,2147 1744,2147 1749,2147 1753,2148 1758,2148 1762,2148 1767,2148 1771,2149 1776,2149 1780,2149 1785,2150 1789,2150 1794,2150 1798,2150 1803,2151 1807,2149 1812,2150 1816,2150 1821,2150 1825,2151 1830,2151 1834,2151 1839,2152 1843,2151 1848,2152 1852,2152 1857,2152 1861,2153 1866,2153 1870,2153 1875,2152 1879,2152 1884,2152 1888,2153 1893,2153 1897,2153 1902,2154 1906,2154 1911,2154 1915,2155 1920,2155 1924,2155 1929,2155 1933,2155 1938,2156 1942,2156 1947,2154 1951,2155 1956,2155 1960,2155 1965,2155 1969,2156 1974,2156 1978,2156 1983,2157 1987,2157 1992,2157 1996,2158 2001,2158 2005,2158 2010,2159 2014,2157 2019,2157 2023,2158 2028,2158 2032,2158 2037,2159 2041,2159 2046,2159 2050,2160 2055,2160 2059,2160 2064,2161 2068,2161 2073,2161 2077,2161 2082,2160 2086,2160 2091,2161 2095,2161 2100,2161 2104,2161 2109,2161 2113,2162 2118,2162 2122,2162 2127,2163 2131,2163 2136,2163 2140,2164 2145,2164 2149,2162 2154,2162 2158,2163 2163,2163 2167,2164 2172,2164 2176,2164 2181,2164 2185,2165 2190,2165 2194,2165 2199,2165 2203,2165 2208,2166 2212,2166 2217,2166 2221,2165 2226,2165 2230,2166 2235,2166 2239,2166 2244,2166 2248,2166 2253,2167 2257,2167 2262,2167 2266,2167 2271,2168 2275,2168 2280,2168 2284,2169 2289,2167 2293,2167 2298,2168 2302,2168 2307,2168 2311,2168 2316,2169 2320,2169 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Slower growth, tapering fees_0.000300.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Slower growth, tapering fees_0.000300.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Slower growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,790 142,783 147,776 151,769 156,762 160,755 165,749 169,742 174,736 178,729 183,723 187,717 192,711 196,705 201,699 205,694 210,688 214,682 219,677 223,672 228,666 232,661 237,656 241,651 246,646 250,641 255,636 259,631 264,627 268,622 273,618 277,613 282,609 286,604 291,600 295,596 300,592 304,588 309,584 313,580 318,576 322,572 327,568 331,564 336,561 340,557 345,554 349,550 354,547 358,543 363,540 367,537 372,533 376,530 381,527 385,524 390,521 394,518 399,515 403,512 408,509 412,507 417,504 421,501 426,498 430,496 435,493 439,491 444,488 448,486 453,483 457,481 462,478 466,476 471,474 475,472 480,469 484,467 489,465 493,463 498,461 502,459 506,457 511,455 515,453 520,451 524,449 529,447 533,445 538,444 542,442 547,440 551,438 556,437 560,435 565,433 569,432 574,430 578,429 583,427 587,426 592,424 596,423 601,421 605,420 610,418 614,417 619,416 623,414 628,413 632,412 637,411 641,409 646,408 650,407 655,406 659,405 664,403 668,402 673,401 677,400 682,399 686,398 691,397 695,396 700,395 704,394 709,393 713,392 718,391 722,390 727,389 731,388 736,388 740,387 745,386 749,385 754,384 758,383 763,383 767,382 772,381 776,380 781,380 785,379 790,378 794,377 799,377 803,376 808,375 812,375 817,374 821,374 826,373 830,372 835,372 839,371 844,371 848,370 853,369 857,369 862,368 866,368 871,367 875,367 880,366 884,366 889,365 893,365 898,364 902,364 907,364 911,363 916,363 920,362 925,362 929,361 934,361 938,361 943,360 947,360 952,359 956,359 961,359 965,358 970,358 974,357 979,357 983,356 988,356 992,356 997,355 1001,355 1006,354 1010,354 1015,353 1019,353 1024,353 1028,352 1033,352 1037,351 1042,351 1046,351 1051,350 1055,350 1060,349 1064,349 1069,348 1073,348 1078,348 1082,347 1087,347 1091,346 1096,346 1100,345 1105,345 1109,345 1114,344 1118,344 1123,343 1127,343 1132,343 1136,342 1141,342 1145,341 1150,341 1154,340 1159,340 1163,340 1168,339 1172,339 1177,338 1181,338 1186,337 1190,337 1195,337 1199,336 1204,336 1208,335 1213,335 1217,335 1222,334 1226,334 1231,333 1235,333 1240,332 1244,332 1249,332 1253,331 1258,331 1262,330 1267,330 1271,330 1276,329 1280,329 1285,328 1289,328 1294,328 1298,327 1303,327 1307,327 1312,326 1316,326 1321,326 1325,326 1330,325 1334,325 1339,325 1343,324 1348,324 1352,324 1357,324 1361,324 1366,323 1370,323 1375,323 1379,323 1384,322 1388,322 1393,322 1397,322 1402,322 1406,322 1411,321 1415,321 1420,321 1424,321 1429,321 1433,321 1438,321 1442,320 1447,320 1451,320 1456,320 1460,320 1465,320 1469,320 1474,320 1478,319 1483,319 1487,319 1492,319 1496,319 1501,319 1505,319 1510,319 1514,319 1519,319 1523,318 1528,318 1532,318 1537,318 1541,318 1546,318 1550,318 1555,318 1559,318 1564,318 1568,318 1573,318 1577,318 1582,318 1586,318 1591,317 1595,317 1600,317 1604,317 1609,317 1613,317 1618,317 1622,317 1626,317 1631,317 1635,317 1640,317 1644,317 1649,317 1653,317 1658,317 1662,317 1667,317 1671,317 1676,317 1680,317 1685,317 1689,317 1694,317 1698,317 1703,317 1707,317 1712,316 1716,316 1721,316 1725,316 1730,316 1734,316 1739,316 1743,316 1748,316 1752,316 1757,316 1761,316 1766,316 1770,316 1775,316 1779,316 1784,316 1788,316 1793,316 1797,316 1802,316 1806,316 1811,316 1815,316 1820,316 1824,316 1829,316 1833,316 1838,316 1842,316 1847,316 1851,316 1856,316 1860,316 1865,316 1869,316 1874,316 1878,316 1883,316 1887,316 1892,316 1896,316 1901,316 1905,316 1910,316 1914,316 1919,316 1923,316 1928,316 1932,316 1937,316 1941,316 1946,316 1950,316 1955,316 1959,316 1964,316 1968,316 1973,316 1977,316 1982,316 1986,316 1991,316 1995,316 2000,316 2004,316 2009,316 2013,316 2018,316 2022,316 2027,316 2031,316 2036,316 2040,316 2045,316 2049,316 2054,316 2058,316 2063,316 2067,316 2072,316 2076,316 2081,316 2085,316 2090,316 2094,316 2099,316 2103,316 2108,316 2112,316 2117,316 2121,316 2126,316 2130,316 2135,316 2139,316 2144,316 2148,316 2153,316 2157,316 2162,316 2166,316 2171,316 2175,316 2180,316 2184,316 2189,316 2193,316 2198,316 2202,316 2207,316 2211,316 2216,316 2220,316 2225,316 2229,316 2234,316 2238,316 2243,316 2247,316 2252,316 2256,316 2261,316 2265,316 2270,316 2274,316 2279,316 2283,316 2288,316 2292,316 2297,316 2301,316 2306,316 2310,316 2315,316 2319,316 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2208" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2208 74,2208 "/>
+<text x="65" y="2092" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2092 74,2092 "/>
+<text x="65" y="1975" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1975 74,1975 "/>
+<text x="65" y="1859" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1859 74,1859 "/>
+<text x="65" y="1743" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1743 74,1743 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1510" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1510 74,1510 "/>
+<text x="65" y="1394" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1394 74,1394 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2207 115,2201 120,2195 124,2190 129,2184 133,2178 138,2173 142,2167 147,2162 151,2157 156,2151 160,2146 165,2141 169,2136 174,2131 178,2127 183,2122 187,2117 192,2113 196,2109 201,2105 205,2101 210,2097 214,2093 219,2089 223,2086 228,2082 232,2079 237,2075 241,2072 246,2069 250,2066 255,2063 259,2060 264,2057 268,2055 273,2052 277,2050 282,2047 286,2045 291,2042 295,2040 300,2038 304,2035 309,2033 313,2031 318,2029 322,2027 327,2025 331,2023 336,2021 340,2019 345,2017 349,2015 354,2013 358,2011 363,2009 367,2008 372,2006 376,2004 381,2002 385,2001 390,1999 394,1997 399,1996 403,1994 408,1992 412,1990 417,1989 421,1987 426,1986 430,1984 435,1982 439,1981 444,1979 448,1977 453,1976 457,1974 462,1973 466,1971 471,1970 475,1968 480,1966 484,1965 489,1963 493,1962 498,1960 502,1959 506,1957 511,1955 515,1954 520,1952 524,1951 529,1949 533,1948 538,1946 542,1945 547,1943 551,1941 556,1940 560,1938 565,1937 569,1935 574,1934 578,1932 583,1931 587,1929 592,1928 596,1926 601,1925 605,1923 610,1921 614,1920 619,1918 623,1917 628,1915 632,1914 637,1912 641,1911 646,1909 650,1908 655,1906 659,1905 664,1903 668,1901 673,1900 677,1898 682,1897 686,1895 691,1894 695,1892 700,1891 704,1889 709,1888 713,1886 718,1885 722,1883 727,1882 731,1880 736,1879 740,1877 745,1875 749,1874 754,1872 758,1871 763,1869 767,1868 772,1866 776,1865 781,1863 785,1862 790,1860 794,1859 799,1857 803,1856 808,1854 812,1853 817,1851 821,1849 826,1848 830,1846 835,1845 839,1843 844,1842 848,1840 853,1839 857,1837 862,1836 866,1834 871,1833 875,1831 880,1830 884,1828 889,1826 893,1825 898,1823 902,1822 907,1820 911,1819 916,1817 920,1816 925,1814 929,1813 934,1811 938,1810 943,1808 947,1807 952,1805 956,1804 961,1802 965,1800 970,1799 974,1797 979,1796 983,1794 988,1793 992,1791 997,1790 1001,1788 1006,1787 1010,1785 1015,1784 1019,1782 1024,1781 1028,1779 1033,1778 1037,1776 1042,1774 1046,1773 1051,1771 1055,1770 1060,1768 1064,1767 1069,1765 1073,1764 1078,1762 1082,1761 1087,1759 1091,1758 1096,1756 1100,1755 1105,1753 1109,1752 1114,1750 1118,1748 1123,1747 1127,1745 1132,1744 1136,1742 1141,1741 1145,1739 1150,1738 1154,1736 1159,1735 1163,1733 1168,1732 1172,1730 1177,1729 1181,1727 1186,1726 1190,1724 1195,1722 1199,1721 1204,1719 1208,1718 1213,1716 1217,1715 1222,1713 1226,1712 1231,1710 1235,1709 1240,1707 1244,1706 1249,1704 1253,1703 1258,1701 1262,1700 1267,1698 1271,1696 1276,1695 1280,1693 1285,1692 1289,1690 1294,1689 1298,1687 1303,1686 1307,1684 1312,1683 1316,1681 1321,1680 1325,1678 1330,1677 1334,1675 1339,1673 1343,1672 1348,1670 1352,1669 1357,1667 1361,1666 1366,1664 1370,1663 1375,1661 1379,1660 1384,1658 1388,1657 1393,1655 1397,1654 1402,1652 1406,1651 1411,1649 1415,1647 1420,1646 1424,1644 1429,1643 1433,1641 1438,1640 1442,1638 1447,1637 1451,1635 1456,1634 1460,1632 1465,1631 1469,1629 1474,1628 1478,1626 1483,1625 1487,1623 1492,1621 1496,1620 1501,1618 1505,1617 1510,1615 1514,1614 1519,1612 1523,1611 1528,1609 1532,1608 1537,1606 1541,1605 1546,1603 1550,1602 1555,1600 1559,1599 1564,1597 1568,1595 1573,1594 1577,1592 1582,1591 1586,1589 1591,1588 1595,1586 1600,1585 1604,1583 1609,1582 1613,1580 1618,1579 1622,1577 1626,1576 1631,1574 1635,1573 1640,1571 1644,1569 1649,1568 1653,1566 1658,1565 1662,1563 1667,1562 1671,1560 1676,1559 1680,1557 1685,1556 1689,1554 1694,1553 1698,1551 1703,1550 1707,1548 1712,1547 1716,1545 1721,1543 1725,1542 1730,1540 1734,1539 1739,1537 1743,1536 1748,1534 1752,1533 1757,1531 1761,1530 1766,1528 1770,1527 1775,1525 1779,1524 1784,1522 1788,1521 1793,1519 1797,1517 1802,1516 1806,1514 1811,1513 1815,1511 1820,1510 1824,1508 1829,1507 1833,1505 1838,1504 1842,1502 1847,1501 1851,1499 1856,1498 1860,1496 1865,1494 1869,1493 1874,1491 1878,1490 1883,1488 1887,1487 1892,1485 1896,1484 1901,1482 1905,1481 1910,1479 1914,1478 1919,1476 1923,1475 1928,1473 1932,1472 1937,1470 1941,1468 1946,1467 1950,1465 1955,1464 1959,1462 1964,1461 1968,1459 1973,1458 1977,1456 1982,1455 1986,1453 1991,1452 1995,1450 2000,1449 2004,1447 2009,1446 2013,1444 2018,1442 2022,1441 2027,1439 2031,1438 2036,1436 2040,1435 2045,1433 2049,1432 2054,1430 2058,1429 2063,1427 2067,1426 2072,1424 2076,1423 2081,1421 2085,1420 2090,1418 2094,1416 2099,1415 2103,1413 2108,1412 2112,1410 2117,1409 2121,1407 2126,1406 2130,1404 2135,1403 2139,1401 2144,1400 2148,1398 2153,1397 2157,1395 2162,1394 2166,1392 2171,1390 2175,1389 2180,1387 2184,1386 2189,1384 2193,1383 2198,1381 2202,1380 2207,1378 2211,1377 2216,1375 2220,1374 2225,1372 2229,1371 2234,1369 2238,1368 2243,1366 2247,1364 2252,1363 2256,1361 2261,1360 2265,1358 2270,1357 2274,1355 2279,1354 2283,1352 2288,1351 2292,1349 2297,1348 2301,1346 2306,1345 2310,1343 2315,1341 2319,1340 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2272 1267,2267 1272,2263 1276,2259 1281,2255 1285,2252 1290,2248 1294,2244 1299,2241 1303,2238 1308,2235 1312,2232 1317,2229 1321,2226 1326,2221 1330,2219 1335,2217 1339,2214 1344,2212 1348,2209 1353,2207 1357,2205 1362,2203 1366,2201 1371,2199 1375,2197 1380,2196 1384,2194 1389,2192 1393,2191 1398,2187 1402,2186 1407,2184 1411,2183 1416,2182 1420,2181 1425,2179 1429,2178 1434,2177 1438,2176 1443,2175 1447,2174 1452,2173 1456,2172 1461,2172 1465,2169 1470,2168 1474,2167 1479,2167 1483,2166 1488,2165 1492,2165 1497,2164 1501,2163 1506,2163 1510,2163 1515,2162 1519,2161 1524,2161 1528,2161 1533,2158 1537,2158 1542,2158 1546,2158 1551,2157 1555,2157 1560,2157 1564,2156 1569,2156 1573,2156 1578,2156 1582,2156 1587,2156 1591,2155 1596,2155 1600,2153 1605,2153 1609,2153 1614,2153 1618,2153 1623,2153 1627,2153 1632,2153 1636,2153 1641,2153 1645,2153 1650,2153 1654,2153 1659,2153 1663,2153 1668,2153 1672,2151 1677,2151 1681,2151 1686,2151 1690,2151 1695,2152 1699,2152 1704,2152 1708,2152 1713,2152 1717,2152 1722,2153 1726,2152 1731,2153 1735,2153 1740,2151 1744,2151 1749,2151 1753,2152 1758,2151 1762,2152 1767,2152 1771,2152 1776,2153 1780,2152 1785,2153 1789,2153 1794,2153 1798,2154 1803,2154 1807,2152 1812,2152 1816,2153 1821,2153 1825,2153 1830,2153 1834,2154 1839,2154 1843,2154 1848,2154 1852,2155 1857,2155 1861,2155 1866,2155 1870,2155 1875,2154 1879,2154 1884,2154 1888,2155 1893,2155 1897,2155 1902,2155 1906,2156 1911,2156 1915,2156 1920,2157 1924,2157 1929,2157 1933,2157 1938,2157 1942,2158 1947,2156 1951,2156 1956,2156 1960,2157 1965,2157 1969,2157 1974,2158 1978,2158 1983,2158 1987,2158 1992,2159 1996,2159 2001,2159 2005,2159 2010,2160 2014,2158 2019,2158 2023,2159 2028,2159 2032,2159 2037,2160 2041,2160 2046,2160 2050,2160 2055,2161 2059,2161 2064,2161 2068,2162 2073,2162 2077,2162 2082,2161 2086,2161 2091,2161 2095,2162 2100,2162 2104,2162 2109,2162 2113,2162 2118,2162 2122,2163 2127,2163 2131,2163 2136,2164 2140,2164 2145,2164 2149,2163 2154,2163 2158,2163 2163,2164 2167,2164 2172,2164 2176,2164 2181,2164 2185,2165 2190,2165 2194,2165 2199,2166 2203,2166 2208,2166 2212,2167 2217,2167 2221,2165 2226,2165 2230,2165 2235,2166 2239,2166 2244,2166 2248,2166 2253,2167 2257,2167 2262,2168 2266,2167 2271,2168 2275,2168 2280,2168 2284,2168 2289,2167 2293,2167 2298,2168 2302,2168 2307,2168 2311,2168 2316,2169 2320,2169 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Strong growth, tapering fees_0.000100.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Strong growth, tapering fees_0.000100.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Strong growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,769 156,762 160,755 165,749 169,742 174,736 178,730 183,724 187,718 192,712 196,706 201,701 205,695 210,689 214,684 219,679 223,673 228,668 232,663 237,658 241,653 246,648 250,644 255,639 259,634 264,630 268,625 273,621 277,617 282,613 286,608 291,604 295,600 300,596 304,592 309,589 313,585 318,581 322,577 327,574 331,570 336,567 340,563 345,560 349,557 354,553 358,550 363,547 367,544 372,541 376,538 381,535 385,532 390,529 394,526 399,524 403,521 408,518 412,516 417,513 421,511 426,508 430,506 435,503 439,501 444,499 448,496 453,494 457,492 462,490 466,488 471,485 475,483 480,481 484,479 489,477 493,475 498,474 502,472 506,470 511,468 515,466 520,465 524,463 529,461 533,460 538,458 542,456 547,455 551,453 556,452 560,450 565,449 569,447 574,446 578,445 583,443 587,442 592,441 596,439 601,438 605,437 610,436 614,435 619,433 623,432 628,431 632,430 637,429 641,428 646,427 650,426 655,425 659,424 664,423 668,422 673,421 677,420 682,419 686,419 691,418 695,417 700,416 704,415 709,415 713,414 718,413 722,412 727,412 731,411 736,410 740,410 745,409 749,408 754,408 758,407 763,406 767,406 772,405 776,405 781,404 785,404 790,403 794,403 799,402 803,402 808,401 812,401 817,400 821,400 826,399 830,399 835,399 839,398 844,398 848,397 853,397 857,397 862,396 866,396 871,396 875,395 880,395 884,395 889,395 893,394 898,394 902,394 907,393 911,393 916,393 920,393 925,393 929,392 934,392 938,392 943,392 947,391 952,391 956,391 961,391 965,390 970,390 974,390 979,390 983,390 988,389 992,389 997,389 1001,389 1006,388 1010,388 1015,388 1019,388 1024,387 1028,387 1033,387 1037,387 1042,387 1046,386 1051,386 1055,386 1060,386 1064,385 1069,385 1073,385 1078,385 1082,384 1087,384 1091,384 1096,384 1100,384 1105,383 1109,383 1114,383 1118,383 1123,382 1127,382 1132,382 1136,382 1141,381 1145,381 1150,381 1154,381 1159,380 1163,380 1168,380 1172,380 1177,380 1181,379 1186,379 1190,379 1195,379 1199,378 1204,378 1208,378 1213,378 1217,377 1222,377 1226,377 1231,377 1235,377 1240,376 1244,376 1249,376 1253,376 1258,375 1262,375 1267,375 1271,375 1276,374 1280,374 1285,374 1289,374 1294,373 1298,373 1303,373 1307,373 1312,373 1316,372 1321,372 1325,372 1330,372 1334,371 1339,371 1343,371 1348,371 1352,370 1357,370 1361,370 1366,370 1370,370 1375,369 1379,369 1384,369 1388,369 1393,368 1397,368 1402,368 1406,368 1411,367 1415,367 1420,367 1424,367 1429,366 1433,366 1438,366 1442,366 1447,366 1451,365 1456,365 1460,365 1465,365 1469,364 1474,364 1478,364 1483,364 1487,363 1492,363 1496,363 1501,363 1505,362 1510,362 1514,362 1519,362 1523,362 1528,361 1532,361 1537,361 1541,361 1546,360 1550,360 1555,360 1559,360 1564,359 1568,359 1573,359 1577,359 1582,358 1586,358 1591,358 1595,358 1600,357 1604,357 1609,357 1613,357 1618,357 1622,356 1626,356 1631,356 1635,356 1640,355 1644,355 1649,355 1653,355 1658,354 1662,354 1667,354 1671,354 1676,353 1680,353 1685,353 1689,353 1694,352 1698,352 1703,352 1707,352 1712,352 1716,351 1721,351 1725,351 1730,351 1734,350 1739,350 1743,350 1748,350 1752,349 1757,349 1761,349 1766,349 1770,348 1775,348 1779,348 1784,348 1788,347 1793,347 1797,347 1802,347 1806,346 1811,346 1815,346 1820,346 1824,346 1829,345 1833,345 1838,345 1842,345 1847,344 1851,344 1856,344 1860,344 1865,343 1869,343 1874,343 1878,343 1883,342 1887,342 1892,342 1896,342 1901,341 1905,341 1910,341 1914,341 1919,340 1923,340 1928,340 1932,340 1937,339 1941,339 1946,339 1950,339 1955,338 1959,338 1964,338 1968,338 1973,338 1977,337 1982,337 1986,337 1991,337 1995,336 2000,336 2004,336 2009,336 2013,335 2018,335 2022,335 2027,335 2031,334 2036,334 2040,334 2045,334 2049,333 2054,333 2058,333 2063,333 2067,332 2072,332 2076,332 2081,332 2085,331 2090,331 2094,331 2099,331 2103,330 2108,330 2112,330 2117,330 2121,329 2126,329 2130,329 2135,329 2139,328 2144,328 2148,328 2153,328 2157,327 2162,327 2166,327 2171,327 2175,326 2180,326 2184,326 2189,326 2193,325 2198,325 2202,325 2207,325 2211,324 2216,324 2220,324 2225,324 2229,323 2234,323 2238,323 2243,323 2247,322 2252,322 2256,322 2261,322 2265,321 2270,321 2274,321 2279,321 2283,320 2288,320 2292,320 2297,320 2301,319 2306,319 2310,319 2315,319 2319,318 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2204" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2204 74,2204 "/>
+<text x="65" y="2084" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2084 74,2084 "/>
+<text x="65" y="1963" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1963 74,1963 "/>
+<text x="65" y="1843" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1843 74,1843 "/>
+<text x="65" y="1722" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1722 74,1722 "/>
+<text x="65" y="1602" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1602 74,1602 "/>
+<text x="65" y="1481" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1481 74,1481 "/>
+<text x="65" y="1361" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1361 74,1361 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2016 151,2004 156,1992 160,1981 165,1970 169,1958 174,1947 178,1936 183,1925 187,1915 192,1905 196,1895 201,1885 205,1875 210,1866 214,1857 219,1848 223,1840 228,1832 232,1824 237,1817 241,1810 246,1803 250,1796 255,1790 259,1784 264,1778 268,1773 273,1767 277,1762 282,1758 286,1753 291,1749 295,1745 300,1741 304,1737 309,1733 313,1730 318,1727 322,1724 327,1721 331,1718 336,1715 340,1713 345,1710 349,1708 354,1706 358,1703 363,1701 367,1699 372,1697 376,1696 381,1694 385,1692 390,1690 394,1689 399,1687 403,1686 408,1684 412,1683 417,1682 421,1680 426,1679 430,1678 435,1677 439,1676 444,1674 448,1673 453,1672 457,1671 462,1670 466,1669 471,1668 475,1667 480,1666 484,1665 489,1664 493,1663 498,1662 502,1661 506,1660 511,1659 515,1658 520,1657 524,1657 529,1656 533,1655 538,1654 542,1653 547,1652 551,1651 556,1650 560,1650 565,1649 569,1648 574,1647 578,1646 583,1645 587,1645 592,1644 596,1643 601,1642 605,1641 610,1641 614,1640 619,1639 623,1638 628,1637 632,1636 637,1636 641,1635 646,1634 650,1633 655,1632 659,1632 664,1631 668,1630 673,1629 677,1628 682,1628 686,1627 691,1626 695,1625 700,1624 704,1624 709,1623 713,1622 718,1621 722,1620 727,1620 731,1619 736,1618 740,1617 745,1616 749,1616 754,1615 758,1614 763,1613 767,1612 772,1612 776,1611 781,1610 785,1609 790,1609 794,1608 799,1607 803,1606 808,1605 812,1605 817,1604 821,1603 826,1602 830,1601 835,1601 839,1600 844,1599 848,1598 853,1597 857,1597 862,1596 866,1595 871,1594 875,1593 880,1593 884,1592 889,1591 893,1590 898,1589 902,1589 907,1588 911,1587 916,1586 920,1586 925,1585 929,1584 934,1583 938,1582 943,1582 947,1581 952,1580 956,1579 961,1578 965,1578 970,1577 974,1576 979,1575 983,1574 988,1574 992,1573 997,1572 1001,1571 1006,1570 1010,1570 1015,1569 1019,1568 1024,1567 1028,1567 1033,1566 1037,1565 1042,1564 1046,1563 1051,1563 1055,1562 1060,1561 1064,1560 1069,1559 1073,1559 1078,1558 1082,1557 1087,1556 1091,1555 1096,1555 1100,1554 1105,1553 1109,1552 1114,1551 1118,1551 1123,1550 1127,1549 1132,1548 1136,1548 1141,1547 1145,1546 1150,1545 1154,1544 1159,1544 1163,1543 1168,1542 1172,1541 1177,1540 1181,1540 1186,1539 1190,1538 1195,1537 1199,1536 1204,1536 1208,1535 1213,1534 1217,1533 1222,1532 1226,1532 1231,1531 1235,1530 1240,1529 1244,1529 1249,1528 1253,1527 1258,1526 1262,1525 1267,1525 1271,1524 1276,1523 1280,1522 1285,1521 1289,1521 1294,1520 1298,1519 1303,1518 1307,1517 1312,1517 1316,1516 1321,1515 1325,1514 1330,1513 1334,1513 1339,1512 1343,1511 1348,1510 1352,1510 1357,1509 1361,1508 1366,1507 1370,1506 1375,1506 1379,1505 1384,1504 1388,1503 1393,1502 1397,1502 1402,1501 1406,1500 1411,1499 1415,1498 1420,1498 1424,1497 1429,1496 1433,1495 1438,1494 1442,1494 1447,1493 1451,1492 1456,1491 1460,1491 1465,1490 1469,1489 1474,1488 1478,1487 1483,1487 1487,1486 1492,1485 1496,1484 1501,1483 1505,1483 1510,1482 1514,1481 1519,1480 1523,1479 1528,1479 1532,1478 1537,1477 1541,1476 1546,1475 1550,1475 1555,1474 1559,1473 1564,1472 1568,1471 1573,1471 1577,1470 1582,1469 1586,1468 1591,1468 1595,1467 1600,1466 1604,1465 1609,1464 1613,1464 1618,1463 1622,1462 1626,1461 1631,1460 1635,1460 1640,1459 1644,1458 1649,1457 1653,1456 1658,1456 1662,1455 1667,1454 1671,1453 1676,1452 1680,1452 1685,1451 1689,1450 1694,1449 1698,1449 1703,1448 1707,1447 1712,1446 1716,1445 1721,1445 1725,1444 1730,1443 1734,1442 1739,1441 1743,1441 1748,1440 1752,1439 1757,1438 1761,1437 1766,1437 1770,1436 1775,1435 1779,1434 1784,1433 1788,1433 1793,1432 1797,1431 1802,1430 1806,1430 1811,1429 1815,1428 1820,1427 1824,1426 1829,1426 1833,1425 1838,1424 1842,1423 1847,1422 1851,1422 1856,1421 1860,1420 1865,1419 1869,1418 1874,1418 1878,1417 1883,1416 1887,1415 1892,1414 1896,1414 1901,1413 1905,1412 1910,1411 1914,1411 1919,1410 1923,1409 1928,1408 1932,1407 1937,1407 1941,1406 1946,1405 1950,1404 1955,1403 1959,1403 1964,1402 1968,1401 1973,1400 1977,1399 1982,1399 1986,1398 1991,1397 1995,1396 2000,1395 2004,1395 2009,1394 2013,1393 2018,1392 2022,1392 2027,1391 2031,1390 2036,1389 2040,1388 2045,1388 2049,1387 2054,1386 2058,1385 2063,1384 2067,1384 2072,1383 2076,1382 2081,1381 2085,1380 2090,1380 2094,1379 2099,1378 2103,1377 2108,1376 2112,1376 2117,1375 2121,1374 2126,1373 2130,1373 2135,1372 2139,1371 2144,1370 2148,1369 2153,1369 2157,1368 2162,1367 2166,1366 2171,1365 2175,1365 2180,1364 2184,1363 2189,1362 2193,1361 2198,1361 2202,1360 2207,1359 2211,1358 2216,1357 2220,1357 2225,1356 2229,1355 2234,1354 2238,1354 2243,1353 2247,1352 2252,1351 2256,1350 2261,1350 2265,1349 2270,1348 2274,1347 2279,1346 2283,1346 2288,1345 2292,1344 2297,1343 2301,1342 2306,1342 2310,1341 2315,1340 2319,1339 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2276 1762,2276 1767,2276 1771,2276 1776,2276 1780,2276 1785,2276 1789,2276 1794,2276 1798,2276 1803,2276 1807,2276 1812,2276 1816,2276 1821,2276 1825,2276 1830,2276 1834,2276 1839,2276 1843,2276 1848,2276 1852,2276 1857,2276 1861,2276 1866,2276 1870,2276 1875,2276 1879,2276 1884,2276 1888,2276 1893,2276 1897,2276 1902,2276 1906,2276 1911,2276 1915,2276 1920,2276 1924,2276 1929,2276 1933,2276 1938,2276 1942,2276 1947,2276 1951,2276 1956,2276 1960,2276 1965,2276 1969,2276 1974,2276 1978,2276 1983,2276 1987,2276 1992,2276 1996,2276 2001,2276 2005,2276 2010,2276 2014,2276 2019,2276 2023,2276 2028,2276 2032,2276 2037,2276 2041,2276 2046,2276 2050,2276 2055,2276 2059,2276 2064,2276 2068,2276 2073,2276 2077,2276 2082,2276 2086,2276 2091,2276 2095,2276 2100,2276 2104,2276 2109,2276 2113,2276 2118,2276 2122,2276 2127,2276 2131,2276 2136,2276 2140,2276 2145,2276 2149,2276 2154,2276 2158,2276 2163,2276 2167,2276 2172,2276 2176,2276 2181,2276 2185,2276 2190,2276 2194,2276 2199,2276 2203,2276 2208,2276 2212,2276 2217,2276 2221,2276 2226,2276 2230,2276 2235,2276 2239,2276 2244,2276 2248,2276 2253,2276 2257,2276 2262,2276 2266,2276 2271,2276 2275,2276 2280,2276 2284,2276 2289,2276 2293,2276 2298,2276 2302,2276 2307,2276 2311,2276 2316,2276 2320,2275 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Strong growth, tapering fees_0.000200.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Strong growth, tapering fees_0.000200.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Strong growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,769 156,762 160,755 165,749 169,742 174,736 178,730 183,724 187,718 192,712 196,706 201,701 205,695 210,689 214,684 219,679 223,673 228,668 232,663 237,658 241,653 246,648 250,644 255,639 259,634 264,630 268,625 273,621 277,617 282,613 286,608 291,604 295,600 300,596 304,592 309,589 313,585 318,581 322,577 327,574 331,570 336,567 340,563 345,560 349,557 354,553 358,550 363,547 367,544 372,541 376,538 381,535 385,532 390,529 394,526 399,524 403,521 408,518 412,516 417,513 421,511 426,508 430,506 435,503 439,501 444,499 448,496 453,494 457,492 462,490 466,488 471,485 475,483 480,481 484,479 489,477 493,475 498,474 502,472 506,470 511,468 515,466 520,465 524,463 529,461 533,460 538,458 542,456 547,455 551,453 556,452 560,450 565,449 569,447 574,446 578,445 583,443 587,442 592,441 596,439 601,438 605,437 610,436 614,435 619,433 623,432 628,431 632,430 637,429 641,428 646,427 650,426 655,425 659,424 664,423 668,422 673,421 677,420 682,419 686,419 691,418 695,417 700,416 704,415 709,415 713,414 718,413 722,412 727,412 731,411 736,410 740,410 745,409 749,408 754,408 758,407 763,406 767,406 772,405 776,405 781,404 785,404 790,403 794,403 799,402 803,402 808,401 812,401 817,400 821,400 826,399 830,399 835,399 839,398 844,398 848,397 853,397 857,397 862,396 866,396 871,396 875,395 880,395 884,395 889,395 893,394 898,394 902,394 907,393 911,393 916,393 920,393 925,393 929,392 934,392 938,392 943,392 947,391 952,391 956,391 961,391 965,390 970,390 974,390 979,390 983,390 988,389 992,389 997,389 1001,389 1006,388 1010,388 1015,388 1019,388 1024,387 1028,387 1033,387 1037,387 1042,387 1046,386 1051,386 1055,386 1060,386 1064,385 1069,385 1073,385 1078,385 1082,384 1087,384 1091,384 1096,384 1100,384 1105,383 1109,383 1114,383 1118,383 1123,382 1127,382 1132,382 1136,382 1141,381 1145,381 1150,381 1154,381 1159,380 1163,380 1168,380 1172,380 1177,380 1181,379 1186,379 1190,379 1195,379 1199,378 1204,378 1208,378 1213,378 1217,377 1222,377 1226,377 1231,377 1235,377 1240,376 1244,376 1249,376 1253,376 1258,375 1262,375 1267,375 1271,375 1276,374 1280,374 1285,374 1289,374 1294,373 1298,373 1303,373 1307,373 1312,373 1316,372 1321,372 1325,372 1330,372 1334,371 1339,371 1343,371 1348,371 1352,370 1357,370 1361,370 1366,370 1370,370 1375,369 1379,369 1384,369 1388,369 1393,368 1397,368 1402,368 1406,368 1411,367 1415,367 1420,367 1424,367 1429,366 1433,366 1438,366 1442,366 1447,366 1451,365 1456,365 1460,365 1465,365 1469,364 1474,364 1478,364 1483,364 1487,363 1492,363 1496,363 1501,363 1505,362 1510,362 1514,362 1519,362 1523,362 1528,361 1532,361 1537,361 1541,361 1546,360 1550,360 1555,360 1559,360 1564,359 1568,359 1573,359 1577,359 1582,358 1586,358 1591,358 1595,358 1600,357 1604,357 1609,357 1613,357 1618,357 1622,356 1626,356 1631,356 1635,356 1640,355 1644,355 1649,355 1653,355 1658,354 1662,354 1667,354 1671,354 1676,353 1680,353 1685,353 1689,353 1694,352 1698,352 1703,352 1707,352 1712,352 1716,351 1721,351 1725,351 1730,351 1734,350 1739,350 1743,350 1748,350 1752,349 1757,349 1761,349 1766,349 1770,348 1775,348 1779,348 1784,348 1788,347 1793,347 1797,347 1802,347 1806,346 1811,346 1815,346 1820,346 1824,346 1829,345 1833,345 1838,345 1842,345 1847,344 1851,344 1856,344 1860,344 1865,343 1869,343 1874,343 1878,343 1883,342 1887,342 1892,342 1896,342 1901,341 1905,341 1910,341 1914,341 1919,340 1923,340 1928,340 1932,340 1937,339 1941,339 1946,339 1950,339 1955,338 1959,338 1964,338 1968,338 1973,338 1977,337 1982,337 1986,337 1991,337 1995,336 2000,336 2004,336 2009,336 2013,335 2018,335 2022,335 2027,335 2031,334 2036,334 2040,334 2045,334 2049,333 2054,333 2058,333 2063,333 2067,332 2072,332 2076,332 2081,332 2085,331 2090,331 2094,331 2099,331 2103,330 2108,330 2112,330 2117,330 2121,329 2126,329 2130,329 2135,329 2139,328 2144,328 2148,328 2153,328 2157,327 2162,327 2166,327 2171,327 2175,326 2180,326 2184,326 2189,326 2193,325 2198,325 2202,325 2207,325 2211,324 2216,324 2220,324 2225,324 2229,323 2234,323 2238,323 2243,323 2247,322 2252,322 2256,322 2261,322 2265,321 2270,321 2274,321 2279,321 2283,321 2288,320 2292,320 2297,320 2301,320 2306,320 2310,319 2315,319 2319,319 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2204" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2204 74,2204 "/>
+<text x="65" y="2084" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2084 74,2084 "/>
+<text x="65" y="1963" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1963 74,1963 "/>
+<text x="65" y="1843" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1843 74,1843 "/>
+<text x="65" y="1722" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1722 74,1722 "/>
+<text x="65" y="1602" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1602 74,1602 "/>
+<text x="65" y="1481" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1481 74,1481 "/>
+<text x="65" y="1361" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1361 74,1361 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2016 151,2004 156,1992 160,1981 165,1970 169,1958 174,1947 178,1936 183,1925 187,1915 192,1905 196,1895 201,1885 205,1875 210,1866 214,1857 219,1848 223,1840 228,1832 232,1824 237,1817 241,1810 246,1803 250,1796 255,1790 259,1784 264,1778 268,1773 273,1767 277,1762 282,1758 286,1753 291,1749 295,1745 300,1741 304,1737 309,1733 313,1730 318,1727 322,1724 327,1721 331,1718 336,1715 340,1713 345,1710 349,1708 354,1706 358,1703 363,1701 367,1699 372,1697 376,1696 381,1694 385,1692 390,1690 394,1689 399,1687 403,1686 408,1684 412,1683 417,1682 421,1680 426,1679 430,1678 435,1677 439,1676 444,1674 448,1673 453,1672 457,1671 462,1670 466,1669 471,1668 475,1667 480,1666 484,1665 489,1664 493,1663 498,1662 502,1661 506,1660 511,1659 515,1658 520,1657 524,1657 529,1656 533,1655 538,1654 542,1653 547,1652 551,1651 556,1650 560,1650 565,1649 569,1648 574,1647 578,1646 583,1645 587,1645 592,1644 596,1643 601,1642 605,1641 610,1641 614,1640 619,1639 623,1638 628,1637 632,1636 637,1636 641,1635 646,1634 650,1633 655,1632 659,1632 664,1631 668,1630 673,1629 677,1628 682,1628 686,1627 691,1626 695,1625 700,1624 704,1624 709,1623 713,1622 718,1621 722,1620 727,1620 731,1619 736,1618 740,1617 745,1616 749,1616 754,1615 758,1614 763,1613 767,1612 772,1612 776,1611 781,1610 785,1609 790,1609 794,1608 799,1607 803,1606 808,1605 812,1605 817,1604 821,1603 826,1602 830,1601 835,1601 839,1600 844,1599 848,1598 853,1597 857,1597 862,1596 866,1595 871,1594 875,1593 880,1593 884,1592 889,1591 893,1590 898,1589 902,1589 907,1588 911,1587 916,1586 920,1586 925,1585 929,1584 934,1583 938,1582 943,1582 947,1581 952,1580 956,1579 961,1578 965,1578 970,1577 974,1576 979,1575 983,1574 988,1574 992,1573 997,1572 1001,1571 1006,1570 1010,1570 1015,1569 1019,1568 1024,1567 1028,1567 1033,1566 1037,1565 1042,1564 1046,1563 1051,1563 1055,1562 1060,1561 1064,1560 1069,1559 1073,1559 1078,1558 1082,1557 1087,1556 1091,1555 1096,1555 1100,1554 1105,1553 1109,1552 1114,1551 1118,1551 1123,1550 1127,1549 1132,1548 1136,1548 1141,1547 1145,1546 1150,1545 1154,1544 1159,1544 1163,1543 1168,1542 1172,1541 1177,1540 1181,1540 1186,1539 1190,1538 1195,1537 1199,1536 1204,1536 1208,1535 1213,1534 1217,1533 1222,1532 1226,1532 1231,1531 1235,1530 1240,1529 1244,1529 1249,1528 1253,1527 1258,1526 1262,1525 1267,1525 1271,1524 1276,1523 1280,1522 1285,1521 1289,1521 1294,1520 1298,1519 1303,1518 1307,1517 1312,1517 1316,1516 1321,1515 1325,1514 1330,1513 1334,1513 1339,1512 1343,1511 1348,1510 1352,1510 1357,1509 1361,1508 1366,1507 1370,1506 1375,1506 1379,1505 1384,1504 1388,1503 1393,1502 1397,1502 1402,1501 1406,1500 1411,1499 1415,1498 1420,1498 1424,1497 1429,1496 1433,1495 1438,1494 1442,1494 1447,1493 1451,1492 1456,1491 1460,1491 1465,1490 1469,1489 1474,1488 1478,1487 1483,1487 1487,1486 1492,1485 1496,1484 1501,1483 1505,1483 1510,1482 1514,1481 1519,1480 1523,1479 1528,1479 1532,1478 1537,1477 1541,1476 1546,1475 1550,1475 1555,1474 1559,1473 1564,1472 1568,1471 1573,1471 1577,1470 1582,1469 1586,1468 1591,1468 1595,1467 1600,1466 1604,1465 1609,1464 1613,1464 1618,1463 1622,1462 1626,1461 1631,1460 1635,1460 1640,1459 1644,1458 1649,1457 1653,1456 1658,1456 1662,1455 1667,1454 1671,1453 1676,1452 1680,1452 1685,1451 1689,1450 1694,1449 1698,1449 1703,1448 1707,1447 1712,1446 1716,1445 1721,1445 1725,1444 1730,1443 1734,1442 1739,1441 1743,1441 1748,1440 1752,1439 1757,1438 1761,1437 1766,1437 1770,1436 1775,1435 1779,1434 1784,1433 1788,1433 1793,1432 1797,1431 1802,1430 1806,1430 1811,1429 1815,1428 1820,1427 1824,1426 1829,1426 1833,1425 1838,1424 1842,1423 1847,1422 1851,1422 1856,1421 1860,1420 1865,1419 1869,1418 1874,1418 1878,1417 1883,1416 1887,1415 1892,1414 1896,1414 1901,1413 1905,1412 1910,1411 1914,1411 1919,1410 1923,1409 1928,1408 1932,1407 1937,1407 1941,1406 1946,1405 1950,1404 1955,1403 1959,1403 1964,1402 1968,1401 1973,1400 1977,1399 1982,1399 1986,1398 1991,1397 1995,1396 2000,1395 2004,1395 2009,1394 2013,1393 2018,1392 2022,1392 2027,1391 2031,1390 2036,1389 2040,1388 2045,1388 2049,1387 2054,1386 2058,1385 2063,1384 2067,1384 2072,1383 2076,1382 2081,1381 2085,1380 2090,1380 2094,1379 2099,1378 2103,1377 2108,1376 2112,1376 2117,1375 2121,1374 2126,1373 2130,1373 2135,1372 2139,1371 2144,1370 2148,1369 2153,1369 2157,1368 2162,1367 2166,1366 2171,1365 2175,1365 2180,1364 2184,1363 2189,1362 2193,1361 2198,1361 2202,1360 2207,1359 2211,1358 2216,1357 2220,1357 2225,1356 2229,1355 2234,1354 2238,1354 2243,1353 2247,1352 2252,1351 2256,1350 2261,1350 2265,1349 2270,1348 2274,1347 2279,1346 2283,1346 2288,1345 2292,1344 2297,1343 2301,1342 2306,1342 2310,1341 2315,1340 2319,1339 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2276 1762,2276 1767,2276 1771,2276 1776,2276 1780,2276 1785,2276 1789,2276 1794,2276 1798,2276 1803,2276 1807,2276 1812,2276 1816,2276 1821,2276 1825,2276 1830,2276 1834,2276 1839,2276 1843,2276 1848,2276 1852,2276 1857,2276 1861,2276 1866,2276 1870,2276 1875,2276 1879,2276 1884,2276 1888,2276 1893,2276 1897,2276 1902,2276 1906,2276 1911,2276 1915,2276 1920,2276 1924,2276 1929,2276 1933,2276 1938,2276 1942,2276 1947,2276 1951,2276 1956,2276 1960,2276 1965,2276 1969,2276 1974,2276 1978,2276 1983,2276 1987,2276 1992,2276 1996,2276 2001,2276 2005,2276 2010,2276 2014,2276 2019,2276 2023,2276 2028,2276 2032,2276 2037,2276 2041,2276 2046,2276 2050,2276 2055,2276 2059,2276 2064,2276 2068,2276 2073,2276 2077,2276 2082,2276 2086,2276 2091,2276 2095,2276 2100,2276 2104,2276 2109,2276 2113,2276 2118,2276 2122,2276 2127,2276 2131,2276 2136,2276 2140,2276 2145,2276 2149,2276 2154,2276 2158,2276 2163,2276 2167,2276 2172,2276 2176,2276 2181,2276 2185,2276 2190,2276 2194,2276 2199,2276 2203,2276 2208,2276 2212,2276 2217,2276 2221,2276 2226,2276 2230,2276 2235,2276 2239,2276 2244,2276 2248,2276 2253,2276 2257,2276 2262,2276 2266,2276 2271,2275 2275,2274 2280,2272 2284,2271 2289,2269 2293,2269 2298,2268 2302,2267 2307,2266 2311,2265 2316,2264 2320,2263 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Strong growth, tapering fees_0.000300.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Strong growth, tapering fees_0.000300.svg
@@ -1,0 +1,669 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Strong growth, tapering fees
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,769 156,762 160,755 165,749 169,742 174,736 178,730 183,724 187,718 192,712 196,706 201,701 205,695 210,689 214,684 219,679 223,673 228,668 232,663 237,658 241,653 246,648 250,644 255,639 259,634 264,630 268,625 273,621 277,617 282,613 286,608 291,604 295,600 300,596 304,592 309,589 313,585 318,581 322,577 327,574 331,570 336,567 340,563 345,560 349,557 354,553 358,550 363,547 367,544 372,541 376,538 381,535 385,532 390,529 394,526 399,524 403,521 408,518 412,516 417,513 421,511 426,508 430,506 435,503 439,501 444,499 448,496 453,494 457,492 462,490 466,488 471,485 475,483 480,481 484,479 489,477 493,475 498,474 502,472 506,470 511,468 515,466 520,465 524,463 529,461 533,460 538,458 542,456 547,455 551,453 556,452 560,450 565,449 569,447 574,446 578,445 583,443 587,442 592,441 596,439 601,438 605,437 610,436 614,435 619,433 623,432 628,431 632,430 637,429 641,428 646,427 650,426 655,425 659,424 664,423 668,422 673,421 677,420 682,419 686,419 691,418 695,417 700,416 704,415 709,415 713,414 718,413 722,412 727,412 731,411 736,410 740,410 745,409 749,408 754,408 758,407 763,406 767,406 772,405 776,405 781,404 785,404 790,403 794,403 799,402 803,402 808,401 812,401 817,400 821,400 826,399 830,399 835,399 839,398 844,398 848,397 853,397 857,397 862,396 866,396 871,396 875,395 880,395 884,395 889,395 893,394 898,394 902,394 907,393 911,393 916,393 920,393 925,393 929,392 934,392 938,392 943,392 947,391 952,391 956,391 961,391 965,390 970,390 974,390 979,390 983,390 988,389 992,389 997,389 1001,389 1006,388 1010,388 1015,388 1019,388 1024,387 1028,387 1033,387 1037,387 1042,387 1046,386 1051,386 1055,386 1060,386 1064,385 1069,385 1073,385 1078,385 1082,384 1087,384 1091,384 1096,384 1100,384 1105,383 1109,383 1114,383 1118,383 1123,382 1127,382 1132,382 1136,382 1141,381 1145,381 1150,381 1154,381 1159,380 1163,380 1168,380 1172,380 1177,380 1181,379 1186,379 1190,379 1195,379 1199,378 1204,378 1208,378 1213,378 1217,377 1222,377 1226,377 1231,377 1235,377 1240,376 1244,376 1249,376 1253,376 1258,375 1262,375 1267,375 1271,375 1276,374 1280,374 1285,374 1289,374 1294,373 1298,373 1303,373 1307,373 1312,373 1316,372 1321,372 1325,372 1330,372 1334,371 1339,371 1343,371 1348,371 1352,370 1357,370 1361,370 1366,370 1370,370 1375,369 1379,369 1384,369 1388,369 1393,368 1397,368 1402,368 1406,368 1411,367 1415,367 1420,367 1424,367 1429,366 1433,366 1438,366 1442,366 1447,366 1451,365 1456,365 1460,365 1465,365 1469,364 1474,364 1478,364 1483,364 1487,363 1492,363 1496,363 1501,363 1505,362 1510,362 1514,362 1519,362 1523,362 1528,361 1532,361 1537,361 1541,361 1546,360 1550,360 1555,360 1559,360 1564,359 1568,359 1573,359 1577,359 1582,358 1586,358 1591,358 1595,358 1600,357 1604,357 1609,357 1613,357 1618,357 1622,356 1626,356 1631,356 1635,356 1640,355 1644,355 1649,355 1653,355 1658,354 1662,354 1667,354 1671,354 1676,353 1680,353 1685,353 1689,353 1694,352 1698,352 1703,352 1707,352 1712,352 1716,351 1721,351 1725,351 1730,351 1734,350 1739,350 1743,350 1748,350 1752,349 1757,349 1761,349 1766,349 1770,348 1775,348 1779,348 1784,348 1788,347 1793,347 1797,347 1802,347 1806,346 1811,346 1815,346 1820,346 1824,346 1829,345 1833,345 1838,345 1842,345 1847,344 1851,344 1856,344 1860,344 1865,343 1869,343 1874,343 1878,343 1883,342 1887,342 1892,342 1896,342 1901,341 1905,341 1910,341 1914,341 1919,340 1923,340 1928,340 1932,340 1937,339 1941,339 1946,339 1950,339 1955,338 1959,338 1964,338 1968,338 1973,338 1977,337 1982,337 1986,337 1991,337 1995,336 2000,336 2004,336 2009,336 2013,335 2018,335 2022,335 2027,335 2031,334 2036,334 2040,334 2045,334 2049,333 2054,333 2058,333 2063,333 2067,332 2072,332 2076,332 2081,332 2085,331 2090,331 2094,331 2099,331 2103,330 2108,330 2112,330 2117,330 2121,329 2126,329 2130,329 2135,329 2139,328 2144,328 2148,328 2153,328 2157,327 2162,327 2166,327 2171,327 2175,326 2180,326 2184,326 2189,326 2193,325 2198,325 2202,325 2207,325 2211,324 2216,324 2220,324 2225,324 2229,324 2234,323 2238,323 2243,323 2247,323 2252,323 2256,322 2261,322 2265,322 2270,322 2274,322 2279,322 2283,321 2288,321 2292,321 2297,321 2301,321 2306,321 2310,321 2315,321 2319,320 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2204" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2204 74,2204 "/>
+<text x="65" y="2084" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2084 74,2084 "/>
+<text x="65" y="1963" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1963 74,1963 "/>
+<text x="65" y="1843" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1843 74,1843 "/>
+<text x="65" y="1722" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1722 74,1722 "/>
+<text x="65" y="1602" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1602 74,1602 "/>
+<text x="65" y="1481" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1481 74,1481 "/>
+<text x="65" y="1361" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1361 74,1361 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,2324 79,2324 84,2324 88,2324 93,2324 97,2324 102,2324 106,2324 111,2324 115,2324 120,2324 124,2324 129,2324 133,2324 138,2324 142,2324 147,2016 151,2004 156,1992 160,1981 165,1970 169,1958 174,1947 178,1936 183,1925 187,1915 192,1905 196,1895 201,1885 205,1875 210,1866 214,1857 219,1848 223,1840 228,1832 232,1824 237,1817 241,1810 246,1803 250,1796 255,1790 259,1784 264,1778 268,1773 273,1767 277,1762 282,1758 286,1753 291,1749 295,1745 300,1741 304,1737 309,1733 313,1730 318,1727 322,1724 327,1721 331,1718 336,1715 340,1713 345,1710 349,1708 354,1706 358,1703 363,1701 367,1699 372,1697 376,1696 381,1694 385,1692 390,1690 394,1689 399,1687 403,1686 408,1684 412,1683 417,1682 421,1680 426,1679 430,1678 435,1677 439,1676 444,1674 448,1673 453,1672 457,1671 462,1670 466,1669 471,1668 475,1667 480,1666 484,1665 489,1664 493,1663 498,1662 502,1661 506,1660 511,1659 515,1658 520,1657 524,1657 529,1656 533,1655 538,1654 542,1653 547,1652 551,1651 556,1650 560,1650 565,1649 569,1648 574,1647 578,1646 583,1645 587,1645 592,1644 596,1643 601,1642 605,1641 610,1641 614,1640 619,1639 623,1638 628,1637 632,1636 637,1636 641,1635 646,1634 650,1633 655,1632 659,1632 664,1631 668,1630 673,1629 677,1628 682,1628 686,1627 691,1626 695,1625 700,1624 704,1624 709,1623 713,1622 718,1621 722,1620 727,1620 731,1619 736,1618 740,1617 745,1616 749,1616 754,1615 758,1614 763,1613 767,1612 772,1612 776,1611 781,1610 785,1609 790,1609 794,1608 799,1607 803,1606 808,1605 812,1605 817,1604 821,1603 826,1602 830,1601 835,1601 839,1600 844,1599 848,1598 853,1597 857,1597 862,1596 866,1595 871,1594 875,1593 880,1593 884,1592 889,1591 893,1590 898,1589 902,1589 907,1588 911,1587 916,1586 920,1586 925,1585 929,1584 934,1583 938,1582 943,1582 947,1581 952,1580 956,1579 961,1578 965,1578 970,1577 974,1576 979,1575 983,1574 988,1574 992,1573 997,1572 1001,1571 1006,1570 1010,1570 1015,1569 1019,1568 1024,1567 1028,1567 1033,1566 1037,1565 1042,1564 1046,1563 1051,1563 1055,1562 1060,1561 1064,1560 1069,1559 1073,1559 1078,1558 1082,1557 1087,1556 1091,1555 1096,1555 1100,1554 1105,1553 1109,1552 1114,1551 1118,1551 1123,1550 1127,1549 1132,1548 1136,1548 1141,1547 1145,1546 1150,1545 1154,1544 1159,1544 1163,1543 1168,1542 1172,1541 1177,1540 1181,1540 1186,1539 1190,1538 1195,1537 1199,1536 1204,1536 1208,1535 1213,1534 1217,1533 1222,1532 1226,1532 1231,1531 1235,1530 1240,1529 1244,1529 1249,1528 1253,1527 1258,1526 1262,1525 1267,1525 1271,1524 1276,1523 1280,1522 1285,1521 1289,1521 1294,1520 1298,1519 1303,1518 1307,1517 1312,1517 1316,1516 1321,1515 1325,1514 1330,1513 1334,1513 1339,1512 1343,1511 1348,1510 1352,1510 1357,1509 1361,1508 1366,1507 1370,1506 1375,1506 1379,1505 1384,1504 1388,1503 1393,1502 1397,1502 1402,1501 1406,1500 1411,1499 1415,1498 1420,1498 1424,1497 1429,1496 1433,1495 1438,1494 1442,1494 1447,1493 1451,1492 1456,1491 1460,1491 1465,1490 1469,1489 1474,1488 1478,1487 1483,1487 1487,1486 1492,1485 1496,1484 1501,1483 1505,1483 1510,1482 1514,1481 1519,1480 1523,1479 1528,1479 1532,1478 1537,1477 1541,1476 1546,1475 1550,1475 1555,1474 1559,1473 1564,1472 1568,1471 1573,1471 1577,1470 1582,1469 1586,1468 1591,1468 1595,1467 1600,1466 1604,1465 1609,1464 1613,1464 1618,1463 1622,1462 1626,1461 1631,1460 1635,1460 1640,1459 1644,1458 1649,1457 1653,1456 1658,1456 1662,1455 1667,1454 1671,1453 1676,1452 1680,1452 1685,1451 1689,1450 1694,1449 1698,1449 1703,1448 1707,1447 1712,1446 1716,1445 1721,1445 1725,1444 1730,1443 1734,1442 1739,1441 1743,1441 1748,1440 1752,1439 1757,1438 1761,1437 1766,1437 1770,1436 1775,1435 1779,1434 1784,1433 1788,1433 1793,1432 1797,1431 1802,1430 1806,1430 1811,1429 1815,1428 1820,1427 1824,1426 1829,1426 1833,1425 1838,1424 1842,1423 1847,1422 1851,1422 1856,1421 1860,1420 1865,1419 1869,1418 1874,1418 1878,1417 1883,1416 1887,1415 1892,1414 1896,1414 1901,1413 1905,1412 1910,1411 1914,1411 1919,1410 1923,1409 1928,1408 1932,1407 1937,1407 1941,1406 1946,1405 1950,1404 1955,1403 1959,1403 1964,1402 1968,1401 1973,1400 1977,1399 1982,1399 1986,1398 1991,1397 1995,1396 2000,1395 2004,1395 2009,1394 2013,1393 2018,1392 2022,1392 2027,1391 2031,1390 2036,1389 2040,1388 2045,1388 2049,1387 2054,1386 2058,1385 2063,1384 2067,1384 2072,1383 2076,1382 2081,1381 2085,1380 2090,1380 2094,1379 2099,1378 2103,1377 2108,1376 2112,1376 2117,1375 2121,1374 2126,1373 2130,1373 2135,1372 2139,1371 2144,1370 2148,1369 2153,1369 2157,1368 2162,1367 2166,1366 2171,1365 2175,1365 2180,1364 2184,1363 2189,1362 2193,1361 2198,1361 2202,1360 2207,1359 2211,1358 2216,1357 2220,1357 2225,1356 2229,1355 2234,1354 2238,1354 2243,1353 2247,1352 2252,1351 2256,1350 2261,1350 2265,1349 2270,1348 2274,1347 2279,1346 2283,1346 2288,1345 2292,1344 2297,1343 2301,1342 2306,1342 2310,1341 2315,1340 2319,1339 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2276 1762,2276 1767,2276 1771,2276 1776,2276 1780,2276 1785,2276 1789,2276 1794,2276 1798,2276 1803,2276 1807,2276 1812,2276 1816,2276 1821,2276 1825,2276 1830,2276 1834,2276 1839,2276 1843,2276 1848,2276 1852,2276 1857,2276 1861,2276 1866,2276 1870,2276 1875,2276 1879,2276 1884,2276 1888,2276 1893,2276 1897,2276 1902,2276 1906,2276 1911,2276 1915,2276 1920,2276 1924,2276 1929,2276 1933,2276 1938,2276 1942,2276 1947,2276 1951,2276 1956,2276 1960,2276 1965,2276 1969,2276 1974,2276 1978,2276 1983,2276 1987,2276 1992,2276 1996,2276 2001,2276 2005,2276 2010,2276 2014,2276 2019,2276 2023,2276 2028,2276 2032,2276 2037,2276 2041,2276 2046,2276 2050,2276 2055,2276 2059,2276 2064,2276 2068,2276 2073,2276 2077,2276 2082,2276 2086,2276 2091,2276 2095,2276 2100,2276 2104,2276 2109,2276 2113,2276 2118,2276 2122,2276 2127,2276 2131,2276 2136,2276 2140,2276 2145,2276 2149,2276 2154,2276 2158,2276 2163,2276 2167,2276 2172,2276 2176,2276 2181,2276 2185,2276 2190,2276 2194,2276 2199,2276 2203,2276 2208,2276 2212,2276 2217,2276 2221,2276 2226,2276 2230,2276 2235,2276 2239,2276 2244,2276 2248,2276 2253,2276 2257,2276 2262,2276 2266,2276 2271,2276 2275,2276 2280,2276 2284,2276 2289,2276 2293,2276 2298,2276 2302,2276 2307,2276 2311,2276 2316,2276 2320,2276 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, high frequency_0.000100.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, high frequency_0.000100.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, high frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,885 88,877 93,869 97,861 102,854 106,846 111,839 115,831 120,824 124,817 129,810 133,803 138,796 142,790 147,783 151,777 156,770 160,764 165,758 169,752 174,746 178,740 183,734 187,729 192,723 196,718 201,712 205,707 210,702 214,696 219,691 223,687 228,682 232,677 237,672 241,668 246,663 250,658 255,654 259,650 264,645 268,641 273,637 277,633 282,629 286,625 291,621 295,617 300,614 304,610 309,607 313,603 318,600 322,596 327,593 331,589 336,586 340,583 345,580 349,577 354,574 358,571 363,568 367,565 372,562 376,559 381,557 385,554 390,551 394,549 399,546 403,544 408,541 412,539 417,537 421,534 426,532 430,530 435,528 439,526 444,524 448,521 453,519 457,517 462,515 466,514 471,512 475,510 480,508 484,506 489,504 493,503 498,501 502,499 506,498 511,496 515,495 520,493 524,492 529,490 533,489 538,487 542,486 547,485 551,483 556,482 560,481 565,480 569,478 574,477 578,476 583,475 587,474 592,473 596,472 601,471 605,470 610,469 614,468 619,467 623,466 628,465 632,464 637,463 641,462 646,461 650,461 655,460 659,459 664,458 668,458 673,457 677,456 682,456 686,455 691,454 695,454 700,453 704,452 709,452 713,451 718,451 722,450 727,450 731,449 736,449 740,448 745,448 749,447 754,447 758,446 763,446 767,446 772,445 776,445 781,445 785,444 790,444 794,444 799,443 803,443 808,443 812,442 817,442 821,442 826,442 830,441 835,441 839,441 844,441 848,441 853,441 857,440 862,440 866,440 871,440 875,440 880,440 884,440 889,440 893,439 898,439 902,439 907,439 911,439 916,439 920,439 925,439 929,439 934,439 938,439 943,439 947,439 952,439 956,439 961,439 965,439 970,439 974,438 979,438 983,438 988,438 992,438 997,438 1001,438 1006,438 1010,438 1015,438 1019,438 1024,438 1028,438 1033,438 1037,438 1042,438 1046,438 1051,438 1055,438 1060,438 1064,437 1069,437 1073,437 1078,437 1082,437 1087,437 1091,437 1096,437 1100,437 1105,437 1109,437 1114,437 1118,437 1123,437 1127,437 1132,437 1136,437 1141,436 1145,436 1150,436 1154,436 1159,436 1163,436 1168,436 1172,436 1177,436 1181,436 1186,436 1190,436 1195,436 1199,436 1204,436 1208,435 1213,435 1217,435 1222,435 1226,435 1231,435 1235,435 1240,435 1244,435 1249,435 1253,435 1258,435 1262,435 1267,435 1271,434 1276,434 1280,434 1285,434 1289,434 1294,434 1298,434 1303,434 1307,434 1312,434 1316,434 1321,434 1325,434 1330,434 1334,433 1339,433 1343,433 1348,433 1352,433 1357,433 1361,433 1366,433 1370,433 1375,433 1379,433 1384,432 1388,432 1393,432 1397,432 1402,432 1406,432 1411,432 1415,432 1420,432 1424,432 1429,432 1433,432 1438,432 1442,431 1447,431 1451,431 1456,431 1460,431 1465,431 1469,431 1474,431 1478,431 1483,431 1487,431 1492,430 1496,430 1501,430 1505,430 1510,430 1514,430 1519,430 1523,430 1528,430 1532,430 1537,430 1541,429 1546,429 1550,429 1555,429 1559,429 1564,429 1568,429 1573,429 1577,429 1582,429 1586,428 1591,428 1595,428 1600,428 1604,428 1609,428 1613,428 1618,428 1622,428 1626,428 1631,427 1635,427 1640,427 1644,427 1649,427 1653,427 1658,427 1662,427 1667,427 1671,427 1676,426 1680,426 1685,426 1689,426 1694,426 1698,426 1703,426 1707,426 1712,425 1716,425 1721,425 1725,425 1730,425 1734,425 1739,425 1743,425 1748,425 1752,425 1757,424 1761,424 1766,424 1770,424 1775,424 1779,424 1784,424 1788,424 1793,423 1797,423 1802,423 1806,423 1811,423 1815,423 1820,423 1824,423 1829,423 1833,422 1838,422 1842,422 1847,422 1851,422 1856,422 1860,422 1865,422 1869,421 1874,421 1878,421 1883,421 1887,421 1892,421 1896,421 1901,421 1905,420 1910,420 1914,420 1919,420 1923,420 1928,420 1932,420 1937,420 1941,419 1946,419 1950,419 1955,419 1959,419 1964,419 1968,419 1973,419 1977,418 1982,418 1986,418 1991,418 1995,418 2000,418 2004,418 2009,417 2013,417 2018,417 2022,417 2027,417 2031,417 2036,417 2040,416 2045,416 2049,416 2054,416 2058,416 2063,416 2067,416 2072,416 2076,415 2081,415 2085,415 2090,415 2094,415 2099,415 2103,414 2108,414 2112,414 2117,414 2121,414 2126,414 2130,414 2135,413 2139,413 2144,413 2148,413 2153,413 2157,413 2162,413 2166,412 2171,412 2175,412 2180,412 2184,412 2189,412 2193,412 2198,411 2202,411 2207,411 2211,411 2216,411 2220,411 2225,411 2229,410 2234,410 2238,410 2243,410 2247,410 2252,409 2256,409 2261,409 2265,409 2270,409 2274,409 2279,409 2283,408 2288,408 2292,408 2297,408 2301,408 2306,408 2310,407 2315,407 2319,407 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2225 74,2225 "/>
+<text x="65" y="2125" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2125 74,2125 "/>
+<text x="65" y="2025" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2025 74,2025 "/>
+<text x="65" y="1925" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1925 74,1925 "/>
+<text x="65" y="1825" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1825 74,1825 "/>
+<text x="65" y="1725" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1725 74,1725 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+14M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1526" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1526 74,1526 "/>
+<text x="65" y="1426" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+18M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1426 74,1426 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1609 79,2312 84,1825 88,1338 93,2042 97,2216 102,1435 106,1609 111,2312 115,1825 120,1338 124,2042 129,2216 133,1435 138,1609 142,2312 147,1825 151,1338 156,2042 160,2216 165,1435 169,1609 174,2312 178,1825 183,1338 187,2042 192,2216 196,1435 201,1609 205,2312 210,1825 214,1338 219,2042 223,2216 228,1435 232,1609 237,2312 241,1825 246,1338 250,2042 255,2216 259,1435 264,1609 268,2312 273,1825 277,1338 282,2042 286,2216 291,1435 295,1609 300,2312 304,1825 309,1338 313,2042 318,2216 322,1435 327,1609 331,2312 336,1825 340,1338 345,2042 349,2216 354,1435 358,1609 363,2312 367,1825 372,1338 376,2042 381,2216 385,1435 390,1609 394,2312 399,1825 403,1338 408,2042 412,2216 417,1435 421,1609 426,2312 430,1825 435,1338 439,2042 444,2216 448,1435 453,1609 457,2312 462,1825 466,1338 471,2042 475,2216 480,1435 484,1609 489,2312 493,1825 498,1338 502,2042 506,2216 511,1435 515,1609 520,2312 524,1825 529,1338 533,2042 538,2216 542,1435 547,1609 551,2312 556,1825 560,1338 565,2042 569,2216 574,1435 578,1609 583,2312 587,1825 592,1338 596,2042 601,2216 605,1435 610,1609 614,2312 619,1825 623,1338 628,2042 632,2216 637,1435 641,1609 646,2312 650,1825 655,1338 659,2042 664,2216 668,1435 673,1609 677,2312 682,1825 686,1338 691,2042 695,2216 700,1435 704,1609 709,2312 713,1825 718,1338 722,2042 727,2216 731,1435 736,1609 740,2312 745,1825 749,1338 754,2042 758,2216 763,1435 767,1609 772,2312 776,1825 781,1338 785,2042 790,2216 794,1435 799,1609 803,2312 808,1825 812,1338 817,2042 821,2216 826,1435 830,1609 835,2312 839,1825 844,1338 848,2042 853,2216 857,1435 862,1609 866,2312 871,1825 875,1338 880,2042 884,2216 889,1435 893,1609 898,2312 902,1825 907,1338 911,2042 916,2216 920,1435 925,1609 929,2312 934,1825 938,1338 943,2042 947,2216 952,1435 956,1609 961,2312 965,1825 970,1338 974,2042 979,2216 983,1435 988,1609 992,2312 997,1825 1001,1338 1006,2042 1010,2216 1015,1435 1019,1609 1024,2312 1028,1825 1033,1338 1037,2042 1042,2216 1046,1435 1051,1609 1055,2312 1060,1825 1064,1338 1069,2042 1073,2216 1078,1435 1082,1609 1087,2312 1091,1825 1096,1338 1100,2042 1105,2216 1109,1435 1114,1609 1118,2312 1123,1825 1127,1338 1132,2042 1136,2216 1141,1435 1145,1609 1150,2312 1154,1825 1159,1338 1163,2042 1168,2216 1172,1435 1177,1609 1181,2312 1186,1825 1190,1338 1195,2042 1199,2216 1204,1435 1208,1609 1213,2312 1217,1825 1222,1338 1226,2042 1231,2216 1235,1435 1240,1609 1244,2312 1249,1825 1253,1338 1258,2042 1262,2216 1267,1435 1271,1609 1276,2312 1280,1825 1285,1338 1289,2042 1294,2216 1298,1435 1303,1609 1307,2312 1312,1825 1316,1338 1321,2042 1325,2216 1330,1435 1334,1609 1339,2312 1343,1825 1348,1338 1352,2042 1357,2216 1361,1435 1366,1609 1370,2312 1375,1825 1379,1338 1384,2042 1388,2216 1393,1435 1397,1609 1402,2312 1406,1825 1411,1338 1415,2042 1420,2216 1424,1435 1429,1609 1433,2312 1438,1825 1442,1338 1447,2042 1451,2216 1456,1435 1460,1609 1465,2312 1469,1825 1474,1338 1478,2042 1483,2216 1487,1435 1492,1609 1496,2312 1501,1825 1505,1338 1510,2042 1514,2216 1519,1435 1523,1609 1528,2312 1532,1825 1537,1338 1541,2042 1546,2216 1550,1435 1555,1609 1559,2312 1564,1825 1568,1338 1573,2042 1577,2216 1582,1435 1586,1609 1591,2312 1595,1825 1600,1338 1604,2042 1609,2216 1613,1435 1618,1609 1622,2312 1626,1825 1631,1338 1635,2042 1640,2216 1644,1435 1649,1609 1653,2312 1658,1825 1662,1338 1667,2042 1671,2216 1676,1435 1680,1609 1685,2312 1689,1825 1694,1338 1698,2042 1703,2216 1707,1435 1712,1609 1716,2312 1721,1825 1725,1338 1730,2042 1734,2216 1739,1435 1743,1609 1748,2312 1752,1825 1757,1338 1761,2042 1766,2216 1770,1435 1775,1609 1779,2312 1784,1825 1788,1338 1793,2042 1797,2216 1802,1435 1806,1609 1811,2312 1815,1825 1820,1338 1824,2042 1829,2216 1833,1435 1838,1609 1842,2312 1847,1825 1851,1338 1856,2042 1860,2216 1865,1435 1869,1609 1874,2312 1878,1825 1883,1338 1887,2042 1892,2216 1896,1435 1901,1609 1905,2312 1910,1825 1914,1338 1919,2042 1923,2216 1928,1435 1932,1609 1937,2312 1941,1825 1946,1338 1950,2042 1955,2216 1959,1435 1964,1609 1968,2312 1973,1825 1977,1338 1982,2042 1986,2216 1991,1435 1995,1609 2000,2312 2004,1825 2009,1338 2013,2042 2018,2216 2022,1435 2027,1609 2031,2312 2036,1825 2040,1338 2045,2042 2049,2216 2054,1435 2058,1609 2063,2312 2067,1825 2072,1338 2076,2042 2081,2216 2085,1435 2090,1609 2094,2312 2099,1825 2103,1338 2108,2042 2112,2216 2117,1435 2121,1609 2126,2312 2130,1825 2135,1338 2139,2042 2144,2216 2148,1435 2153,1609 2157,2312 2162,1825 2166,1338 2171,2042 2175,2216 2180,1435 2184,1609 2189,2312 2193,1825 2198,1338 2202,2042 2207,2216 2211,1435 2216,1609 2220,2312 2225,1825 2229,1338 2234,2042 2238,2216 2243,1435 2247,1609 2252,2312 2256,1825 2261,1338 2265,2042 2270,2216 2274,1435 2279,1609 2283,2312 2288,1825 2292,1338 2297,2042 2301,2216 2306,1435 2310,1609 2315,2312 2319,1825 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2276 1762,2276 1767,2276 1771,2276 1776,2276 1780,2276 1785,2276 1789,2276 1794,2276 1798,2276 1803,2276 1807,2276 1812,2276 1816,2276 1821,2276 1825,2276 1830,2276 1834,2276 1839,2276 1843,2276 1848,2276 1852,2276 1857,2276 1861,2276 1866,2276 1870,2276 1875,2276 1879,2276 1884,2276 1888,2276 1893,2276 1897,2276 1902,2276 1906,2276 1911,2276 1915,2276 1920,2276 1924,2276 1929,2276 1933,2276 1938,2276 1942,2276 1947,2276 1951,2276 1956,2276 1960,2276 1965,2276 1969,2276 1974,2276 1978,2276 1983,2276 1987,2276 1992,2276 1996,2276 2001,2276 2005,2276 2010,2276 2014,2276 2019,2276 2023,2276 2028,2276 2032,2276 2037,2276 2041,2276 2046,2276 2050,2276 2055,2276 2059,2276 2064,2276 2068,2276 2073,2276 2077,2276 2082,2276 2086,2276 2091,2276 2095,2276 2100,2276 2104,2276 2109,2276 2113,2276 2118,2276 2122,2276 2127,2276 2131,2276 2136,2276 2140,2276 2145,2276 2149,2276 2154,2276 2158,2276 2163,2276 2167,2276 2172,2276 2176,2276 2181,2276 2185,2276 2190,2276 2194,2276 2199,2276 2203,2276 2208,2276 2212,2276 2217,2276 2221,2276 2226,2276 2230,2276 2235,2276 2239,2276 2244,2276 2248,2276 2253,2276 2257,2276 2262,2276 2266,2276 2271,2276 2275,2276 2280,2276 2284,2276 2289,2276 2293,2276 2298,2276 2302,2276 2307,2276 2311,2276 2316,2276 2320,2276 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, high frequency_0.000200.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, high frequency_0.000200.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, high frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,885 88,877 93,869 97,861 102,854 106,846 111,839 115,831 120,824 124,817 129,810 133,803 138,796 142,790 147,783 151,777 156,770 160,764 165,758 169,752 174,746 178,740 183,734 187,729 192,723 196,718 201,712 205,707 210,702 214,696 219,691 223,687 228,682 232,677 237,672 241,668 246,663 250,658 255,654 259,650 264,645 268,641 273,637 277,633 282,629 286,625 291,621 295,617 300,614 304,610 309,607 313,603 318,600 322,596 327,593 331,589 336,586 340,583 345,580 349,577 354,574 358,571 363,568 367,565 372,562 376,559 381,557 385,554 390,551 394,549 399,546 403,544 408,541 412,539 417,537 421,534 426,532 430,530 435,528 439,526 444,524 448,521 453,519 457,517 462,515 466,514 471,512 475,510 480,508 484,506 489,504 493,503 498,501 502,499 506,498 511,496 515,495 520,493 524,492 529,490 533,489 538,487 542,486 547,485 551,483 556,482 560,481 565,480 569,478 574,477 578,476 583,475 587,474 592,473 596,472 601,471 605,470 610,469 614,468 619,467 623,466 628,465 632,464 637,463 641,462 646,461 650,461 655,460 659,459 664,458 668,458 673,457 677,456 682,456 686,455 691,454 695,454 700,453 704,452 709,452 713,451 718,451 722,450 727,450 731,449 736,449 740,448 745,448 749,447 754,447 758,446 763,446 767,446 772,445 776,445 781,445 785,444 790,444 794,444 799,443 803,443 808,443 812,442 817,442 821,442 826,442 830,441 835,441 839,441 844,441 848,441 853,441 857,440 862,440 866,440 871,440 875,440 880,440 884,440 889,440 893,439 898,439 902,439 907,439 911,439 916,439 920,439 925,439 929,439 934,439 938,439 943,439 947,439 952,439 956,439 961,439 965,439 970,439 974,438 979,438 983,438 988,438 992,438 997,438 1001,438 1006,438 1010,438 1015,438 1019,438 1024,438 1028,438 1033,438 1037,438 1042,438 1046,438 1051,438 1055,438 1060,438 1064,437 1069,437 1073,437 1078,437 1082,437 1087,437 1091,437 1096,437 1100,437 1105,437 1109,437 1114,437 1118,437 1123,437 1127,437 1132,437 1136,437 1141,436 1145,436 1150,436 1154,436 1159,436 1163,436 1168,436 1172,436 1177,436 1181,436 1186,436 1190,436 1195,436 1199,436 1204,436 1208,435 1213,435 1217,435 1222,435 1226,435 1231,435 1235,435 1240,435 1244,435 1249,435 1253,435 1258,435 1262,435 1267,435 1271,434 1276,434 1280,434 1285,434 1289,434 1294,434 1298,434 1303,434 1307,434 1312,434 1316,434 1321,434 1325,434 1330,434 1334,433 1339,433 1343,433 1348,433 1352,433 1357,433 1361,433 1366,433 1370,433 1375,433 1379,433 1384,432 1388,432 1393,432 1397,432 1402,432 1406,432 1411,432 1415,432 1420,432 1424,432 1429,432 1433,432 1438,432 1442,431 1447,431 1451,431 1456,431 1460,431 1465,431 1469,431 1474,431 1478,431 1483,431 1487,431 1492,430 1496,430 1501,430 1505,430 1510,430 1514,430 1519,430 1523,430 1528,430 1532,430 1537,430 1541,429 1546,429 1550,429 1555,429 1559,429 1564,429 1568,429 1573,429 1577,429 1582,429 1586,428 1591,428 1595,428 1600,428 1604,428 1609,428 1613,428 1618,428 1622,428 1626,428 1631,427 1635,427 1640,427 1644,427 1649,427 1653,427 1658,427 1662,427 1667,427 1671,427 1676,426 1680,426 1685,426 1689,426 1694,426 1698,426 1703,426 1707,426 1712,425 1716,425 1721,425 1725,425 1730,425 1734,425 1739,425 1743,425 1748,425 1752,425 1757,424 1761,424 1766,424 1770,424 1775,424 1779,424 1784,424 1788,424 1793,423 1797,423 1802,423 1806,423 1811,423 1815,423 1820,423 1824,423 1829,423 1833,422 1838,422 1842,422 1847,422 1851,422 1856,422 1860,422 1865,422 1869,421 1874,421 1878,421 1883,421 1887,421 1892,421 1896,421 1901,421 1905,420 1910,420 1914,420 1919,420 1923,420 1928,420 1932,420 1937,420 1941,419 1946,419 1950,419 1955,419 1959,419 1964,419 1968,419 1973,419 1977,418 1982,418 1986,418 1991,418 1995,418 2000,418 2004,418 2009,417 2013,417 2018,417 2022,417 2027,417 2031,417 2036,417 2040,416 2045,416 2049,416 2054,416 2058,416 2063,416 2067,416 2072,416 2076,415 2081,415 2085,415 2090,415 2094,415 2099,415 2103,414 2108,414 2112,414 2117,414 2121,414 2126,414 2130,414 2135,413 2139,413 2144,413 2148,413 2153,413 2157,413 2162,413 2166,412 2171,412 2175,412 2180,412 2184,412 2189,412 2193,412 2198,411 2202,411 2207,411 2211,411 2216,411 2220,411 2225,411 2229,410 2234,410 2238,410 2243,410 2247,410 2252,409 2256,409 2261,409 2265,409 2270,409 2274,409 2279,409 2283,408 2288,408 2292,408 2297,408 2301,408 2306,408 2310,407 2315,407 2319,407 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2225 74,2225 "/>
+<text x="65" y="2125" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2125 74,2125 "/>
+<text x="65" y="2025" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2025 74,2025 "/>
+<text x="65" y="1925" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1925 74,1925 "/>
+<text x="65" y="1825" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1825 74,1825 "/>
+<text x="65" y="1725" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1725 74,1725 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+14M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1526" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1526 74,1526 "/>
+<text x="65" y="1426" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+18M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1426 74,1426 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1609 79,2312 84,1825 88,1338 93,2042 97,2216 102,1435 106,1609 111,2312 115,1825 120,1338 124,2042 129,2216 133,1435 138,1609 142,2312 147,1825 151,1338 156,2042 160,2216 165,1435 169,1609 174,2312 178,1825 183,1338 187,2042 192,2216 196,1435 201,1609 205,2312 210,1825 214,1338 219,2042 223,2216 228,1435 232,1609 237,2312 241,1825 246,1338 250,2042 255,2216 259,1435 264,1609 268,2312 273,1825 277,1338 282,2042 286,2216 291,1435 295,1609 300,2312 304,1825 309,1338 313,2042 318,2216 322,1435 327,1609 331,2312 336,1825 340,1338 345,2042 349,2216 354,1435 358,1609 363,2312 367,1825 372,1338 376,2042 381,2216 385,1435 390,1609 394,2312 399,1825 403,1338 408,2042 412,2216 417,1435 421,1609 426,2312 430,1825 435,1338 439,2042 444,2216 448,1435 453,1609 457,2312 462,1825 466,1338 471,2042 475,2216 480,1435 484,1609 489,2312 493,1825 498,1338 502,2042 506,2216 511,1435 515,1609 520,2312 524,1825 529,1338 533,2042 538,2216 542,1435 547,1609 551,2312 556,1825 560,1338 565,2042 569,2216 574,1435 578,1609 583,2312 587,1825 592,1338 596,2042 601,2216 605,1435 610,1609 614,2312 619,1825 623,1338 628,2042 632,2216 637,1435 641,1609 646,2312 650,1825 655,1338 659,2042 664,2216 668,1435 673,1609 677,2312 682,1825 686,1338 691,2042 695,2216 700,1435 704,1609 709,2312 713,1825 718,1338 722,2042 727,2216 731,1435 736,1609 740,2312 745,1825 749,1338 754,2042 758,2216 763,1435 767,1609 772,2312 776,1825 781,1338 785,2042 790,2216 794,1435 799,1609 803,2312 808,1825 812,1338 817,2042 821,2216 826,1435 830,1609 835,2312 839,1825 844,1338 848,2042 853,2216 857,1435 862,1609 866,2312 871,1825 875,1338 880,2042 884,2216 889,1435 893,1609 898,2312 902,1825 907,1338 911,2042 916,2216 920,1435 925,1609 929,2312 934,1825 938,1338 943,2042 947,2216 952,1435 956,1609 961,2312 965,1825 970,1338 974,2042 979,2216 983,1435 988,1609 992,2312 997,1825 1001,1338 1006,2042 1010,2216 1015,1435 1019,1609 1024,2312 1028,1825 1033,1338 1037,2042 1042,2216 1046,1435 1051,1609 1055,2312 1060,1825 1064,1338 1069,2042 1073,2216 1078,1435 1082,1609 1087,2312 1091,1825 1096,1338 1100,2042 1105,2216 1109,1435 1114,1609 1118,2312 1123,1825 1127,1338 1132,2042 1136,2216 1141,1435 1145,1609 1150,2312 1154,1825 1159,1338 1163,2042 1168,2216 1172,1435 1177,1609 1181,2312 1186,1825 1190,1338 1195,2042 1199,2216 1204,1435 1208,1609 1213,2312 1217,1825 1222,1338 1226,2042 1231,2216 1235,1435 1240,1609 1244,2312 1249,1825 1253,1338 1258,2042 1262,2216 1267,1435 1271,1609 1276,2312 1280,1825 1285,1338 1289,2042 1294,2216 1298,1435 1303,1609 1307,2312 1312,1825 1316,1338 1321,2042 1325,2216 1330,1435 1334,1609 1339,2312 1343,1825 1348,1338 1352,2042 1357,2216 1361,1435 1366,1609 1370,2312 1375,1825 1379,1338 1384,2042 1388,2216 1393,1435 1397,1609 1402,2312 1406,1825 1411,1338 1415,2042 1420,2216 1424,1435 1429,1609 1433,2312 1438,1825 1442,1338 1447,2042 1451,2216 1456,1435 1460,1609 1465,2312 1469,1825 1474,1338 1478,2042 1483,2216 1487,1435 1492,1609 1496,2312 1501,1825 1505,1338 1510,2042 1514,2216 1519,1435 1523,1609 1528,2312 1532,1825 1537,1338 1541,2042 1546,2216 1550,1435 1555,1609 1559,2312 1564,1825 1568,1338 1573,2042 1577,2216 1582,1435 1586,1609 1591,2312 1595,1825 1600,1338 1604,2042 1609,2216 1613,1435 1618,1609 1622,2312 1626,1825 1631,1338 1635,2042 1640,2216 1644,1435 1649,1609 1653,2312 1658,1825 1662,1338 1667,2042 1671,2216 1676,1435 1680,1609 1685,2312 1689,1825 1694,1338 1698,2042 1703,2216 1707,1435 1712,1609 1716,2312 1721,1825 1725,1338 1730,2042 1734,2216 1739,1435 1743,1609 1748,2312 1752,1825 1757,1338 1761,2042 1766,2216 1770,1435 1775,1609 1779,2312 1784,1825 1788,1338 1793,2042 1797,2216 1802,1435 1806,1609 1811,2312 1815,1825 1820,1338 1824,2042 1829,2216 1833,1435 1838,1609 1842,2312 1847,1825 1851,1338 1856,2042 1860,2216 1865,1435 1869,1609 1874,2312 1878,1825 1883,1338 1887,2042 1892,2216 1896,1435 1901,1609 1905,2312 1910,1825 1914,1338 1919,2042 1923,2216 1928,1435 1932,1609 1937,2312 1941,1825 1946,1338 1950,2042 1955,2216 1959,1435 1964,1609 1968,2312 1973,1825 1977,1338 1982,2042 1986,2216 1991,1435 1995,1609 2000,2312 2004,1825 2009,1338 2013,2042 2018,2216 2022,1435 2027,1609 2031,2312 2036,1825 2040,1338 2045,2042 2049,2216 2054,1435 2058,1609 2063,2312 2067,1825 2072,1338 2076,2042 2081,2216 2085,1435 2090,1609 2094,2312 2099,1825 2103,1338 2108,2042 2112,2216 2117,1435 2121,1609 2126,2312 2130,1825 2135,1338 2139,2042 2144,2216 2148,1435 2153,1609 2157,2312 2162,1825 2166,1338 2171,2042 2175,2216 2180,1435 2184,1609 2189,2312 2193,1825 2198,1338 2202,2042 2207,2216 2211,1435 2216,1609 2220,2312 2225,1825 2229,1338 2234,2042 2238,2216 2243,1435 2247,1609 2252,2312 2256,1825 2261,1338 2265,2042 2270,2216 2274,1435 2279,1609 2283,2312 2288,1825 2292,1338 2297,2042 2301,2216 2306,1435 2310,1609 2315,2312 2319,1825 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2276 1762,2276 1767,2276 1771,2276 1776,2276 1780,2276 1785,2276 1789,2276 1794,2276 1798,2276 1803,2276 1807,2276 1812,2276 1816,2276 1821,2276 1825,2276 1830,2276 1834,2276 1839,2276 1843,2276 1848,2276 1852,2276 1857,2276 1861,2276 1866,2276 1870,2276 1875,2276 1879,2276 1884,2276 1888,2276 1893,2276 1897,2276 1902,2276 1906,2276 1911,2276 1915,2276 1920,2276 1924,2276 1929,2276 1933,2276 1938,2276 1942,2276 1947,2276 1951,2276 1956,2276 1960,2276 1965,2276 1969,2276 1974,2276 1978,2276 1983,2276 1987,2276 1992,2276 1996,2276 2001,2276 2005,2276 2010,2276 2014,2276 2019,2276 2023,2276 2028,2276 2032,2276 2037,2276 2041,2276 2046,2276 2050,2276 2055,2276 2059,2276 2064,2276 2068,2276 2073,2276 2077,2276 2082,2276 2086,2276 2091,2276 2095,2276 2100,2276 2104,2276 2109,2276 2113,2276 2118,2276 2122,2276 2127,2276 2131,2276 2136,2276 2140,2276 2145,2276 2149,2276 2154,2276 2158,2276 2163,2276 2167,2276 2172,2276 2176,2276 2181,2276 2185,2276 2190,2276 2194,2276 2199,2276 2203,2276 2208,2276 2212,2276 2217,2276 2221,2276 2226,2276 2230,2276 2235,2276 2239,2276 2244,2276 2248,2276 2253,2276 2257,2276 2262,2276 2266,2276 2271,2276 2275,2276 2280,2276 2284,2276 2289,2276 2293,2276 2298,2276 2302,2276 2307,2276 2311,2276 2316,2276 2320,2276 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, high frequency_0.000300.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, high frequency_0.000300.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, high frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,885 88,877 93,869 97,861 102,854 106,846 111,839 115,831 120,824 124,817 129,810 133,803 138,796 142,790 147,783 151,777 156,770 160,764 165,758 169,752 174,746 178,740 183,734 187,729 192,723 196,718 201,712 205,707 210,702 214,696 219,691 223,687 228,682 232,677 237,672 241,668 246,663 250,658 255,654 259,650 264,645 268,641 273,637 277,633 282,629 286,625 291,621 295,617 300,614 304,610 309,607 313,603 318,600 322,596 327,593 331,589 336,586 340,583 345,580 349,577 354,574 358,571 363,568 367,565 372,562 376,559 381,557 385,554 390,551 394,549 399,546 403,544 408,541 412,539 417,537 421,534 426,532 430,530 435,528 439,526 444,524 448,521 453,519 457,517 462,515 466,514 471,512 475,510 480,508 484,506 489,504 493,503 498,501 502,499 506,498 511,496 515,495 520,493 524,492 529,490 533,489 538,487 542,486 547,485 551,483 556,482 560,481 565,480 569,478 574,477 578,476 583,475 587,474 592,473 596,472 601,471 605,470 610,469 614,468 619,467 623,466 628,465 632,464 637,463 641,462 646,461 650,461 655,460 659,459 664,458 668,458 673,457 677,456 682,456 686,455 691,454 695,454 700,453 704,452 709,452 713,451 718,451 722,450 727,450 731,449 736,449 740,448 745,448 749,447 754,447 758,446 763,446 767,446 772,445 776,445 781,445 785,444 790,444 794,444 799,443 803,443 808,443 812,442 817,442 821,442 826,442 830,441 835,441 839,441 844,441 848,441 853,441 857,440 862,440 866,440 871,440 875,440 880,440 884,440 889,440 893,439 898,439 902,439 907,439 911,439 916,439 920,439 925,439 929,439 934,439 938,439 943,439 947,439 952,439 956,439 961,439 965,439 970,439 974,438 979,438 983,438 988,438 992,438 997,438 1001,438 1006,438 1010,438 1015,438 1019,438 1024,438 1028,438 1033,438 1037,438 1042,438 1046,438 1051,438 1055,438 1060,438 1064,437 1069,437 1073,437 1078,437 1082,437 1087,437 1091,437 1096,437 1100,437 1105,437 1109,437 1114,437 1118,437 1123,437 1127,437 1132,437 1136,437 1141,436 1145,436 1150,436 1154,436 1159,436 1163,436 1168,436 1172,436 1177,436 1181,436 1186,436 1190,436 1195,436 1199,436 1204,436 1208,435 1213,435 1217,435 1222,435 1226,435 1231,435 1235,435 1240,435 1244,435 1249,435 1253,435 1258,435 1262,435 1267,435 1271,434 1276,434 1280,434 1285,434 1289,434 1294,434 1298,434 1303,434 1307,434 1312,434 1316,434 1321,434 1325,434 1330,434 1334,433 1339,433 1343,433 1348,433 1352,433 1357,433 1361,433 1366,433 1370,433 1375,433 1379,433 1384,432 1388,432 1393,432 1397,432 1402,432 1406,432 1411,432 1415,432 1420,432 1424,432 1429,432 1433,432 1438,432 1442,431 1447,431 1451,431 1456,431 1460,431 1465,431 1469,431 1474,431 1478,431 1483,431 1487,431 1492,430 1496,430 1501,430 1505,430 1510,430 1514,430 1519,430 1523,430 1528,430 1532,430 1537,430 1541,429 1546,429 1550,429 1555,429 1559,429 1564,429 1568,429 1573,429 1577,429 1582,429 1586,428 1591,428 1595,428 1600,428 1604,428 1609,428 1613,428 1618,428 1622,428 1626,428 1631,427 1635,427 1640,427 1644,427 1649,427 1653,427 1658,427 1662,427 1667,427 1671,427 1676,426 1680,426 1685,426 1689,426 1694,426 1698,426 1703,426 1707,426 1712,425 1716,425 1721,425 1725,425 1730,425 1734,425 1739,425 1743,425 1748,425 1752,425 1757,424 1761,424 1766,424 1770,424 1775,424 1779,424 1784,424 1788,424 1793,423 1797,423 1802,423 1806,423 1811,423 1815,423 1820,423 1824,423 1829,423 1833,422 1838,422 1842,422 1847,422 1851,422 1856,422 1860,422 1865,422 1869,421 1874,421 1878,421 1883,421 1887,421 1892,421 1896,421 1901,421 1905,420 1910,420 1914,420 1919,420 1923,420 1928,420 1932,420 1937,420 1941,419 1946,419 1950,419 1955,419 1959,419 1964,419 1968,419 1973,419 1977,418 1982,418 1986,418 1991,418 1995,418 2000,418 2004,418 2009,417 2013,417 2018,417 2022,417 2027,417 2031,417 2036,417 2040,416 2045,416 2049,416 2054,416 2058,416 2063,416 2067,416 2072,416 2076,415 2081,415 2085,415 2090,415 2094,415 2099,415 2103,414 2108,414 2112,414 2117,414 2121,414 2126,414 2130,414 2135,413 2139,413 2144,413 2148,413 2153,413 2157,413 2162,413 2166,412 2171,412 2175,412 2180,412 2184,412 2189,412 2193,412 2198,411 2202,411 2207,411 2211,411 2216,411 2220,411 2225,411 2229,410 2234,410 2238,410 2243,410 2247,410 2252,409 2256,409 2261,409 2265,409 2270,409 2274,409 2279,409 2283,408 2288,408 2292,408 2297,408 2301,408 2306,408 2310,407 2315,407 2319,407 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2225 74,2225 "/>
+<text x="65" y="2125" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2125 74,2125 "/>
+<text x="65" y="2025" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2025 74,2025 "/>
+<text x="65" y="1925" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1925 74,1925 "/>
+<text x="65" y="1825" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1825 74,1825 "/>
+<text x="65" y="1725" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1725 74,1725 "/>
+<text x="65" y="1626" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+14M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1626 74,1626 "/>
+<text x="65" y="1526" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1526 74,1526 "/>
+<text x="65" y="1426" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+18M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1426 74,1426 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1609 79,2312 84,1825 88,1338 93,2042 97,2216 102,1435 106,1609 111,2312 115,1825 120,1338 124,2042 129,2216 133,1435 138,1609 142,2312 147,1825 151,1338 156,2042 160,2216 165,1435 169,1609 174,2312 178,1825 183,1338 187,2042 192,2216 196,1435 201,1609 205,2312 210,1825 214,1338 219,2042 223,2216 228,1435 232,1609 237,2312 241,1825 246,1338 250,2042 255,2216 259,1435 264,1609 268,2312 273,1825 277,1338 282,2042 286,2216 291,1435 295,1609 300,2312 304,1825 309,1338 313,2042 318,2216 322,1435 327,1609 331,2312 336,1825 340,1338 345,2042 349,2216 354,1435 358,1609 363,2312 367,1825 372,1338 376,2042 381,2216 385,1435 390,1609 394,2312 399,1825 403,1338 408,2042 412,2216 417,1435 421,1609 426,2312 430,1825 435,1338 439,2042 444,2216 448,1435 453,1609 457,2312 462,1825 466,1338 471,2042 475,2216 480,1435 484,1609 489,2312 493,1825 498,1338 502,2042 506,2216 511,1435 515,1609 520,2312 524,1825 529,1338 533,2042 538,2216 542,1435 547,1609 551,2312 556,1825 560,1338 565,2042 569,2216 574,1435 578,1609 583,2312 587,1825 592,1338 596,2042 601,2216 605,1435 610,1609 614,2312 619,1825 623,1338 628,2042 632,2216 637,1435 641,1609 646,2312 650,1825 655,1338 659,2042 664,2216 668,1435 673,1609 677,2312 682,1825 686,1338 691,2042 695,2216 700,1435 704,1609 709,2312 713,1825 718,1338 722,2042 727,2216 731,1435 736,1609 740,2312 745,1825 749,1338 754,2042 758,2216 763,1435 767,1609 772,2312 776,1825 781,1338 785,2042 790,2216 794,1435 799,1609 803,2312 808,1825 812,1338 817,2042 821,2216 826,1435 830,1609 835,2312 839,1825 844,1338 848,2042 853,2216 857,1435 862,1609 866,2312 871,1825 875,1338 880,2042 884,2216 889,1435 893,1609 898,2312 902,1825 907,1338 911,2042 916,2216 920,1435 925,1609 929,2312 934,1825 938,1338 943,2042 947,2216 952,1435 956,1609 961,2312 965,1825 970,1338 974,2042 979,2216 983,1435 988,1609 992,2312 997,1825 1001,1338 1006,2042 1010,2216 1015,1435 1019,1609 1024,2312 1028,1825 1033,1338 1037,2042 1042,2216 1046,1435 1051,1609 1055,2312 1060,1825 1064,1338 1069,2042 1073,2216 1078,1435 1082,1609 1087,2312 1091,1825 1096,1338 1100,2042 1105,2216 1109,1435 1114,1609 1118,2312 1123,1825 1127,1338 1132,2042 1136,2216 1141,1435 1145,1609 1150,2312 1154,1825 1159,1338 1163,2042 1168,2216 1172,1435 1177,1609 1181,2312 1186,1825 1190,1338 1195,2042 1199,2216 1204,1435 1208,1609 1213,2312 1217,1825 1222,1338 1226,2042 1231,2216 1235,1435 1240,1609 1244,2312 1249,1825 1253,1338 1258,2042 1262,2216 1267,1435 1271,1609 1276,2312 1280,1825 1285,1338 1289,2042 1294,2216 1298,1435 1303,1609 1307,2312 1312,1825 1316,1338 1321,2042 1325,2216 1330,1435 1334,1609 1339,2312 1343,1825 1348,1338 1352,2042 1357,2216 1361,1435 1366,1609 1370,2312 1375,1825 1379,1338 1384,2042 1388,2216 1393,1435 1397,1609 1402,2312 1406,1825 1411,1338 1415,2042 1420,2216 1424,1435 1429,1609 1433,2312 1438,1825 1442,1338 1447,2042 1451,2216 1456,1435 1460,1609 1465,2312 1469,1825 1474,1338 1478,2042 1483,2216 1487,1435 1492,1609 1496,2312 1501,1825 1505,1338 1510,2042 1514,2216 1519,1435 1523,1609 1528,2312 1532,1825 1537,1338 1541,2042 1546,2216 1550,1435 1555,1609 1559,2312 1564,1825 1568,1338 1573,2042 1577,2216 1582,1435 1586,1609 1591,2312 1595,1825 1600,1338 1604,2042 1609,2216 1613,1435 1618,1609 1622,2312 1626,1825 1631,1338 1635,2042 1640,2216 1644,1435 1649,1609 1653,2312 1658,1825 1662,1338 1667,2042 1671,2216 1676,1435 1680,1609 1685,2312 1689,1825 1694,1338 1698,2042 1703,2216 1707,1435 1712,1609 1716,2312 1721,1825 1725,1338 1730,2042 1734,2216 1739,1435 1743,1609 1748,2312 1752,1825 1757,1338 1761,2042 1766,2216 1770,1435 1775,1609 1779,2312 1784,1825 1788,1338 1793,2042 1797,2216 1802,1435 1806,1609 1811,2312 1815,1825 1820,1338 1824,2042 1829,2216 1833,1435 1838,1609 1842,2312 1847,1825 1851,1338 1856,2042 1860,2216 1865,1435 1869,1609 1874,2312 1878,1825 1883,1338 1887,2042 1892,2216 1896,1435 1901,1609 1905,2312 1910,1825 1914,1338 1919,2042 1923,2216 1928,1435 1932,1609 1937,2312 1941,1825 1946,1338 1950,2042 1955,2216 1959,1435 1964,1609 1968,2312 1973,1825 1977,1338 1982,2042 1986,2216 1991,1435 1995,1609 2000,2312 2004,1825 2009,1338 2013,2042 2018,2216 2022,1435 2027,1609 2031,2312 2036,1825 2040,1338 2045,2042 2049,2216 2054,1435 2058,1609 2063,2312 2067,1825 2072,1338 2076,2042 2081,2216 2085,1435 2090,1609 2094,2312 2099,1825 2103,1338 2108,2042 2112,2216 2117,1435 2121,1609 2126,2312 2130,1825 2135,1338 2139,2042 2144,2216 2148,1435 2153,1609 2157,2312 2162,1825 2166,1338 2171,2042 2175,2216 2180,1435 2184,1609 2189,2312 2193,1825 2198,1338 2202,2042 2207,2216 2211,1435 2216,1609 2220,2312 2225,1825 2229,1338 2234,2042 2238,2216 2243,1435 2247,1609 2252,2312 2256,1825 2261,1338 2265,2042 2270,2216 2274,1435 2279,1609 2283,2312 2288,1825 2292,1338 2297,2042 2301,2216 2306,1435 2310,1609 2315,2312 2319,1825 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2276 1762,2276 1767,2276 1771,2276 1776,2276 1780,2276 1785,2276 1789,2276 1794,2276 1798,2276 1803,2276 1807,2276 1812,2276 1816,2276 1821,2276 1825,2276 1830,2276 1834,2276 1839,2276 1843,2276 1848,2276 1852,2276 1857,2276 1861,2276 1866,2276 1870,2276 1875,2276 1879,2276 1884,2276 1888,2276 1893,2276 1897,2276 1902,2276 1906,2276 1911,2276 1915,2276 1920,2276 1924,2276 1929,2276 1933,2276 1938,2276 1942,2276 1947,2276 1951,2276 1956,2276 1960,2276 1965,2276 1969,2276 1974,2276 1978,2276 1983,2276 1987,2276 1992,2276 1996,2276 2001,2276 2005,2276 2010,2276 2014,2276 2019,2276 2023,2276 2028,2276 2032,2276 2037,2276 2041,2276 2046,2276 2050,2276 2055,2276 2059,2276 2064,2276 2068,2276 2073,2276 2077,2276 2082,2276 2086,2276 2091,2276 2095,2276 2100,2276 2104,2276 2109,2276 2113,2276 2118,2276 2122,2276 2127,2276 2131,2276 2136,2276 2140,2276 2145,2276 2149,2276 2154,2276 2158,2276 2163,2276 2167,2276 2172,2276 2176,2276 2181,2276 2185,2276 2190,2276 2194,2276 2199,2276 2203,2276 2208,2276 2212,2276 2217,2276 2221,2276 2226,2276 2230,2276 2235,2276 2239,2276 2244,2276 2248,2276 2253,2276 2257,2276 2262,2276 2266,2276 2271,2276 2275,2276 2280,2276 2284,2276 2289,2276 2293,2276 2298,2276 2302,2276 2307,2276 2311,2276 2316,2276 2320,2276 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, low frequency_0.000100.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, low frequency_0.000100.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, low frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,885 88,876 93,868 97,860 102,852 106,844 111,837 115,829 120,822 124,814 129,807 133,800 138,793 142,786 147,779 151,773 156,766 160,759 165,753 169,747 174,741 178,734 183,729 187,723 192,717 196,711 201,706 205,700 210,694 214,689 219,684 223,679 228,673 232,669 237,664 241,659 246,654 250,649 255,645 259,640 264,635 268,631 273,627 277,622 282,618 286,614 291,610 295,606 300,602 304,598 309,594 313,590 318,587 322,583 327,579 331,576 336,573 340,569 345,566 349,562 354,559 358,556 363,553 367,550 372,547 376,543 381,541 385,538 390,535 394,532 399,529 403,527 408,524 412,521 417,519 421,516 426,514 430,511 435,509 439,506 444,504 448,502 453,500 457,497 462,495 466,493 471,491 475,489 480,486 484,485 489,483 493,481 498,479 502,477 506,475 511,473 515,471 520,470 524,468 529,466 533,464 538,463 542,461 547,460 551,458 556,457 560,455 565,453 569,452 574,451 578,449 583,448 587,447 592,445 596,444 601,443 605,442 610,440 614,439 619,438 623,437 628,435 632,434 637,433 641,432 646,431 650,430 655,429 659,428 664,427 668,426 673,425 677,424 682,423 686,422 691,422 695,421 700,420 704,419 709,418 713,417 718,416 722,416 727,415 731,414 736,414 740,413 745,412 749,411 754,411 758,410 763,409 767,409 772,408 776,408 781,407 785,406 790,406 794,405 799,405 803,404 808,404 812,403 817,403 821,402 826,402 830,401 835,401 839,401 844,400 848,400 853,399 857,399 862,399 866,398 871,398 875,397 880,397 884,397 889,396 893,396 898,396 902,395 907,395 911,395 916,394 920,394 925,394 929,394 934,393 938,393 943,393 947,392 952,392 956,392 961,392 965,391 970,391 974,391 979,391 983,390 988,390 992,390 997,389 1001,389 1006,389 1010,389 1015,388 1019,388 1024,388 1028,387 1033,387 1037,387 1042,386 1046,386 1051,386 1055,385 1060,385 1064,385 1069,384 1073,384 1078,384 1082,384 1087,383 1091,383 1096,383 1100,382 1105,382 1109,382 1114,382 1118,381 1123,381 1127,381 1132,380 1136,380 1141,380 1145,380 1150,379 1154,379 1159,379 1163,378 1168,378 1172,378 1177,377 1181,377 1186,377 1190,376 1195,376 1199,376 1204,375 1208,375 1213,375 1217,375 1222,374 1226,374 1231,374 1235,373 1240,373 1244,373 1249,373 1253,372 1258,372 1262,372 1267,371 1271,371 1276,371 1280,370 1285,370 1289,369 1294,369 1298,369 1303,369 1307,368 1312,368 1316,368 1321,367 1325,367 1330,367 1334,367 1339,366 1343,366 1348,366 1352,365 1357,365 1361,365 1366,364 1370,364 1375,363 1379,363 1384,363 1388,363 1393,362 1397,362 1402,362 1406,361 1411,361 1415,361 1420,360 1424,360 1429,360 1433,360 1438,359 1442,359 1447,358 1451,358 1456,358 1460,357 1465,357 1469,357 1474,356 1478,356 1483,356 1487,355 1492,355 1496,355 1501,355 1505,354 1510,354 1514,354 1519,353 1523,353 1528,352 1532,352 1537,352 1541,351 1546,351 1550,351 1555,350 1559,350 1564,350 1568,350 1573,349 1577,349 1582,349 1586,348 1591,348 1595,347 1600,347 1604,347 1609,346 1613,346 1618,346 1622,345 1626,345 1631,345 1635,344 1640,344 1644,344 1649,343 1653,343 1658,343 1662,342 1667,342 1671,342 1676,341 1680,341 1685,341 1689,340 1694,340 1698,340 1703,339 1707,339 1712,338 1716,338 1721,338 1725,337 1730,337 1734,337 1739,336 1743,336 1748,336 1752,335 1757,335 1761,334 1766,334 1770,334 1775,333 1779,333 1784,333 1788,333 1793,332 1797,332 1802,332 1806,331 1811,331 1815,330 1820,330 1824,330 1829,329 1833,329 1838,329 1842,328 1847,328 1851,328 1856,327 1860,327 1865,326 1869,326 1874,326 1878,325 1883,325 1887,325 1892,324 1896,324 1901,323 1905,323 1910,323 1914,322 1919,322 1923,322 1928,321 1932,321 1937,321 1941,320 1946,320 1950,320 1955,320 1959,319 1964,319 1968,319 1973,318 1977,318 1982,318 1986,318 1991,318 1995,317 2000,317 2004,317 2009,317 2013,317 2018,317 2022,316 2027,316 2031,316 2036,316 2040,316 2045,316 2049,316 2054,316 2058,316 2063,315 2067,315 2072,315 2076,315 2081,315 2085,315 2090,315 2094,315 2099,315 2103,315 2108,315 2112,315 2117,315 2121,315 2126,315 2130,314 2135,315 2139,315 2144,315 2148,314 2153,315 2157,315 2162,314 2166,314 2171,315 2175,315 2180,314 2184,314 2189,315 2193,315 2198,314 2202,314 2207,314 2211,314 2216,314 2220,314 2225,314 2229,314 2234,314 2238,314 2243,314 2247,314 2252,314 2256,314 2261,314 2265,314 2270,314 2274,314 2279,314 2283,314 2288,314 2292,314 2297,314 2301,314 2306,314 2310,314 2315,314 2319,314 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 100, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2226 74,2226 "/>
+<text x="65" y="2127" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2127 74,2127 "/>
+<text x="65" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2029 74,2029 "/>
+<text x="65" y="1930" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1930 74,1930 "/>
+<text x="65" y="1831" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1831 74,1831 "/>
+<text x="65" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1733 74,1733 "/>
+<text x="65" y="1634" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1634 74,1634 "/>
+<text x="65" y="1535" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1535 74,1535 "/>
+<text x="65" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+9M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1437 74,1437 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1797 79,1346 84,1967 88,2289 93,1600 97,1423 102,2148 106,2174 111,1443 115,1570 120,2275 124,2000 129,1353 133,1763 138,2324 142,1797 147,1346 151,1967 156,2289 160,1600 165,1423 169,2148 174,2174 178,1443 183,1570 187,2275 192,2000 196,1353 201,1763 205,2324 210,1797 214,1346 219,1967 223,2289 228,1600 232,1423 237,2148 241,2174 246,1443 250,1570 255,2275 259,2000 264,1353 268,1763 273,2324 277,1797 282,1346 286,1967 291,2289 295,1600 300,1423 304,2148 309,2174 313,1443 318,1570 322,2275 327,2000 331,1353 336,1763 340,2324 345,1797 349,1346 354,1967 358,2289 363,1600 367,1423 372,2148 376,2174 381,1443 385,1570 390,2275 394,2000 399,1353 403,1763 408,2324 412,1797 417,1346 421,1967 426,2289 430,1600 435,1423 439,2148 444,2174 448,1443 453,1570 457,2275 462,2000 466,1353 471,1763 475,2324 480,1797 484,1346 489,1967 493,2289 498,1600 502,1423 506,2148 511,2174 515,1443 520,1570 524,2275 529,2000 533,1353 538,1763 542,2324 547,1797 551,1346 556,1967 560,2289 565,1600 569,1423 574,2148 578,2174 583,1443 587,1570 592,2275 596,2000 601,1353 605,1763 610,2324 614,1797 619,1346 623,1967 628,2289 632,1600 637,1423 641,2148 646,2174 650,1443 655,1570 659,2275 664,2000 668,1353 673,1763 677,2324 682,1797 686,1346 691,1967 695,2289 700,1600 704,1423 709,2148 713,2174 718,1443 722,1570 727,2275 731,2000 736,1353 740,1763 745,2324 749,1797 754,1346 758,1967 763,2289 767,1600 772,1423 776,2148 781,2174 785,1443 790,1570 794,2275 799,2000 803,1353 808,1763 812,2324 817,1797 821,1346 826,1967 830,2289 835,1600 839,1423 844,2148 848,2174 853,1443 857,1570 862,2275 866,2000 871,1353 875,1763 880,2324 884,1797 889,1346 893,1967 898,2289 902,1600 907,1423 911,2148 916,2174 920,1443 925,1570 929,2275 934,2000 938,1353 943,1763 947,2324 952,1797 956,1346 961,1967 965,2289 970,1600 974,1423 979,2148 983,2174 988,1443 992,1570 997,2275 1001,2000 1006,1353 1010,1763 1015,2324 1019,1797 1024,1346 1028,1967 1033,2289 1037,1600 1042,1423 1046,2148 1051,2174 1055,1443 1060,1570 1064,2275 1069,2000 1073,1353 1078,1763 1082,2324 1087,1797 1091,1346 1096,1967 1100,2289 1105,1600 1109,1423 1114,2148 1118,2174 1123,1443 1127,1570 1132,2275 1136,2000 1141,1353 1145,1763 1150,2324 1154,1797 1159,1346 1163,1967 1168,2289 1172,1600 1177,1423 1181,2148 1186,2174 1190,1443 1195,1570 1199,2275 1204,2000 1208,1353 1213,1763 1217,2324 1222,1797 1226,1346 1231,1967 1235,2289 1240,1600 1244,1423 1249,2148 1253,2174 1258,1443 1262,1570 1267,2275 1271,2000 1276,1353 1280,1763 1285,2324 1289,1797 1294,1346 1298,1967 1303,2289 1307,1600 1312,1423 1316,2148 1321,2174 1325,1443 1330,1570 1334,2275 1339,2000 1343,1353 1348,1763 1352,2324 1357,1797 1361,1346 1366,1967 1370,2289 1375,1600 1379,1423 1384,2148 1388,2174 1393,1443 1397,1570 1402,2275 1406,2000 1411,1353 1415,1763 1420,2324 1424,1797 1429,1346 1433,1967 1438,2289 1442,1600 1447,1423 1451,2148 1456,2174 1460,1443 1465,1570 1469,2275 1474,2000 1478,1353 1483,1763 1487,2324 1492,1797 1496,1346 1501,1967 1505,2289 1510,1600 1514,1423 1519,2148 1523,2174 1528,1443 1532,1570 1537,2275 1541,2000 1546,1353 1550,1763 1555,2324 1559,1797 1564,1346 1568,1967 1573,2289 1577,1600 1582,1423 1586,2148 1591,2174 1595,1443 1600,1570 1604,2275 1609,2000 1613,1353 1618,1763 1622,2324 1626,1797 1631,1346 1635,1967 1640,2289 1644,1600 1649,1423 1653,2148 1658,2174 1662,1443 1667,1570 1671,2275 1676,2000 1680,1353 1685,1763 1689,2324 1694,1797 1698,1346 1703,1967 1707,2289 1712,1600 1716,1423 1721,2148 1725,2174 1730,1443 1734,1570 1739,2275 1743,2000 1748,1353 1752,1763 1757,2324 1761,1797 1766,1346 1770,1967 1775,2289 1779,1600 1784,1423 1788,2148 1793,2174 1797,1443 1802,1570 1806,2275 1811,2000 1815,1353 1820,1763 1824,2324 1829,1797 1833,1346 1838,1967 1842,2289 1847,1600 1851,1423 1856,2148 1860,2174 1865,1443 1869,1570 1874,2275 1878,2000 1883,1353 1887,1763 1892,2324 1896,1797 1901,1346 1905,1967 1910,2289 1914,1600 1919,1423 1923,2148 1928,2174 1932,1443 1937,1570 1941,2275 1946,2000 1950,1353 1955,1763 1959,2324 1964,1797 1968,1346 1973,1967 1977,2289 1982,1600 1986,1423 1991,2148 1995,2174 2000,1443 2004,1570 2009,2275 2013,2000 2018,1353 2022,1763 2027,2324 2031,1797 2036,1346 2040,1967 2045,2289 2049,1600 2054,1423 2058,2148 2063,2174 2067,1443 2072,1570 2076,2275 2081,2000 2085,1353 2090,1763 2094,2324 2099,1797 2103,1346 2108,1967 2112,2289 2117,1600 2121,1423 2126,2148 2130,2174 2135,1443 2139,1570 2144,2275 2148,2000 2153,1353 2157,1763 2162,2324 2166,1797 2171,1346 2175,1967 2180,2289 2184,1600 2189,1423 2193,2148 2198,2174 2202,1443 2207,1570 2211,2275 2216,2000 2220,1353 2225,1763 2229,2324 2234,1797 2238,1346 2243,1967 2247,2289 2252,1600 2256,1423 2261,2148 2265,2174 2270,1443 2274,1570 2279,2275 2283,2000 2288,1353 2292,1763 2297,2324 2301,1797 2306,1346 2310,1967 2315,2289 2319,1600 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2276 1762,2276 1767,2276 1771,2276 1776,2276 1780,2276 1785,2276 1789,2276 1794,2276 1798,2276 1803,2276 1807,2276 1812,2276 1816,2276 1821,2276 1825,2276 1830,2276 1834,2276 1839,2276 1843,2276 1848,2276 1852,2276 1857,2276 1861,2276 1866,2276 1870,2276 1875,2276 1879,2276 1884,2276 1888,2276 1893,2276 1897,2276 1902,2276 1906,2276 1911,2276 1915,2276 1920,2276 1924,2276 1929,2164 1933,2276 1938,2276 1942,2179 1947,2197 1951,2276 1956,2276 1960,1934 1965,2254 1969,2276 1974,2233 1978,1832 1983,2267 1987,2276 1992,2143 1996,1872 2001,2270 2005,2261 2010,1956 2014,2080 2019,2270 2023,2231 2028,1832 2032,2204 2037,2266 2041,2178 2046,1832 2050,2239 2055,2257 2059,2072 2064,1841 2068,2253 2073,2242 2077,1858 2082,2037 2086,2257 2091,2212 2095,1832 2100,2182 2104,2256 2109,2156 2113,1832 2118,2227 2122,2249 2127,2043 2131,1833 2136,2245 2140,2233 2145,1832 2149,2018 2154,2251 2158,2203 2163,1832 2167,2172 2172,2251 2176,2145 2181,1832 2185,2221 2190,2245 2194,2029 2199,1832 2203,2241 2208,2229 2212,1832 2217,2011 2221,2249 2226,2199 2230,1832 2235,2167 2239,2249 2244,2140 2248,1832 2253,2219 2257,2243 2262,2022 2266,1832 2271,2239 2275,2227 2280,1832 2284,2006 2289,2247 2293,2196 2298,1832 2302,2164 2307,2248 2311,2137 2316,1832 2320,2217 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, low frequency_0.000200.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, low frequency_0.000200.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, low frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,885 88,876 93,868 97,860 102,852 106,844 111,837 115,829 120,822 124,814 129,807 133,800 138,793 142,786 147,779 151,773 156,766 160,759 165,753 169,747 174,741 178,734 183,729 187,723 192,717 196,711 201,706 205,700 210,694 214,689 219,684 223,679 228,673 232,669 237,664 241,659 246,654 250,649 255,645 259,640 264,635 268,631 273,627 277,622 282,618 286,614 291,610 295,606 300,602 304,598 309,594 313,590 318,587 322,583 327,579 331,576 336,573 340,569 345,566 349,562 354,559 358,556 363,553 367,550 372,547 376,543 381,541 385,538 390,535 394,532 399,529 403,527 408,524 412,521 417,519 421,516 426,514 430,511 435,509 439,506 444,504 448,502 453,500 457,497 462,495 466,493 471,491 475,489 480,486 484,485 489,483 493,481 498,479 502,477 506,475 511,473 515,471 520,470 524,468 529,466 533,464 538,463 542,461 547,460 551,458 556,457 560,455 565,453 569,452 574,451 578,449 583,448 587,447 592,445 596,444 601,443 605,442 610,440 614,439 619,438 623,437 628,435 632,434 637,433 641,432 646,431 650,430 655,429 659,428 664,427 668,426 673,425 677,424 682,423 686,422 691,422 695,421 700,420 704,419 709,418 713,417 718,416 722,416 727,415 731,414 736,414 740,413 745,412 749,411 754,411 758,410 763,409 767,409 772,408 776,408 781,407 785,406 790,406 794,405 799,405 803,404 808,404 812,403 817,403 821,402 826,402 830,401 835,401 839,401 844,400 848,400 853,399 857,399 862,399 866,398 871,398 875,397 880,397 884,397 889,396 893,396 898,396 902,395 907,395 911,395 916,394 920,394 925,394 929,394 934,393 938,393 943,393 947,392 952,392 956,392 961,392 965,391 970,391 974,391 979,391 983,390 988,390 992,390 997,389 1001,389 1006,389 1010,389 1015,388 1019,388 1024,388 1028,387 1033,387 1037,387 1042,386 1046,386 1051,386 1055,385 1060,385 1064,385 1069,384 1073,384 1078,384 1082,384 1087,383 1091,383 1096,383 1100,382 1105,382 1109,382 1114,382 1118,381 1123,381 1127,381 1132,380 1136,380 1141,380 1145,380 1150,379 1154,379 1159,379 1163,378 1168,378 1172,378 1177,377 1181,377 1186,377 1190,376 1195,376 1199,376 1204,375 1208,375 1213,375 1217,375 1222,374 1226,374 1231,374 1235,373 1240,373 1244,373 1249,373 1253,372 1258,372 1262,372 1267,371 1271,371 1276,371 1280,370 1285,370 1289,369 1294,369 1298,369 1303,369 1307,368 1312,368 1316,368 1321,367 1325,367 1330,367 1334,367 1339,366 1343,366 1348,366 1352,365 1357,365 1361,365 1366,364 1370,364 1375,363 1379,363 1384,363 1388,363 1393,362 1397,362 1402,362 1406,361 1411,361 1415,361 1420,360 1424,360 1429,360 1433,360 1438,359 1442,359 1447,358 1451,358 1456,358 1460,357 1465,357 1469,357 1474,356 1478,356 1483,356 1487,355 1492,355 1496,355 1501,355 1505,354 1510,354 1514,354 1519,353 1523,353 1528,352 1532,352 1537,352 1541,351 1546,351 1550,351 1555,350 1559,350 1564,350 1568,350 1573,349 1577,349 1582,349 1586,348 1591,348 1595,347 1600,347 1604,347 1609,346 1613,346 1618,346 1622,345 1626,345 1631,345 1635,344 1640,344 1644,344 1649,343 1653,343 1658,343 1662,342 1667,342 1671,342 1676,341 1680,341 1685,341 1689,340 1694,340 1698,340 1703,339 1707,339 1712,338 1716,338 1721,338 1725,337 1730,337 1734,337 1739,336 1743,336 1748,336 1752,335 1757,335 1761,334 1766,334 1770,334 1775,333 1779,333 1784,333 1788,333 1793,332 1797,332 1802,332 1806,331 1811,331 1815,330 1820,330 1824,330 1829,329 1833,329 1838,329 1842,328 1847,328 1851,328 1856,327 1860,327 1865,326 1869,326 1874,326 1878,325 1883,325 1887,325 1892,325 1896,324 1901,324 1905,324 1910,323 1914,323 1919,323 1923,323 1928,322 1932,322 1937,322 1941,322 1946,321 1950,321 1955,321 1959,320 1964,320 1968,320 1973,320 1977,319 1982,319 1986,319 1991,319 1995,319 2000,319 2004,318 2009,318 2013,318 2018,318 2022,318 2027,318 2031,317 2036,317 2040,317 2045,317 2049,317 2054,317 2058,317 2063,316 2067,316 2072,316 2076,316 2081,316 2085,316 2090,316 2094,316 2099,316 2103,316 2108,316 2112,315 2117,315 2121,315 2126,315 2130,315 2135,315 2139,315 2144,315 2148,315 2153,315 2157,315 2162,314 2166,314 2171,314 2175,314 2180,314 2184,314 2189,314 2193,314 2198,314 2202,314 2207,314 2211,314 2216,314 2220,314 2225,314 2229,314 2234,314 2238,314 2243,314 2247,313 2252,314 2256,314 2261,314 2265,313 2270,313 2274,314 2279,314 2283,313 2288,313 2292,313 2297,313 2301,313 2306,313 2310,313 2315,313 2319,313 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 200, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2226 74,2226 "/>
+<text x="65" y="2127" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2127 74,2127 "/>
+<text x="65" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2029 74,2029 "/>
+<text x="65" y="1930" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1930 74,1930 "/>
+<text x="65" y="1831" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1831 74,1831 "/>
+<text x="65" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1733 74,1733 "/>
+<text x="65" y="1634" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1634 74,1634 "/>
+<text x="65" y="1535" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1535 74,1535 "/>
+<text x="65" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+9M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1437 74,1437 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1797 79,1346 84,1967 88,2289 93,1600 97,1423 102,2148 106,2174 111,1443 115,1570 120,2275 124,2000 129,1353 133,1763 138,2324 142,1797 147,1346 151,1967 156,2289 160,1600 165,1423 169,2148 174,2174 178,1443 183,1570 187,2275 192,2000 196,1353 201,1763 205,2324 210,1797 214,1346 219,1967 223,2289 228,1600 232,1423 237,2148 241,2174 246,1443 250,1570 255,2275 259,2000 264,1353 268,1763 273,2324 277,1797 282,1346 286,1967 291,2289 295,1600 300,1423 304,2148 309,2174 313,1443 318,1570 322,2275 327,2000 331,1353 336,1763 340,2324 345,1797 349,1346 354,1967 358,2289 363,1600 367,1423 372,2148 376,2174 381,1443 385,1570 390,2275 394,2000 399,1353 403,1763 408,2324 412,1797 417,1346 421,1967 426,2289 430,1600 435,1423 439,2148 444,2174 448,1443 453,1570 457,2275 462,2000 466,1353 471,1763 475,2324 480,1797 484,1346 489,1967 493,2289 498,1600 502,1423 506,2148 511,2174 515,1443 520,1570 524,2275 529,2000 533,1353 538,1763 542,2324 547,1797 551,1346 556,1967 560,2289 565,1600 569,1423 574,2148 578,2174 583,1443 587,1570 592,2275 596,2000 601,1353 605,1763 610,2324 614,1797 619,1346 623,1967 628,2289 632,1600 637,1423 641,2148 646,2174 650,1443 655,1570 659,2275 664,2000 668,1353 673,1763 677,2324 682,1797 686,1346 691,1967 695,2289 700,1600 704,1423 709,2148 713,2174 718,1443 722,1570 727,2275 731,2000 736,1353 740,1763 745,2324 749,1797 754,1346 758,1967 763,2289 767,1600 772,1423 776,2148 781,2174 785,1443 790,1570 794,2275 799,2000 803,1353 808,1763 812,2324 817,1797 821,1346 826,1967 830,2289 835,1600 839,1423 844,2148 848,2174 853,1443 857,1570 862,2275 866,2000 871,1353 875,1763 880,2324 884,1797 889,1346 893,1967 898,2289 902,1600 907,1423 911,2148 916,2174 920,1443 925,1570 929,2275 934,2000 938,1353 943,1763 947,2324 952,1797 956,1346 961,1967 965,2289 970,1600 974,1423 979,2148 983,2174 988,1443 992,1570 997,2275 1001,2000 1006,1353 1010,1763 1015,2324 1019,1797 1024,1346 1028,1967 1033,2289 1037,1600 1042,1423 1046,2148 1051,2174 1055,1443 1060,1570 1064,2275 1069,2000 1073,1353 1078,1763 1082,2324 1087,1797 1091,1346 1096,1967 1100,2289 1105,1600 1109,1423 1114,2148 1118,2174 1123,1443 1127,1570 1132,2275 1136,2000 1141,1353 1145,1763 1150,2324 1154,1797 1159,1346 1163,1967 1168,2289 1172,1600 1177,1423 1181,2148 1186,2174 1190,1443 1195,1570 1199,2275 1204,2000 1208,1353 1213,1763 1217,2324 1222,1797 1226,1346 1231,1967 1235,2289 1240,1600 1244,1423 1249,2148 1253,2174 1258,1443 1262,1570 1267,2275 1271,2000 1276,1353 1280,1763 1285,2324 1289,1797 1294,1346 1298,1967 1303,2289 1307,1600 1312,1423 1316,2148 1321,2174 1325,1443 1330,1570 1334,2275 1339,2000 1343,1353 1348,1763 1352,2324 1357,1797 1361,1346 1366,1967 1370,2289 1375,1600 1379,1423 1384,2148 1388,2174 1393,1443 1397,1570 1402,2275 1406,2000 1411,1353 1415,1763 1420,2324 1424,1797 1429,1346 1433,1967 1438,2289 1442,1600 1447,1423 1451,2148 1456,2174 1460,1443 1465,1570 1469,2275 1474,2000 1478,1353 1483,1763 1487,2324 1492,1797 1496,1346 1501,1967 1505,2289 1510,1600 1514,1423 1519,2148 1523,2174 1528,1443 1532,1570 1537,2275 1541,2000 1546,1353 1550,1763 1555,2324 1559,1797 1564,1346 1568,1967 1573,2289 1577,1600 1582,1423 1586,2148 1591,2174 1595,1443 1600,1570 1604,2275 1609,2000 1613,1353 1618,1763 1622,2324 1626,1797 1631,1346 1635,1967 1640,2289 1644,1600 1649,1423 1653,2148 1658,2174 1662,1443 1667,1570 1671,2275 1676,2000 1680,1353 1685,1763 1689,2324 1694,1797 1698,1346 1703,1967 1707,2289 1712,1600 1716,1423 1721,2148 1725,2174 1730,1443 1734,1570 1739,2275 1743,2000 1748,1353 1752,1763 1757,2324 1761,1797 1766,1346 1770,1967 1775,2289 1779,1600 1784,1423 1788,2148 1793,2174 1797,1443 1802,1570 1806,2275 1811,2000 1815,1353 1820,1763 1824,2324 1829,1797 1833,1346 1838,1967 1842,2289 1847,1600 1851,1423 1856,2148 1860,2174 1865,1443 1869,1570 1874,2275 1878,2000 1883,1353 1887,1763 1892,2324 1896,1797 1901,1346 1905,1967 1910,2289 1914,1600 1919,1423 1923,2148 1928,2174 1932,1443 1937,1570 1941,2275 1946,2000 1950,1353 1955,1763 1959,2324 1964,1797 1968,1346 1973,1967 1977,2289 1982,1600 1986,1423 1991,2148 1995,2174 2000,1443 2004,1570 2009,2275 2013,2000 2018,1353 2022,1763 2027,2324 2031,1797 2036,1346 2040,1967 2045,2289 2049,1600 2054,1423 2058,2148 2063,2174 2067,1443 2072,1570 2076,2275 2081,2000 2085,1353 2090,1763 2094,2324 2099,1797 2103,1346 2108,1967 2112,2289 2117,1600 2121,1423 2126,2148 2130,2174 2135,1443 2139,1570 2144,2275 2148,2000 2153,1353 2157,1763 2162,2324 2166,1797 2171,1346 2175,1967 2180,2289 2184,1600 2189,1423 2193,2148 2198,2174 2202,1443 2207,1570 2211,2275 2216,2000 2220,1353 2225,1763 2229,2324 2234,1797 2238,1346 2243,1967 2247,2289 2252,1600 2256,1423 2261,2148 2265,2174 2270,1443 2274,1570 2279,2275 2283,2000 2288,1353 2292,1763 2297,2324 2301,1797 2306,1346 2310,1967 2315,2289 2319,1600 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2276 1762,2276 1767,2276 1771,2276 1776,2276 1780,2276 1785,2276 1789,2276 1794,2276 1798,2276 1803,2276 1807,2276 1812,2276 1816,2276 1821,2276 1825,2272 1830,2276 1834,2276 1839,2276 1843,2141 1848,2276 1852,2276 1857,2270 1861,2152 1866,2276 1870,2276 1875,2158 1879,2260 1884,2276 1888,2276 1893,1872 1897,2276 1902,2276 1906,2254 1911,1832 1915,2276 1920,2276 1924,2175 1929,1983 1933,2276 1938,2276 1942,1974 1947,2197 1951,2276 1956,2254 1960,1832 1965,2246 1969,2276 1974,2207 1978,1832 1983,2263 1987,2274 1992,2098 1996,1905 2001,2270 2005,2259 2010,1832 2014,2149 2019,2271 2023,2230 2028,1832 2032,2222 2037,2269 2041,2174 2046,1832 2050,2247 2055,2261 2059,2047 2064,1866 2068,2259 2073,2245 2077,1832 2082,2118 2086,2262 2091,2214 2095,1832 2100,2206 2104,2260 2109,2153 2113,1832 2118,2237 2122,2253 2127,2014 2131,1848 2136,2251 2140,2237 2145,1832 2149,2098 2154,2256 2158,2204 2163,1832 2167,2195 2172,2255 2176,2139 2181,1832 2185,2230 2190,2248 2194,1992 2199,1838 2203,2246 2208,2231 2212,1832 2217,2086 2221,2252 2226,2197 2230,1832 2235,2188 2239,2251 2244,2129 2248,1832 2253,2226 2257,2244 2262,1976 2266,1832 2271,2243 2275,2227 2280,1832 2284,2077 2289,2249 2293,2192 2298,1832 2302,2183 2307,2249 2311,2122 2316,1832 2320,2223 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>

--- a/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, low frequency_0.000300.svg
+++ b/src/assets/rfc-323/throttle_21000000000.000000 T_Unstable fees, low frequency_0.000300.svg
@@ -1,0 +1,673 @@
+<svg width="2400" height="2400" viewBox="0 0 2400 2400" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="2400" height="2400" opacity="1" fill="#FFFFFF" stroke="none"/>
+<text x="1200" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="48.38709677419355" opacity="1" fill="#000000">
+Unstable fees, low frequency
+</text>
+<text x="1200" y="78" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Target: 21.00B, Trigger after 1y0m
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="1153" x2="93" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="1153" x2="112" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="1153" x2="131" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="1153" x2="149" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="1153" x2="168" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="1153" x2="187" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="1153" x2="206" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="1153" x2="224" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="1153" x2="243" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="1153" x2="281" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="1153" x2="299" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="1153" x2="318" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="1153" x2="337" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="1153" x2="356" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="1153" x2="374" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="1153" x2="393" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="1153" x2="412" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="1153" x2="431" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="1153" x2="468" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="1153" x2="487" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="1153" x2="506" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="1153" x2="524" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="1153" x2="543" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="1153" x2="562" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="1153" x2="581" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="1153" x2="599" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="1153" x2="618" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="1153" x2="655" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="1153" x2="674" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="1153" x2="693" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="1153" x2="712" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="1153" x2="730" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="1153" x2="749" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="1153" x2="768" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="1153" x2="787" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="1153" x2="805" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="1153" x2="843" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="1153" x2="862" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="1153" x2="880" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="1153" x2="899" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="1153" x2="918" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="1153" x2="937" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="1153" x2="955" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="1153" x2="974" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="1153" x2="993" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="1153" x2="1030" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="1153" x2="1049" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="1153" x2="1068" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="1153" x2="1087" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="1153" x2="1105" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="1153" x2="1124" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="1153" x2="1143" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="1153" x2="1162" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="1153" x2="1180" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="1153" x2="1218" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="1153" x2="1236" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="1153" x2="1255" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="1153" x2="1274" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="1153" x2="1293" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="1153" x2="1311" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="1153" x2="1330" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="1153" x2="1349" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="1153" x2="1368" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="1153" x2="1405" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="1153" x2="1424" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="1153" x2="1443" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="1153" x2="1461" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="1153" x2="1480" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="1153" x2="1499" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="1153" x2="1518" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="1153" x2="1536" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="1153" x2="1555" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="1153" x2="1593" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="1153" x2="1611" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="1153" x2="1630" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="1153" x2="1649" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="1153" x2="1668" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="1153" x2="1686" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="1153" x2="1705" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="1153" x2="1724" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="1153" x2="1743" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="1153" x2="1780" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="1153" x2="1799" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="1153" x2="1817" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="1153" x2="1836" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="1153" x2="1855" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="1153" x2="1874" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="1153" x2="1892" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="1153" x2="1911" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="1153" x2="1930" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="1153" x2="1967" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="1153" x2="1986" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="1153" x2="2005" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="1153" x2="2024" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="1153" x2="2042" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="1153" x2="2061" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="1153" x2="2080" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="1153" x2="2099" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="1153" x2="2117" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="1153" x2="2155" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="1153" x2="2174" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="1153" x2="2192" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="1153" x2="2211" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="1153" x2="2230" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="1153" x2="2249" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="1153" x2="2267" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="1153" x2="2286" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="1153" x2="2305" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1134" x2="2324" y2="1134"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1114" x2="2324" y2="1114"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1094" x2="2324" y2="1094"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1074" x2="2324" y2="1074"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1054" x2="2324" y2="1054"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1034" x2="2324" y2="1034"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="1014" x2="2324" y2="1014"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="994" x2="2324" y2="994"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="974" x2="2324" y2="974"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="934" x2="2324" y2="934"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="914" x2="2324" y2="914"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="894" x2="2324" y2="894"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="874" x2="2324" y2="874"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="854" x2="2324" y2="854"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="834" x2="2324" y2="834"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="814" x2="2324" y2="814"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="794" x2="2324" y2="794"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="774" x2="2324" y2="774"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="735" x2="2324" y2="735"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="715" x2="2324" y2="715"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="695" x2="2324" y2="695"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="675" x2="2324" y2="675"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="655" x2="2324" y2="655"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="635" x2="2324" y2="635"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="615" x2="2324" y2="615"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="595" x2="2324" y2="595"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="575" x2="2324" y2="575"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="535" x2="2324" y2="535"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="515" x2="2324" y2="515"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="495" x2="2324" y2="495"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="475" x2="2324" y2="475"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="455" x2="2324" y2="455"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="435" x2="2324" y2="435"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="415" x2="2324" y2="415"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="395" x2="2324" y2="395"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="375" x2="2324" y2="375"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="336" x2="2324" y2="336"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="316" x2="2324" y2="316"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="296" x2="2324" y2="296"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="276" x2="2324" y2="276"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="256" x2="2324" y2="256"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="236" x2="2324" y2="236"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="216" x2="2324" y2="216"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="196" x2="2324" y2="196"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="176" x2="2324" y2="176"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="75" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="1153" x2="262" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="1153" x2="449" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="1153" x2="637" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="1153" x2="824" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="1153" x2="1012" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="1153" x2="1199" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="1153" x2="1386" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="1153" x2="1574" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="1153" x2="1761" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="1153" x2="1949" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="1153" x2="2136" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="1153" x2="2324" y2="167"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="1153" x2="2324" y2="1153"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="954" x2="2324" y2="954"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="754" x2="2324" y2="754"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="555" x2="2324" y2="555"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="355" x2="2324" y2="355"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,166 2324,166 "/>
+<text x="75" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,161 75,166 "/>
+<text x="262" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,161 262,166 "/>
+<text x="449" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,161 449,166 "/>
+<text x="637" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,161 637,166 "/>
+<text x="824" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,161 824,166 "/>
+<text x="1012" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,161 1012,166 "/>
+<text x="1199" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,161 1199,166 "/>
+<text x="1386" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,161 1386,166 "/>
+<text x="1574" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,161 1574,166 "/>
+<text x="1761" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,161 1761,166 "/>
+<text x="1949" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,161 1949,166 "/>
+<text x="2136" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,161 2136,166 "/>
+<text x="2324" y="157" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,161 2324,166 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,167 74,1153 "/>
+<text x="65" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1153 74,1153 "/>
+<text x="65" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,954 74,954 "/>
+<text x="65" y="754" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,754 74,754 "/>
+<text x="65" y="555" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,555 74,555 "/>
+<text x="65" y="355" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,355 74,355 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 2324,1154 "/>
+<text x="75" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1154 75,1159 "/>
+<text x="262" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,1154 262,1159 "/>
+<text x="449" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,1154 449,1159 "/>
+<text x="637" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,1154 637,1159 "/>
+<text x="824" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,1154 824,1159 "/>
+<text x="1012" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,1154 1012,1159 "/>
+<text x="1199" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,1154 1199,1159 "/>
+<text x="1386" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,1154 1386,1159 "/>
+<text x="1574" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,1154 1574,1159 "/>
+<text x="1761" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,1154 1761,1159 "/>
+<text x="1949" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,1154 1949,1159 "/>
+<text x="2136" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,1154 2136,1159 "/>
+<text x="2324" y="1164" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,1154 2324,1159 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,167 2325,1153 "/>
+<text x="2382" y="1153" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1153 2330,1153 "/>
+<text x="2382" y="954" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,954 2330,954 "/>
+<text x="2335" y="754" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,754 2330,754 "/>
+<text x="2335" y="555" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+15B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,555 2330,555 "/>
+<text x="2335" y="355" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20B
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,355 2330,355 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="75,902 79,893 84,884 88,876 93,867 97,859 102,851 106,843 111,835 115,827 120,819 124,812 129,804 133,797 138,789 142,782 147,775 151,768 156,762 160,755 165,748 169,742 174,735 178,729 183,723 187,717 192,710 196,705 201,699 205,693 210,687 214,682 219,676 223,671 228,665 232,660 237,655 241,650 246,645 250,640 255,635 259,630 264,625 268,621 273,616 277,611 282,607 286,603 291,598 295,594 300,590 304,586 309,582 313,578 318,574 322,570 327,566 331,562 336,558 340,555 345,551 349,548 354,544 358,541 363,537 367,534 372,531 376,527 381,524 385,521 390,518 394,515 399,512 403,509 408,506 412,503 417,500 421,497 426,495 430,492 435,489 439,487 444,484 448,482 453,479 457,477 462,474 466,472 471,469 475,467 480,465 484,463 489,460 493,458 498,456 502,454 506,452 511,450 515,448 520,446 524,444 529,442 533,440 538,438 542,436 547,434 551,433 556,431 560,429 565,427 569,426 574,424 578,422 583,421 587,419 592,418 596,416 601,415 605,413 610,412 614,410 619,409 623,407 628,406 632,405 637,403 641,402 646,401 650,399 655,398 659,397 664,396 668,394 673,393 677,392 682,391 686,390 691,389 695,387 700,386 704,385 709,384 713,383 718,382 722,381 727,380 731,379 736,378 740,377 745,376 749,375 754,375 758,374 763,373 767,372 772,371 776,370 781,369 785,369 790,368 794,367 799,366 803,365 808,365 812,364 817,363 821,362 826,362 830,361 835,360 839,360 844,359 848,358 853,358 857,357 862,356 866,356 871,355 875,355 880,354 884,353 889,353 893,352 898,352 902,351 907,351 911,350 916,350 920,349 925,348 929,348 934,347 938,347 943,346 947,346 952,345 956,345 961,344 965,344 970,343 974,343 979,342 983,342 988,341 992,341 997,340 1001,340 1006,339 1010,338 1015,338 1019,337 1024,337 1028,336 1033,336 1037,335 1042,335 1046,334 1051,334 1055,333 1060,333 1064,332 1069,332 1073,331 1078,330 1082,330 1087,329 1091,329 1096,328 1100,328 1105,327 1109,327 1114,326 1118,326 1123,325 1127,325 1132,324 1136,323 1141,323 1145,322 1150,322 1154,321 1159,321 1163,320 1168,320 1172,319 1177,319 1181,318 1186,317 1190,317 1195,316 1199,316 1204,315 1208,315 1213,314 1217,314 1222,313 1226,313 1231,312 1235,311 1240,311 1244,310 1249,310 1253,309 1258,309 1262,308 1267,308 1271,307 1276,306 1280,306 1285,305 1289,305 1294,304 1298,304 1303,303 1307,303 1312,302 1316,302 1321,301 1325,300 1330,300 1334,299 1339,299 1343,298 1348,298 1352,297 1357,296 1361,296 1366,295 1370,295 1375,294 1379,294 1384,293 1388,293 1393,292 1397,291 1402,291 1406,290 1411,290 1415,289 1420,289 1424,288 1429,287 1433,287 1438,286 1442,286 1447,285 1451,285 1456,284 1460,284 1465,283 1469,282 1474,282 1478,281 1483,281 1487,280 1492,280 1496,279 1501,278 1505,278 1510,277 1514,277 1519,276 1523,276 1528,275 1532,274 1537,274 1541,273 1546,273 1550,272 1555,272 1559,271 1564,270 1568,270 1573,269 1577,269 1582,268 1586,268 1591,267 1595,266 1600,266 1604,265 1609,265 1613,264 1618,263 1622,263 1626,262 1631,262 1635,261 1640,261 1644,260 1649,259 1653,259 1658,258 1662,258 1667,257 1671,256 1676,256 1680,255 1685,255 1689,254 1694,254 1698,253 1703,252 1707,252 1712,251 1716,251 1721,250 1725,249 1730,249 1734,248 1739,248 1743,247 1748,246 1752,246 1757,245 1761,245 1766,244 1770,243 1775,243 1779,242 1784,242 1788,241 1793,241 1797,240 1802,239 1806,239 1811,238 1815,238 1820,237 1824,236 1829,236 1833,235 1838,235 1842,234 1847,233 1851,233 1856,232 1860,232 1865,231 1869,230 1874,230 1878,229 1883,229 1887,228 1892,227 1896,227 1901,226 1905,226 1910,225 1914,224 1919,224 1923,223 1928,222 1932,222 1937,221 1941,221 1946,220 1950,219 1955,219 1959,218 1964,218 1968,217 1973,216 1977,216 1982,215 1986,215 1991,214 1995,213 2000,213 2004,212 2009,211 2013,211 2018,210 2022,210 2027,209 2031,208 2036,208 2040,207 2045,207 2049,206 2054,205 2058,205 2063,204 2067,203 2072,203 2076,202 2081,202 2085,201 2090,200 2094,200 2099,199 2103,198 2108,198 2112,197 2117,197 2121,196 2126,195 2130,195 2135,194 2139,194 2144,193 2148,192 2153,192 2157,191 2162,190 2166,190 2171,189 2175,188 2180,188 2184,187 2189,187 2193,186 2198,185 2202,185 2207,184 2211,183 2216,183 2220,182 2225,182 2229,181 2234,180 2238,180 2243,179 2247,178 2252,178 2256,177 2261,176 2265,176 2270,175 2274,175 2279,174 2283,173 2288,173 2292,172 2297,171 2301,171 2306,170 2310,169 2315,169 2319,168 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="75,902 79,893 84,885 88,876 93,868 97,860 102,852 106,844 111,837 115,829 120,822 124,814 129,807 133,800 138,793 142,786 147,779 151,773 156,766 160,759 165,753 169,747 174,741 178,734 183,729 187,723 192,717 196,711 201,706 205,700 210,694 214,689 219,684 223,679 228,673 232,669 237,664 241,659 246,654 250,649 255,645 259,640 264,635 268,631 273,627 277,622 282,618 286,614 291,610 295,606 300,602 304,598 309,594 313,590 318,587 322,583 327,579 331,576 336,573 340,569 345,566 349,562 354,559 358,556 363,553 367,550 372,547 376,543 381,541 385,538 390,535 394,532 399,529 403,527 408,524 412,521 417,519 421,516 426,514 430,511 435,509 439,506 444,504 448,502 453,500 457,497 462,495 466,493 471,491 475,489 480,486 484,485 489,483 493,481 498,479 502,477 506,475 511,473 515,471 520,470 524,468 529,466 533,464 538,463 542,461 547,460 551,458 556,457 560,455 565,453 569,452 574,451 578,449 583,448 587,447 592,445 596,444 601,443 605,442 610,440 614,439 619,438 623,437 628,435 632,434 637,433 641,432 646,431 650,430 655,429 659,428 664,427 668,426 673,425 677,424 682,423 686,422 691,422 695,421 700,420 704,419 709,418 713,417 718,416 722,416 727,415 731,414 736,414 740,413 745,412 749,411 754,411 758,410 763,409 767,409 772,408 776,408 781,407 785,406 790,406 794,405 799,405 803,404 808,404 812,403 817,403 821,402 826,402 830,401 835,401 839,401 844,400 848,400 853,399 857,399 862,399 866,398 871,398 875,397 880,397 884,397 889,396 893,396 898,396 902,395 907,395 911,395 916,394 920,394 925,394 929,394 934,393 938,393 943,393 947,392 952,392 956,392 961,392 965,391 970,391 974,391 979,391 983,390 988,390 992,390 997,389 1001,389 1006,389 1010,389 1015,388 1019,388 1024,388 1028,387 1033,387 1037,387 1042,386 1046,386 1051,386 1055,385 1060,385 1064,385 1069,384 1073,384 1078,384 1082,384 1087,383 1091,383 1096,383 1100,382 1105,382 1109,382 1114,382 1118,381 1123,381 1127,381 1132,380 1136,380 1141,380 1145,380 1150,379 1154,379 1159,379 1163,378 1168,378 1172,378 1177,377 1181,377 1186,377 1190,376 1195,376 1199,376 1204,375 1208,375 1213,375 1217,375 1222,374 1226,374 1231,374 1235,373 1240,373 1244,373 1249,373 1253,372 1258,372 1262,372 1267,371 1271,371 1276,371 1280,370 1285,370 1289,369 1294,369 1298,369 1303,369 1307,368 1312,368 1316,368 1321,367 1325,367 1330,367 1334,367 1339,366 1343,366 1348,366 1352,365 1357,365 1361,365 1366,364 1370,364 1375,363 1379,363 1384,363 1388,363 1393,362 1397,362 1402,362 1406,361 1411,361 1415,361 1420,360 1424,360 1429,360 1433,360 1438,359 1442,359 1447,358 1451,358 1456,358 1460,357 1465,357 1469,357 1474,356 1478,356 1483,356 1487,355 1492,355 1496,355 1501,355 1505,354 1510,354 1514,354 1519,353 1523,353 1528,352 1532,352 1537,352 1541,351 1546,351 1550,351 1555,350 1559,350 1564,350 1568,350 1573,349 1577,349 1582,349 1586,348 1591,348 1595,347 1600,347 1604,347 1609,346 1613,346 1618,346 1622,345 1626,345 1631,345 1635,344 1640,344 1644,344 1649,343 1653,343 1658,343 1662,342 1667,342 1671,342 1676,341 1680,341 1685,341 1689,340 1694,340 1698,340 1703,339 1707,339 1712,338 1716,338 1721,338 1725,337 1730,337 1734,337 1739,336 1743,336 1748,336 1752,335 1757,335 1761,334 1766,334 1770,334 1775,334 1779,333 1784,333 1788,333 1793,332 1797,332 1802,332 1806,331 1811,331 1815,331 1820,330 1824,330 1829,330 1833,329 1838,329 1842,329 1847,328 1851,328 1856,328 1860,328 1865,327 1869,327 1874,327 1878,326 1883,326 1887,326 1892,326 1896,325 1901,325 1905,325 1910,324 1914,324 1919,324 1923,324 1928,323 1932,323 1937,323 1941,323 1946,323 1950,322 1955,322 1959,322 1964,322 1968,321 1973,321 1977,321 1982,321 1986,321 1991,320 1995,320 2000,320 2004,320 2009,320 2013,319 2018,319 2022,319 2027,319 2031,319 2036,319 2040,319 2045,318 2049,318 2054,318 2058,318 2063,318 2067,318 2072,318 2076,317 2081,317 2085,317 2090,317 2094,317 2099,317 2103,317 2108,317 2112,316 2117,316 2121,316 2126,316 2130,316 2135,316 2139,316 2144,316 2148,316 2153,316 2157,316 2162,315 2166,315 2171,315 2175,315 2180,315 2184,315 2189,315 2193,315 2198,315 2202,315 2207,315 2211,315 2216,315 2220,315 2225,315 2229,314 2234,314 2238,314 2243,314 2247,314 2252,314 2256,314 2261,314 2265,314 2270,314 2274,314 2279,314 2283,314 2288,314 2292,314 2297,314 2301,314 2306,314 2310,314 2315,313 2319,313 "/>
+<rect x="2053" y="619" width="267" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2093" y="629" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Total supply
+</text>
+<text x="2093" y="667" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Circulating supply
+</text>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="3" points="2063,641 2083,641 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="3" points="2063,679 2083,679 "/>
+<text x="1200" y="1249" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+kp = 300, ki = -350, kd = 100, min = 5%, max = 50%
+</text>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="93" y1="2324" x2="93" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="112" y1="2324" x2="112" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="131" y1="2324" x2="131" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="149" y1="2324" x2="149" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="168" y1="2324" x2="168" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="187" y1="2324" x2="187" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="206" y1="2324" x2="206" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="224" y1="2324" x2="224" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="243" y1="2324" x2="243" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="281" y1="2324" x2="281" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="299" y1="2324" x2="299" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="318" y1="2324" x2="318" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="337" y1="2324" x2="337" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="356" y1="2324" x2="356" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="374" y1="2324" x2="374" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="393" y1="2324" x2="393" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="412" y1="2324" x2="412" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="431" y1="2324" x2="431" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="468" y1="2324" x2="468" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="487" y1="2324" x2="487" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="506" y1="2324" x2="506" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="524" y1="2324" x2="524" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="543" y1="2324" x2="543" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="562" y1="2324" x2="562" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="581" y1="2324" x2="581" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="599" y1="2324" x2="599" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="618" y1="2324" x2="618" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="655" y1="2324" x2="655" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="674" y1="2324" x2="674" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="693" y1="2324" x2="693" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="712" y1="2324" x2="712" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="730" y1="2324" x2="730" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="749" y1="2324" x2="749" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="768" y1="2324" x2="768" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="787" y1="2324" x2="787" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="805" y1="2324" x2="805" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="843" y1="2324" x2="843" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="862" y1="2324" x2="862" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="880" y1="2324" x2="880" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="899" y1="2324" x2="899" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="918" y1="2324" x2="918" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="937" y1="2324" x2="937" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="955" y1="2324" x2="955" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="974" y1="2324" x2="974" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="993" y1="2324" x2="993" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1030" y1="2324" x2="1030" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1049" y1="2324" x2="1049" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1068" y1="2324" x2="1068" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1087" y1="2324" x2="1087" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1105" y1="2324" x2="1105" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1124" y1="2324" x2="1124" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1143" y1="2324" x2="1143" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1162" y1="2324" x2="1162" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1180" y1="2324" x2="1180" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1218" y1="2324" x2="1218" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1236" y1="2324" x2="1236" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1255" y1="2324" x2="1255" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1274" y1="2324" x2="1274" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1293" y1="2324" x2="1293" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1311" y1="2324" x2="1311" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1330" y1="2324" x2="1330" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1349" y1="2324" x2="1349" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1368" y1="2324" x2="1368" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1405" y1="2324" x2="1405" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1424" y1="2324" x2="1424" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1443" y1="2324" x2="1443" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1461" y1="2324" x2="1461" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1480" y1="2324" x2="1480" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1499" y1="2324" x2="1499" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1518" y1="2324" x2="1518" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1536" y1="2324" x2="1536" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1555" y1="2324" x2="1555" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1593" y1="2324" x2="1593" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1611" y1="2324" x2="1611" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1630" y1="2324" x2="1630" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1649" y1="2324" x2="1649" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1668" y1="2324" x2="1668" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1686" y1="2324" x2="1686" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1705" y1="2324" x2="1705" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1724" y1="2324" x2="1724" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1743" y1="2324" x2="1743" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1780" y1="2324" x2="1780" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1799" y1="2324" x2="1799" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1817" y1="2324" x2="1817" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1836" y1="2324" x2="1836" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1855" y1="2324" x2="1855" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1874" y1="2324" x2="1874" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1892" y1="2324" x2="1892" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1911" y1="2324" x2="1911" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1930" y1="2324" x2="1930" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1967" y1="2324" x2="1967" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="1986" y1="2324" x2="1986" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2005" y1="2324" x2="2005" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2024" y1="2324" x2="2024" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2042" y1="2324" x2="2042" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2061" y1="2324" x2="2061" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2080" y1="2324" x2="2080" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2099" y1="2324" x2="2099" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2117" y1="2324" x2="2117" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2155" y1="2324" x2="2155" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2174" y1="2324" x2="2174" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2192" y1="2324" x2="2192" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2211" y1="2324" x2="2211" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2230" y1="2324" x2="2230" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2249" y1="2324" x2="2249" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2267" y1="2324" x2="2267" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2286" y1="2324" x2="2286" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2305" y1="2324" x2="2305" y2="1338"/>
+<line opacity="0.1" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="75" y1="2324" x2="75" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="262" y1="2324" x2="262" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="449" y1="2324" x2="449" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="637" y1="2324" x2="637" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="824" y1="2324" x2="824" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1012" y1="2324" x2="1012" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1199" y1="2324" x2="1199" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1386" y1="2324" x2="1386" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1574" y1="2324" x2="1574" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1761" y1="2324" x2="1761" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="1949" y1="2324" x2="1949" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2136" y1="2324" x2="2136" y2="1338"/>
+<line opacity="0.2" stroke="#000000" stroke-width="1" x1="2324" y1="2324" x2="2324" y2="1338"/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,1338 74,2324 "/>
+<text x="65" y="2324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2324 74,2324 "/>
+<text x="65" y="2226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+1M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2226 74,2226 "/>
+<text x="65" y="2127" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2127 74,2127 "/>
+<text x="65" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+3M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,2029 74,2029 "/>
+<text x="65" y="1930" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1930 74,1930 "/>
+<text x="65" y="1831" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1831 74,1831 "/>
+<text x="65" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1733 74,1733 "/>
+<text x="65" y="1634" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+7M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1634 74,1634 "/>
+<text x="65" y="1535" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1535 74,1535 "/>
+<text x="65" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+9M
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="69,1437 74,1437 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 2324,2325 "/>
+<text x="75" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0y0m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,2325 75,2330 "/>
+<text x="262" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2y9m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="262,2325 262,2330 "/>
+<text x="449" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+5y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="449,2325 449,2330 "/>
+<text x="637" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="637,2325 637,2330 "/>
+<text x="824" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="824,2325 824,2330 "/>
+<text x="1012" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+13y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1012,2325 1012,2330 "/>
+<text x="1199" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+16y5m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1199,2325 1199,2330 "/>
+<text x="1386" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+19y2m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1386,2325 1386,2330 "/>
+<text x="1574" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+21y11m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1574,2325 1574,2330 "/>
+<text x="1761" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+24y8m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1761,2325 1761,2330 "/>
+<text x="1949" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+27y4m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1949,2325 1949,2330 "/>
+<text x="2136" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30y1m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2136,2325 2136,2330 "/>
+<text x="2324" y="2335" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+32y10m
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2324,2325 2324,2330 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1337 2325,1337 "/>
+<text x="75" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="75,1332 75,1337 "/>
+<text x="450" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+2000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="450,1332 450,1337 "/>
+<text x="825" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+4000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="825,1332 825,1337 "/>
+<text x="1200" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+6000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1200,1332 1200,1337 "/>
+<text x="1575" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+8000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1575,1332 1575,1337 "/>
+<text x="1950" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="1950,1332 1950,1337 "/>
+<text x="2325" y="1328" dy="-0.5ex" text-anchor="middle" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+12000
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1332 2325,1337 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2325,2325 "/>
+<text x="2404" y="2325" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+0%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2325 2330,2325 "/>
+<text x="2404" y="2227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+10%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2227 2330,2227 "/>
+<text x="2404" y="2128" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+20%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2128 2330,2128 "/>
+<text x="2404" y="2029" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+30%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,2029 2330,2029 "/>
+<text x="2404" y="1931" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+40%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1931 2330,1931 "/>
+<text x="2404" y="1832" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+50%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1832 2330,1832 "/>
+<text x="2404" y="1733" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+60%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1733 2330,1733 "/>
+<text x="2404" y="1635" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+70%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1635 2330,1635 "/>
+<text x="2404" y="1536" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+80%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1536 2330,1536 "/>
+<text x="2404" y="1437" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+90%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1437 2330,1437 "/>
+<text x="2335" y="1338" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+100%
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="2325,1338 2330,1338 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="75,1797 79,1346 84,1967 88,2289 93,1600 97,1423 102,2148 106,2174 111,1443 115,1570 120,2275 124,2000 129,1353 133,1763 138,2324 142,1797 147,1346 151,1967 156,2289 160,1600 165,1423 169,2148 174,2174 178,1443 183,1570 187,2275 192,2000 196,1353 201,1763 205,2324 210,1797 214,1346 219,1967 223,2289 228,1600 232,1423 237,2148 241,2174 246,1443 250,1570 255,2275 259,2000 264,1353 268,1763 273,2324 277,1797 282,1346 286,1967 291,2289 295,1600 300,1423 304,2148 309,2174 313,1443 318,1570 322,2275 327,2000 331,1353 336,1763 340,2324 345,1797 349,1346 354,1967 358,2289 363,1600 367,1423 372,2148 376,2174 381,1443 385,1570 390,2275 394,2000 399,1353 403,1763 408,2324 412,1797 417,1346 421,1967 426,2289 430,1600 435,1423 439,2148 444,2174 448,1443 453,1570 457,2275 462,2000 466,1353 471,1763 475,2324 480,1797 484,1346 489,1967 493,2289 498,1600 502,1423 506,2148 511,2174 515,1443 520,1570 524,2275 529,2000 533,1353 538,1763 542,2324 547,1797 551,1346 556,1967 560,2289 565,1600 569,1423 574,2148 578,2174 583,1443 587,1570 592,2275 596,2000 601,1353 605,1763 610,2324 614,1797 619,1346 623,1967 628,2289 632,1600 637,1423 641,2148 646,2174 650,1443 655,1570 659,2275 664,2000 668,1353 673,1763 677,2324 682,1797 686,1346 691,1967 695,2289 700,1600 704,1423 709,2148 713,2174 718,1443 722,1570 727,2275 731,2000 736,1353 740,1763 745,2324 749,1797 754,1346 758,1967 763,2289 767,1600 772,1423 776,2148 781,2174 785,1443 790,1570 794,2275 799,2000 803,1353 808,1763 812,2324 817,1797 821,1346 826,1967 830,2289 835,1600 839,1423 844,2148 848,2174 853,1443 857,1570 862,2275 866,2000 871,1353 875,1763 880,2324 884,1797 889,1346 893,1967 898,2289 902,1600 907,1423 911,2148 916,2174 920,1443 925,1570 929,2275 934,2000 938,1353 943,1763 947,2324 952,1797 956,1346 961,1967 965,2289 970,1600 974,1423 979,2148 983,2174 988,1443 992,1570 997,2275 1001,2000 1006,1353 1010,1763 1015,2324 1019,1797 1024,1346 1028,1967 1033,2289 1037,1600 1042,1423 1046,2148 1051,2174 1055,1443 1060,1570 1064,2275 1069,2000 1073,1353 1078,1763 1082,2324 1087,1797 1091,1346 1096,1967 1100,2289 1105,1600 1109,1423 1114,2148 1118,2174 1123,1443 1127,1570 1132,2275 1136,2000 1141,1353 1145,1763 1150,2324 1154,1797 1159,1346 1163,1967 1168,2289 1172,1600 1177,1423 1181,2148 1186,2174 1190,1443 1195,1570 1199,2275 1204,2000 1208,1353 1213,1763 1217,2324 1222,1797 1226,1346 1231,1967 1235,2289 1240,1600 1244,1423 1249,2148 1253,2174 1258,1443 1262,1570 1267,2275 1271,2000 1276,1353 1280,1763 1285,2324 1289,1797 1294,1346 1298,1967 1303,2289 1307,1600 1312,1423 1316,2148 1321,2174 1325,1443 1330,1570 1334,2275 1339,2000 1343,1353 1348,1763 1352,2324 1357,1797 1361,1346 1366,1967 1370,2289 1375,1600 1379,1423 1384,2148 1388,2174 1393,1443 1397,1570 1402,2275 1406,2000 1411,1353 1415,1763 1420,2324 1424,1797 1429,1346 1433,1967 1438,2289 1442,1600 1447,1423 1451,2148 1456,2174 1460,1443 1465,1570 1469,2275 1474,2000 1478,1353 1483,1763 1487,2324 1492,1797 1496,1346 1501,1967 1505,2289 1510,1600 1514,1423 1519,2148 1523,2174 1528,1443 1532,1570 1537,2275 1541,2000 1546,1353 1550,1763 1555,2324 1559,1797 1564,1346 1568,1967 1573,2289 1577,1600 1582,1423 1586,2148 1591,2174 1595,1443 1600,1570 1604,2275 1609,2000 1613,1353 1618,1763 1622,2324 1626,1797 1631,1346 1635,1967 1640,2289 1644,1600 1649,1423 1653,2148 1658,2174 1662,1443 1667,1570 1671,2275 1676,2000 1680,1353 1685,1763 1689,2324 1694,1797 1698,1346 1703,1967 1707,2289 1712,1600 1716,1423 1721,2148 1725,2174 1730,1443 1734,1570 1739,2275 1743,2000 1748,1353 1752,1763 1757,2324 1761,1797 1766,1346 1770,1967 1775,2289 1779,1600 1784,1423 1788,2148 1793,2174 1797,1443 1802,1570 1806,2275 1811,2000 1815,1353 1820,1763 1824,2324 1829,1797 1833,1346 1838,1967 1842,2289 1847,1600 1851,1423 1856,2148 1860,2174 1865,1443 1869,1570 1874,2275 1878,2000 1883,1353 1887,1763 1892,2324 1896,1797 1901,1346 1905,1967 1910,2289 1914,1600 1919,1423 1923,2148 1928,2174 1932,1443 1937,1570 1941,2275 1946,2000 1950,1353 1955,1763 1959,2324 1964,1797 1968,1346 1973,1967 1977,2289 1982,1600 1986,1423 1991,2148 1995,2174 2000,1443 2004,1570 2009,2275 2013,2000 2018,1353 2022,1763 2027,2324 2031,1797 2036,1346 2040,1967 2045,2289 2049,1600 2054,1423 2058,2148 2063,2174 2067,1443 2072,1570 2076,2275 2081,2000 2085,1353 2090,1763 2094,2324 2099,1797 2103,1346 2108,1967 2112,2289 2117,1600 2121,1423 2126,2148 2130,2174 2135,1443 2139,1570 2144,2275 2148,2000 2153,1353 2157,1763 2162,2324 2166,1797 2171,1346 2175,1967 2180,2289 2184,1600 2189,1423 2193,2148 2198,2174 2202,1443 2207,1570 2211,2275 2216,2000 2220,1353 2225,1763 2229,2324 2234,1797 2238,1346 2243,1967 2247,2289 2252,1600 2256,1423 2261,2148 2265,2174 2270,1443 2274,1570 2279,2275 2283,2000 2288,1353 2292,1763 2297,2324 2301,1797 2306,1346 2310,1967 2315,2289 2319,1600 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="75,2276 79,2276 84,2276 88,2276 93,2276 97,2276 102,2276 106,2276 111,2276 115,2276 120,2276 124,2276 129,2276 133,2276 138,2276 142,2276 147,2276 151,2276 156,2276 160,2276 165,2276 169,2276 174,2276 178,2276 183,2276 187,2276 192,2276 196,2276 201,2276 205,2276 210,2276 214,2276 219,2276 223,2276 228,2276 232,2276 237,2276 241,2276 246,2276 250,2276 255,2276 259,2276 264,2276 268,2276 273,2276 277,2276 282,2276 286,2276 291,2276 295,2276 300,2276 304,2276 309,2276 313,2276 318,2276 322,2276 327,2276 331,2276 336,2276 340,2276 345,2276 349,2276 354,2276 358,2276 363,2276 367,2276 372,2276 376,2276 381,2276 385,2276 390,2276 394,2276 399,2276 403,2276 408,2276 412,2276 417,2276 421,2276 426,2276 430,2276 435,2276 439,2276 444,2276 448,2276 453,2276 457,2276 462,2276 466,2276 471,2276 475,2276 480,2276 484,2276 489,2276 493,2276 498,2276 502,2276 507,2276 511,2276 516,2276 520,2276 525,2276 529,2276 534,2276 538,2276 543,2276 547,2276 552,2276 556,2276 561,2276 565,2276 570,2276 574,2276 579,2276 583,2276 588,2276 592,2276 597,2276 601,2276 606,2276 610,2276 615,2276 619,2276 624,2276 628,2276 633,2276 637,2276 642,2276 646,2276 651,2276 655,2276 660,2276 664,2276 669,2276 673,2276 678,2276 682,2276 687,2276 691,2276 696,2276 700,2276 705,2276 709,2276 714,2276 718,2276 723,2276 727,2276 732,2276 736,2276 741,2276 745,2276 750,2276 754,2276 759,2276 763,2276 768,2276 772,2276 777,2276 781,2276 786,2276 790,2276 795,2276 799,2276 804,2276 808,2276 813,2276 817,2276 822,2276 826,2276 831,2276 835,2276 840,2276 844,2276 849,2276 853,2276 858,2276 862,2276 867,2276 871,2276 876,2276 880,2276 885,2276 889,2276 894,2276 898,2276 903,2276 907,2276 912,2276 916,2276 921,2276 925,2276 930,2276 934,2276 939,2276 943,2276 948,2276 952,2276 957,2276 961,2276 966,2276 970,2276 975,2276 979,2276 984,2276 988,2276 993,2276 997,2276 1002,2276 1006,2276 1011,2276 1015,2276 1020,2276 1024,2276 1029,2276 1033,2276 1038,2276 1042,2276 1047,2276 1051,2276 1056,2276 1060,2276 1065,2276 1069,2276 1074,2276 1078,2276 1083,2276 1087,2276 1092,2276 1096,2276 1101,2276 1105,2276 1110,2276 1114,2276 1119,2276 1123,2276 1128,2276 1132,2276 1137,2276 1141,2276 1146,2276 1150,2276 1155,2276 1159,2276 1164,2276 1168,2276 1173,2276 1177,2276 1182,2276 1186,2276 1191,2276 1195,2276 1200,2276 1204,2276 1209,2276 1213,2276 1218,2276 1222,2276 1227,2276 1231,2276 1236,2276 1240,2276 1245,2276 1249,2276 1254,2276 1258,2276 1263,2276 1267,2276 1272,2276 1276,2276 1281,2276 1285,2276 1290,2276 1294,2276 1299,2276 1303,2276 1308,2276 1312,2276 1317,2276 1321,2276 1326,2276 1330,2276 1335,2276 1339,2276 1344,2276 1348,2276 1353,2276 1357,2276 1362,2276 1366,2276 1371,2276 1375,2276 1380,2276 1384,2276 1389,2276 1393,2276 1398,2276 1402,2276 1407,2276 1411,2276 1416,2276 1420,2276 1425,2276 1429,2276 1434,2276 1438,2276 1443,2276 1447,2276 1452,2276 1456,2276 1461,2276 1465,2276 1470,2276 1474,2276 1479,2276 1483,2276 1488,2276 1492,2276 1497,2276 1501,2276 1506,2276 1510,2276 1515,2276 1519,2276 1524,2276 1528,2276 1533,2276 1537,2276 1542,2276 1546,2276 1551,2276 1555,2276 1560,2276 1564,2276 1569,2276 1573,2276 1578,2276 1582,2276 1587,2276 1591,2276 1596,2276 1600,2276 1605,2276 1609,2276 1614,2276 1618,2276 1623,2276 1627,2276 1632,2276 1636,2276 1641,2276 1645,2276 1650,2276 1654,2276 1659,2276 1663,2276 1668,2276 1672,2276 1677,2276 1681,2276 1686,2276 1690,2276 1695,2276 1699,2276 1704,2276 1708,2276 1713,2276 1717,2276 1722,2276 1726,2276 1731,2276 1735,2276 1740,2276 1744,2276 1749,2276 1753,2276 1758,2192 1762,2276 1767,2276 1771,2276 1776,2015 1780,2276 1785,2276 1789,2265 1794,2180 1798,2276 1803,2276 1807,2142 1812,2272 1816,2276 1821,2276 1825,1832 1830,2276 1834,2276 1839,2263 1843,1832 1848,2276 1852,2276 1857,2193 1861,2073 1866,2276 1870,2276 1875,1987 1879,2231 1884,2276 1888,2267 1893,1832 1897,2263 1902,2276 1906,2227 1911,1832 1915,2276 1920,2276 1924,2128 1929,1991 1933,2276 1938,2273 1942,1857 1947,2194 1951,2276 1956,2245 1960,1832 1965,2242 1969,2276 1974,2196 1978,1832 1983,2262 1987,2272 1992,2075 1996,1932 2001,2273 2005,2276 2010,1832 2014,2165 2019,2263 2023,2216 2028,1832 2032,2226 2037,2276 2041,2173 2046,1832 2050,2251 2055,2243 2059,2036 2064,1894 2068,2264 2073,2276 2077,1832 2082,2143 2086,2243 2091,2199 2095,1832 2100,2214 2104,2240 2109,2156 2113,1832 2118,2243 2122,2276 2127,2007 2131,1868 2136,2257 2140,2276 2145,1832 2149,2128 2154,2276 2158,2233 2163,1832 2167,2206 2172,2227 2176,2144 2181,1832 2185,2238 2190,2276 2194,1987 2199,1856 2203,2253 2208,2276 2212,1832 2217,2118 2221,2244 2226,2176 2230,1832 2235,2199 2239,2216 2244,2135 2248,1832 2253,2233 2257,2276 2262,1971 2266,1846 2271,2246 2275,2180 2280,1832 2284,2109 2289,2276 2293,2226 2298,1832 2302,2195 2307,2276 2311,2127 2316,1832 2320,2229 "/>
+<rect x="2151" y="1790" width="169" height="82" opacity="1" fill="none" stroke="#000000"/>
+<text x="2191" y="1800" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Fees
+</text>
+<text x="2191" y="1838" dy="0.76em" text-anchor="start" font-family="sans-serif" font-size="24.193548387096776" opacity="1" fill="#000000">
+Burn Rate
+</text>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="3" points="2161,1812 2181,1812 "/>
+<polyline fill="none" opacity="1" stroke="#9C27B0" stroke-width="3" points="2161,1850 2181,1850 "/>
+</svg>


### PR DESCRIPTION
TariThrottle is a simple process controller designed to modulate the layer two burn rate in order to achieve two 
goals:

* Primarily, keep the emission and burn rate roughly balanced (ensuring long-term sustainability of Tari), and
* Secondarily, to maintain the total circulating supply at a target value (satisfying an implicit assumption in 
  cryptocurrencies that token supplies are finite).

A proof-of-concept controller has been implemented and tested in a simulation environment ([repo]). As the results 
below attest, the controller logic is sufficient to achieve these goals, even under highly volatile layer two fee 
conditions. 

However, the controller achieves the goals at the expense of a rapidly changing layer two burn rate, which may be 
detrimental to the sustainability of validator nodes. 

At the risk of the tail wagging the dog, the primary conclusion of this study is that the TariThrottle controller 
should likely _not_ aim to maintain a supply target, but instead to ensure a sustainable layer two ecosystem, to 
whit:

* maintain a constant demand gradient so that under normal circumstances there is _always_ a demand for new Tari and 
  thus Minotari are constantly being burnt to satisfy this demand,
* marginal Validator Nodes are able to operate at or near break-even rates, while maintaining a healthy reserve of 
  capacity for surge demand, and 
* the supply of Minotari is sustainable over the long-term.

Therefore, the conclusion of this study is not to abandon the original targets of the TariThrottle completely, 
but to adjust the priority of the primary goal (a sustainable long-term balance), and make it subservient to the 
primary goal of ensuring a constant demand gradient.

A modified Tari throttle model that seeks to achieve these aims is outside of the scope of this RFC and is left for 
a follow-up study.