### PR TITLE
docs: add Tari Improvement proposal structure

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,17 +1,18 @@
 # Disclaimer
 
-The purpose of the documents and content in this repository is for information purposes only and may be subject to 
-change or update without notice. 
+The purpose of the RFCs in this repository is for information purposes only and may be
+subject to change or update without notice.
  
 The documents in this repository are largely the result of community discussions held on #tari-dev on FreeNode IRC and 
 includes some preliminary concepts that are in the process of being developed by the Tari community.  The release of 
 these documents are intended solely for review and discussion by the blockchain and cryptocurrency communities 
 regarding the technological merits of the potential system outlined herein.
 
-Anyone in the community is 
-welcome to contribute ideas, suggestions or constructive criticism can join the discussion in #tari-dev on Freenode IRC, 
-submit a new [issue] or contribute with a [pull request].
+Anyone in the community is welcome to contribute ideas, suggestions or constructive criticism. You can join the
+discussion in #tari-dev on Freenode IRC, comment on the [community forums], submit a new [issue] or contribute with
+a [pull request].
 
 
 [issue]: https://github.com/tari-project/tari/issues
 [pull request]: https://github.com/tari-project/tari/pulls
+[community forums]: https://community.tari.com/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can build and serve the RFCs locally while working on them, and navigate the
 
 To do so:
 - Navigate to the repository directory in a terminal
-- Install the `mdbook` tool: `cargo install mdbook`
+- Install the `mdbook` and `mdbook-mermaid` tools: `cargo install mdbook@0.4.36 mdbook-mermaid@0.13.0`
 - Serve the site: `mdbook serve`
 - View the rendered versions in a browser using the link provided in your terminal: `http://localhost:3000`
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,6 +2,9 @@
 
 [About the Tari RFC documents](about.md)
 
+- [TIP-1: Tari Improvement Proposals](TIP-0001_tari_improvement_proposals.md)
+- [TIP-2: The Tari Community Charter](TIP-0002_tari_community_charter.md)
+- [TIP-3: Community Forums](TIP-0003_community_forums.md)
 - [RFC-0001: An overview of the Tari network](RFC-0001_overview.md)
 - [The Tari Base Layer](base_layer.md)
   - [RFC-0110: Base nodes](RFC-0110_BaseNodes.md)

--- a/src/TIP-0001_tari_improvement_proposals.md
+++ b/src/TIP-0001_tari_improvement_proposals.md
@@ -1,0 +1,3 @@
+# Tari Improvement Proposals
+
+This document is a stub for the upcoming TIP-1: Tari Improvement Proposals.

--- a/src/TIP-0002_tari_community_charter.md
+++ b/src/TIP-0002_tari_community_charter.md
@@ -1,0 +1,3 @@
+# Tari Community Charter
+
+This document is a stub for the upcoming TIP-2: Tari Community Charter.

--- a/src/TIP-0003_community_forums.md
+++ b/src/TIP-0003_community_forums.md
@@ -1,0 +1,3 @@
+# Tari Community Forums
+
+This document is a stub for the upcoming TIP-3: Tari Community Forums.

--- a/src/about.md
+++ b/src/about.md
@@ -1,6 +1,11 @@
-# The Tari RFCs
+# Tari Project Proposals
 
-Tari is a community-driven project. The documents presented in this RFC collection have typically gone through several
+Tari is a community-driven project. This repository contains technical RFCs as well as Tari Improvement Proposals,
+which are more general and may involve community standards and governance practices.
+
+## RFCs
+
+The documents presented in this collection have typically gone through several
 iterations before reaching this point:
 
 * Ideas and questions are posted in #tari-dev on [#FreeNode IRC](https://freenode.net/). This is typically short-form
@@ -8,9 +13,10 @@ iterations before reaching this point:
 * RFCs are "Requests for Comment", so although the proposals in these documents are usually well-thought out, they are
   not cast in stone. RFCs can, and should, undergo further evaluation and discussion by the community. RFC comments are
   best made using Github [issue]s.
+* New RFCs should be posted to the [community forums] for visibility and community review, and should follow the format 
+  given in the [RFC template](RFC_template.md).
 
-New RFC's should follow the format given in the [RFC template](RFC_template.md).
-## Lifecycle
+### Lifecycle
 
 RFCs go through the following lifecycle, which roughly corresponds to the [COSS](https://github.com/unprotocols/rfc/blob/master/2/README.md):
 
@@ -23,5 +29,14 @@ RFCs go through the following lifecycle, which roughly corresponds to the [COSS]
 | Retired     | ![retired](theme/images/status-retired.svg)       | The RFC is no longer in use on the Tari network.                                                                                                                                                                    |
 
 
+## Tari Improvement Proposals (TIP)
+
+Tari Improvement Proposals are proposals for improving the Tari project generally. They are distinct from RFCs in that
+they are product, practice, and community improvement proposals rather than protocol or algorithm proposals.
+
+The format and standards of Tari Improvement Proposals will be covered in [TIP-1].
+
 [pull request]: https://github.com/tari-project/tari/pulls?q=is%3Aopen+is%3Apr+label%3ARFC 'Tari RFC pull requests'
 [issue]: https://github.com/tari-project/tari/issues?q=is%3Aissue+label%3ARFC 'Tari RFC Issues'
+[community forums]: https://community.tari.com/ 'Tari Community Forums'
+[TIP-1]: TIP-0001_tari_improvement_proposals.md 'TIP-1: Tari Improvement Proposals'


### PR DESCRIPTION
## Description

This merge request adds in some structure for Tari Improvement Proposals. No specific proposal is yet added -- this only provides the structure for follow-up PRs to define these proposals and their format.

## Motivation and Context

Now that we are opening things to community comment and bringing things into more visibility, it is important to keep records of decisions made, and their history, for easy access. While the new forums provide an excellent way to discuss ideas in long-form, they do not act as a good quick-reference to current active practices and policies.

The RFCs repository already acts as a place where established practices are documented-- on the code side. Rather than starting an entirely new repository, this PR allows us to leverage the existing repository to begin documenting decisions immediately. In the future, and depending on community discussion, this could be moved to its own repositories, or the RFCs might be subsumed by the TIP process.

## How Has This Been Tested?

By hand. Follow the instructions in the README.md to test this locally.