### PR TITLE
chore: remove unintentional double negative

### DIFF
--- a/src/RFC-0201_TariScript.md
+++ b/src/RFC-0201_TariScript.md
@@ -91,7 +91,7 @@ minor) modifications and additions to the Mimblewimble protocol, which achieved 
 
 ## Scripting on Mimblewimble
 
-Other than Beam, none of the existing [Mimblewimble] projects have not employed a scripting language. 
+Other than Beam, none of the existing [Mimblewimble] projects have employed a scripting language. 
  
 [Grin](https://github.com/mimblewimble/grin) styles itself as a "Minimal implementation of the Mimblewimble protocol",
 so one might infer that this status is unlikely to change soon.


### PR DESCRIPTION
Description
---
This PR doesn't not remove an unintended double negative.

Motivation and Context
---
The presence of the double negative doesn't not change the description of scripting support across the ecosystem.

How Has This Been Tested?
---
The page renders not incorrectly, and doesn't not fail not to build.
