### PR TITLE
fix: formatting in P-TIP-PROC-3

### DIFF
--- a/src/TIP-0003_community_forums.md
+++ b/src/TIP-0003_community_forums.md
@@ -3,7 +3,7 @@
 | TIP           | [P-TIP-PROC-3](#p-tip-proc-3-tari-community-forums) |
 |---------------|-----------------------------------------------------|
 | Title         | Tari Community Forums                               |
-| Last Modified | 2026-05-28                                          |
+| Last Modified | 2026-05-29                                          |
 | Authors       | Fox Piacenti <fox@vulpinity.com>                    |
 | Status        | Proposed                                            |
 | Type          | Process                                             |
@@ -100,7 +100,13 @@ subcategories still serve as a venue for discussion in other languages.
 
 * Added section on International categories.
 
+### 2026-05-29
+
+* Fix link formatting issues
+* [Pull Request #172](https://github.com/tari-project/rfcs/pull/172)
+
 [^1]: In this case, trust is meant in the common definition rather than referring to the Discourse feature.
     Moderator trust levels in Discourse cannot be earned automatically but have to be set manually by an administrator.
+
 [Community Forum Link]: https://community.tari.com/
 [TIP-1]: ./TIP-0001_tari_improvement_proposals.md


### PR DESCRIPTION
## Description

This PR fixes a formatting issue with links in P-TIP-PROC-3.

## Motivation and Context

Links should work in RFCs.

## How Has This Been Tested?

Manually, locally with `mdbook serve`
