### PR TITLE
fix: updated merge/hybrid mining percentages to reflect 50/50 split

### DIFF
--- a/src/RFC-0001_overview.md
+++ b/src/RFC-0001_overview.md
@@ -142,8 +142,8 @@ invented to allow the DAN to be built on top of Tari, but have found some great 
 
 #### Proof of Work
 
-Tari is mined using a hybrid approach. On average, 60% of block rewards come from [Monero merge-mining],
- while 40% come from the [Sha3x][RFC-131] algorithm. Blocks are produced every 2 minutes, on average.  
+Tari is mined using a hybrid approach. On average, 50% of block rewards come from [Monero merge-mining],
+ while 50% come from the [Sha3x][RFC-131] algorithm. Blocks are produced every 2 minutes, on average.  
 
 ### The role of the base layer
 
@@ -209,4 +209,4 @@ strength.
 | 22 Jun 2021 | Remove payment channel layer proposal                | SimianZa |
 | 14 Jan 2022 | Update image. Expound on Base layer responsibilities | CjS77    |
 | 10 Nov 2022 | Update overview for Cerberus                         | CjS77    |
-
+| 09 Dec 2024 | Update percentage split for merge mining             | Solivagant |

--- a/src/RFC-0131_Mining.md
+++ b/src/RFC-0131_Mining.md
@@ -93,10 +93,6 @@ An excellent technical choice would be merge mining with Monero using RandomX as
 a low likelihood of unforeseen optimizations that will give a single miner a considerable advantage. It also means that it stands a 
 good chance of being "commoditized" when ASICs are eventually manufactured. This would mean that SHA3 ASICs are widely available from multiple suppliers.
 
-### The block distribution
-
-A 50/50 split in hash rate among algorithms minimises the chance of hash rate attacks. In Tari, a 50/50 split is employed in favour of merge mining RandomX with Monero and Tari with Sha-3x respectively.
-
 ### The difficulty adjustment strategy
 
 The choice of difficulty adjustment algorithm is important. In typical hybrid mining strategies, each algorithm operates

--- a/src/RFC-0131_Mining.md
+++ b/src/RFC-0131_Mining.md
@@ -95,16 +95,13 @@ good chance of being "commoditized" when ASICs are eventually manufactured. This
 
 ### The block distribution
 
-A 50/50 split in hash rate among algorithms minimises the chance of hash rate attacks. However,
-sufficient buy-in is required, especially with regard to merge mining RandomX with Monero. To make it worthwhile for a
-Monero pool operator to merge mine Tari, but still guard against hash rate attacks and to be inclusive of independent
-Tari supporters and enthusiasts, a 60/40 split is employed in favour of merge mining RandomX with Monero.
+A 50/50 split in hash rate among algorithms minimises the chance of hash rate attacks. In Tari, a 50/50 split is employed in favour of merge mining RandomX with Monero and Tari with Sha-3x respectively.
 
 ### The difficulty adjustment strategy
 
 The choice of difficulty adjustment algorithm is important. In typical hybrid mining strategies, each algorithm operates
 completely independently with a scaled target block time. 
-Tari testnet has been running very successfully using the  Linear Weighted Moving Average (LWMA) from Bitcoin & Zcash
+Tari testnet has been running very successfully using the Linear Weighted Moving Average (LWMA) from Bitcoin & Zcash
 Clones [version 2018-11-27](https://github.com/zawy12/difficulty-algorithms/issues/3#issuecomment-442129791). This LWMA
 difficulty adjustment algorithm has also been
 [tested in simulations](https://github.com/tari-labs/modelling/tree/master/scenarios/multi_pow_01), 

--- a/src/RFC-0131_Mining.md
+++ b/src/RFC-0131_Mining.md
@@ -199,3 +199,4 @@ This RFC is stable as of PR#4862
 | 2022-11-25 | Update mining hash decsription | CjS77      |
 | 2022-10-26 | Finalise SHA-3 algorithm       | CjS77      |
 | 2022-10-11 | First outline                  | SWvHeerden |
+| 2024-12-09 | Corrected percentages for merged and hybrid mining | Solivagant |


### PR DESCRIPTION
Description
---
Corrected references in RFC 001 and RFC-0131 to reflect accurate split in terms of merge mining and hybrid mining stated percentages.

Motivation and Context
---
RFCs were still referencing a 60/40 split, which is inaccurate. 
