### PR TITLE
docs: add tari community charter (TIP-0002)

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,17 +1,18 @@
 # Disclaimer
 
-The purpose of the documents and content in this repository is for information purposes only and may be subject to 
-change or update without notice. 
+The purpose of the RFCs in this repository is for information purposes only and may be
+subject to change or update without notice.
  
 The documents in this repository are largely the result of community discussions held on #tari-dev on FreeNode IRC and 
 includes some preliminary concepts that are in the process of being developed by the Tari community.  The release of 
 these documents are intended solely for review and discussion by the blockchain and cryptocurrency communities 
 regarding the technological merits of the potential system outlined herein.
 
-Anyone in the community is 
-welcome to contribute ideas, suggestions or constructive criticism can join the discussion in #tari-dev on Freenode IRC, 
-submit a new [issue] or contribute with a [pull request].
+Anyone in the community is welcome to contribute ideas, suggestions or constructive criticism. You can join the
+discussion in #tari-dev on Freenode IRC, comment on the [community forums], submit a new [issue] or contribute with
+a [pull request].
 
 
 [issue]: https://github.com/tari-project/tari/issues
 [pull request]: https://github.com/tari-project/tari/pulls
+[community forums]: https://community.tari.com/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can build and serve the RFCs locally while working on them, and navigate the
 
 To do so:
 - Navigate to the repository directory in a terminal
-- Install the `mdbook` tool: `cargo install mdbook`
+- Install the `mdbook` and `mdbook-mermaid` tools: `cargo install mdbook@0.4.36 mdbook-mermaid@0.13.0`
 - Serve the site: `mdbook serve`
 - View the rendered versions in a browser using the link provided in your terminal: `http://localhost:3000`
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,6 +2,9 @@
 
 [About the Tari RFC documents](about.md)
 
+- [TIP-1: Tari Improvement Proposals](TIP-0001_tari_improvement_proposals.md)
+- [TIP-2: The Tari Community Charter](TIP-0002_tari_community_charter.md)
+- [TIP-3: Community Forums](TIP-0003_community_forums.md)
 - [RFC-0001: An overview of the Tari network](RFC-0001_overview.md)
 - [The Tari Base Layer](base_layer.md)
   - [RFC-0110: Base nodes](RFC-0110_BaseNodes.md)

--- a/src/TIP-0001_tari_improvement_proposals.md
+++ b/src/TIP-0001_tari_improvement_proposals.md
@@ -1,0 +1,3 @@
+# Tari Improvement Proposals
+
+This document is a stub for the upcoming TIP-1: Tari Improvement Proposals.

--- a/src/TIP-0002_tari_community_charter.md
+++ b/src/TIP-0002_tari_community_charter.md
@@ -126,7 +126,7 @@ Strategic matters, including significant spending, protocol changes, and amendme
 
 ## Article VI. Nomination and Selection
 
-Any person who has made sustained, verifiable contributions to the Tari protocol may be nominated to the Council. Contributions include, but are not limited to: code, infrastructure, documentation, governance facilitation, community building, and ecosystem development. A single or token contribution shall not suffice. Sustained misconduct shall disqualify a candidate regardless of the strength of their contributions.
+Any person who has made sustained, verifiable contributions to the Tari protocol may be nominated to the Council. Contributions include, but are not limited to: code, infrastructure, documentation, governance facilitation, community building, and ecosystem development. A single or minimal contribution shall not suffice. Sustained misconduct shall disqualify a candidate regardless of the strength of their contributions.
 
 Nominations shall be made publicly, with evidence of the candidate's contributions and a clear account of why they would strengthen the Council. The community shall discuss each nomination openly. The Council shall confirm or decline based on the consensus it observes.
 

--- a/src/TIP-0002_tari_community_charter.md
+++ b/src/TIP-0002_tari_community_charter.md
@@ -1,0 +1,3 @@
+# Tari Community Charter
+
+This document is a stub for the upcoming TIP-2: Tari Community Charter.

--- a/src/TIP-0002_tari_community_charter.md
+++ b/src/TIP-0002_tari_community_charter.md
@@ -1,3 +1,149 @@
-# Tari Community Charter
+# The Tari Community Charter
 
-This document is a stub for the upcoming TIP-2: Tari Community Charter.
+## Introduction
+
+Tari was built in the open from its first commit. Its code has always belonged to the public. This charter establishes how that community governs itself.
+
+The words inscribed in Tari's Genesis block are a declaration of intent. They are reproduced here in full because they are the foundation on which this Council stands. Everything that follows serves the vision they describe.
+
+## Manifesto
+
+*The following words are inscribed in Tari's Genesis block, mined on May 6, 2025.*
+
+> the journey began 2,863 days ago on a sunny day in Oakland
+> through long troughs of sorrow and hard-won triumphs
+> we arrive at the beginning
+> the Tari genesis block
+>
+> the genesis block is heavy
+> it's full of love, beauty, promise, and ambition
+> of countless fraught decisions and long nights
+> of a desire to build something that lasts for generations
+> of a dream to build a better system than all those that came before
+>
+> Tari is a multi-layered system
+> the base layer is the foundation for a new network state
+> one that is pro-human and pro-freedom
+> its strength comes from the people who choose to do the work
+> of securing the network
+> they are the trailblazers. the revolutionaries
+> **for mining Tari is an act of rebellion**
+>
+> a rebellion against a world that increasingly steals our humanity
+> as we sit in the comfort of our homes, doom scrolling away our time
+> in an intimate embrace with our favorite device
+> being milked of our deepest desires and thoughts
+> and manipulated by saccharine interfaces and slippery algorithms
+> the devices we love unconditionally are watching us
+>
+> every click. every stroke watched by cunning eyes
+> we've accepted this fate in the name of convenience
+> this journey towards oblivion
+> it's tragic, and yet, there is something even more insidious at play:
+> the endless, irrevocable surveillance of our financial affairs
+> **a panopticon where every transaction is a scarlet letter**
+>
+> it wasn't supposed to be this way
+> this new financial system isn't supposed to take away our agency or safety
+> our transaction history shouldn't be a cudgel beating us into obedience
+> our wallets aren't a window into our souls
+> **enough**
+>
+> **in this block. in this moment. we choose another way**
+> Tari is a sanctuary
+> for the enlightened who need refuge from the piercing gaze of endless secret eyes
+> for the visionaries who learn of its magical powers and use it to bend the will of the world in their direction
+> and for those who benefit from it unknowingly because, for them, it's a cog in a greater machine
+> **welcome**
+>
+> Tari is a boundless paradise
+> where we all receive a sacred gift: a mythical cloak of invisibility
+> wrapped in our cloaks as if they were a second skin
+> we are finally free like all humans that existed before us
+> to live our lives in joyous anonymity
+> to protect ourselves and our families from the eyes of infinite jackals
+> stalking our every move, waiting for the perfect moment to pounce
+> to live our imperfect lives without every moment becoming an immutable snapshot
+> to be human
+>
+> from this moment until the last node is silenced
+> Tari is ever-changing
+> we define its culture
+> we define its traditions
+> we have the power to shape it, to fix it, to contribute
+> to etch our code in stone
+> **to become immortal**
+>
+> one day, we pray that Tari will earn everyone's trust
+> and become a part of everyone's daily lives
+> when that day comes to pass, **it will be because of us**
+
+---
+
+## Article I. Purpose
+
+The Tari Council is established to uphold the vision, ideals, and objectives declared in the Tari Manifesto, to steward the protocol's tokenomics as published at tari.com/tokenomics, to direct the protocol's resources toward the common benefit, and to ensure that governance rests with those who build it.
+
+The protocol belongs to its contributors. This Council exists to honor that principle and to see it realized.
+
+Tari Labs, the protocol's instigator, participates in the Council as a member, not as its authority. Its voice carries the weight of its contributions, nothing more. Over time, an increasing share of operational control shall pass to the Council, until the protocol belongs fully to those who choose to do the work.
+
+## Article II. Composition
+
+The Council shall consist of five to seven members, drawn from the community and from enterprise, serving terms of twelve months. Initial terms shall be staggered so that no more than half of the Council's seats expire in the same period. No term shall be presumed to renew. At the conclusion of each term, the community may nominate the member to continue, or the seat shall pass to another.
+
+Council members shall receive a monthly stipend of 100,000 XTM for their service.
+
+## Article III. Authority and Responsibility
+
+The Council shall govern the community token allocation.
+
+The Council shall:
+
+1. Direct what gets funded and what gets built.
+2. Assess community consensus and produce decisions. Where consensus is clear, the Council shall act on it. Where consensus is ambiguous, the Council shall decide and explain its reasoning publicly.
+3. Ensure the protocol has funded contributors, operational infrastructure, a functioning governance process, and a clear public voice.
+4. Appoint and oversee workgroup leads responsible for protocol development, infrastructure, community, and ecosystem growth.
+5. Set and enforce spending thresholds, ensuring no disbursement exceeds the limits prescribed by this charter without the required level of community review.
+
+## Article IV. Character of a Council Member
+
+A Council member shall hold the protocol in the highest regard. They shall act in its interest above their own, above any organization's, and above the Council's.
+
+A Council member shall be willing to yield their seat to anyone who can advance the protocol further than they can. This is not an aspiration. It is a condition of service.
+
+A Council member shall demonstrate, through sustained conduct, the qualities the protocol demands: consistency of commitment, constructive in disagreement, generosity toward newcomers, and excellence in the work they produce.
+
+A Council member may be removed by majority vote of the remaining Council for sustained misconduct, prolonged unexplained absence, or conduct incompatible with this Charter. The removal and the reasoning behind it shall be made public.
+
+## Article V. Decisions
+
+Routine matters shall proceed by lazy consensus. A proposal made publicly and meeting no objection within five days shall be adopted.
+
+Substantive matters shall be discussed in public channels and community calls. The Council shall assess rough consensus. The standard is not unanimity. The standard is whether those who object can articulate why.
+
+Strategic matters, including significant spending, protocol changes, and amendments to this charter, shall require fourteen days of open discussion, a seven-day Final Comment Period, and majority Council approval.
+
+## Article VI. Nomination and Selection
+
+Any person who has made sustained, verifiable contributions to the Tari protocol may be nominated to the Council. Contributions include, but are not limited to: code, infrastructure, documentation, governance facilitation, community building, and ecosystem development. A single or token contribution shall not suffice. Sustained misconduct shall disqualify a candidate regardless of the strength of their contributions.
+
+Nominations shall be made publicly, with evidence of the candidate's contributions and a clear account of why they would strengthen the Council. The community shall discuss each nomination openly. The Council shall confirm or decline based on the consensus it observes.
+
+The Council shall reflect the breadth of the protocol's needs: development, infrastructure, community, and enterprise. No single interest shall dominate.
+
+The inaugural Council shall be appointed by Tari Labs from nominations received from the community. Thereafter, nominations and selections shall follow the process described in this Charter.
+
+## Article VII. The Obligation to Improve
+
+The Council's highest obligation is to the protocol, not to itself.
+
+Every member shall accept that the Council must be continuously strengthened. If the protocol would be better served by different people at the table, the Council is bound to make that change. Permanence is not a virtue. Progress is.
+
+This obligation shall be the measure against which every future Council is judged.
+
+## Article VIII. Amendments
+
+This charter may be amended through the same process required for strategic decisions: open discussion, a Final Comment Period, and Council approval.
+
+When this charter no longer serves the protocol, the community shall have both the power and the duty to change it.

--- a/src/TIP-0003_community_forums.md
+++ b/src/TIP-0003_community_forums.md
@@ -1,0 +1,3 @@
+# Tari Community Forums
+
+This document is a stub for the upcoming TIP-3: Tari Community Forums.

--- a/src/about.md
+++ b/src/about.md
@@ -1,6 +1,11 @@
-# The Tari RFCs
+# Tari Project Proposals
 
-Tari is a community-driven project. The documents presented in this RFC collection have typically gone through several
+Tari is a community-driven project. This repository contains technical RFCs as well as Tari Improvement Proposals,
+which are more general and may involve community standards and governance practices.
+
+## RFCs
+
+The documents presented in this collection have typically gone through several
 iterations before reaching this point:
 
 * Ideas and questions are posted in #tari-dev on [#FreeNode IRC](https://freenode.net/). This is typically short-form
@@ -8,9 +13,10 @@ iterations before reaching this point:
 * RFCs are "Requests for Comment", so although the proposals in these documents are usually well-thought out, they are
   not cast in stone. RFCs can, and should, undergo further evaluation and discussion by the community. RFC comments are
   best made using Github [issue]s.
+* New RFCs should be posted to the [community forums] for visibility and community review, and should follow the format 
+  given in the [RFC template](RFC_template.md).
 
-New RFC's should follow the format given in the [RFC template](RFC_template.md).
-## Lifecycle
+### Lifecycle
 
 RFCs go through the following lifecycle, which roughly corresponds to the [COSS](https://github.com/unprotocols/rfc/blob/master/2/README.md):
 
@@ -23,5 +29,14 @@ RFCs go through the following lifecycle, which roughly corresponds to the [COSS]
 | Retired     | ![retired](theme/images/status-retired.svg)       | The RFC is no longer in use on the Tari network.                                                                                                                                                                    |
 
 
+## Tari Improvement Proposals (TIP)
+
+Tari Improvement Proposals are proposals for improving the Tari project generally. They are distinct from RFCs in that
+they are product, practice, and community improvement proposals rather than protocol or algorithm proposals.
+
+The format and standards of Tari Improvement Proposals will be covered in [TIP-1].
+
 [pull request]: https://github.com/tari-project/tari/pulls?q=is%3Aopen+is%3Apr+label%3ARFC 'Tari RFC pull requests'
 [issue]: https://github.com/tari-project/tari/issues?q=is%3Aissue+label%3ARFC 'Tari RFC Issues'
+[community forums]: https://community.tari.com/ 'Tari Community Forums'
+[TIP-1]: TIP-0001_tari_improvement_proposals.md 'TIP-1: Tari Improvement Proposals'


### PR DESCRIPTION
Adds the Tari Community Charter as TIP-0002, defining governance principles, community values, and decision-making processes for the Tari project.