### PR TITLE
feat: gitHub history link

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -8,6 +8,7 @@ build-dir = "./book"
 create-missing = false
 
 [output.html]
+edit-url-template = "https://github.com/tari-project/rfcs/commits/main/{path}"
 mathjax-support=true
 theme = "src/theme"
 additional-js = []

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -113,6 +113,11 @@
                         <h1 class="menu-title"><img src="{{ resource "theme/images/tari-horizontal-logo.png" }}"/> </h1>
 
                         <div class="right-buttons">
+                            {{#if git_repository_edit_url}}
+                                <a href="{{git_repository_edit_url}}" title="View change history" aria-label="View change history">
+                                    {{fa "solid" "clock-rotate-left"}}
+                                </a>
+                            {{/if}}
                             <a href="{{ resource "print.html" }}" title="Print this book" aria-label="Print this book">
                                 {{fa "solid" "print"}}
                             </a>


### PR DESCRIPTION
## Description

This PR adds a 'history' button to pages so that people can look at the history of a particular page.

## Motivation and Context

Maintaining changelogs is proving tedious and error prone, and there is already automated collection of this data in the form of commits. Leveraging the existing tooling to reduce the amount of manual effort is desirable.

## How Has This Been Tested?

Locally, following the README's instructions.

