### PR TITLE
fix: remove dotenv

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-require('dotenv').config({ path: './mdbook.env'});
 const axios = require('axios');
 const fs = require('fs');
 const fsp = fs.promises;
@@ -8,7 +7,7 @@ const { exec } = require('child_process');
 const tar = require('tar');
 
 const VERSION = process.env.MDBOOK_VERSION || '0.4.37'; // replace with the version you want
-const MDBOOK_HASH = process.env.MDBOOK_HASH;
+const MDBOOK_HASH = process.env.MDBOOK_HASH || "93f9a98032be3f4b7b4bab42fdc97d58b5d69d81eef910a5c8fa68e03fbf8a8d";
 const url = `https://github.com/rust-lang/mdBook/releases/download/v${VERSION}/mdbook-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz`;
 
 async function downloadFile(url, path) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "axios": "=1.6.7",
-        "dotenv": "^16.4.5",
         "tar": "=6.2.0"
       }
     },
@@ -54,17 +53,6 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/follow-redirects": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "axios": "=1.6.7",
-    "dotenv": "=16.4.5",
     "tar": "=6.2.0"
   }
 }


### PR DESCRIPTION
dotenv was used for testing of the `build.js` script and is not needed anymore.

Removing it for security reasons. 

There weren't any major concerns but some fat-finger errors may have led to deployment problems. The envars are set in the build environments (e.g. cloudflare) or have sane fallback defaults.


