### PR TITLE
fix: implemented status used for TIPs in effect, too

### DIFF
--- a/src/Process/TIP-PROC-0005_adjust_bridge_limits.md
+++ b/src/Process/TIP-PROC-0005_adjust_bridge_limits.md
@@ -1,6 +1,6 @@
-# A-TIP-PROC-5: Adjust Bridge Limits
+# I-TIP-PROC-5: Adjust Bridge Limits
 
-| TIP             | [A-TIP-PROC-5](#a-tip-proc-5-adjust-bridge-limits) |
+| TIP             | [I-TIP-PROC-5](#i-tip-proc-5-adjust-bridge-limits) |
 |-----------------|----------------------------------------------------|
 | Title           | Adjust Bridge Limits                               |
 | Last Modified   | 2026-06-17                                         |

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -3,9 +3,9 @@
 [About the Tari RFC documents](about.md)
 
 - [P-TIP-PROC-1: Tari Improvement Proposals](TIP-0001_tari_improvement_proposals.md)
-- [A-TIP-PROC-2: The Tari Community Charter](TIP-0002_tari_community_charter.md)
+- [I-TIP-PROC-2: The Tari Community Charter](TIP-0002_tari_community_charter.md)
 - [P-TIP-PROC-3: Community Forums](TIP-0003_community_forums.md)
-- [A-TIP-0005: Adjust Bridge Limits](Process/TIP-PROC-0005_adjust_bridge_limits.md)
+- [I-TIP-0005: Adjust Bridge Limits](Process/TIP-PROC-0005_adjust_bridge_limits.md)
 - [RFC-0001: An overview of the Tari network](RFC-0001_overview.md)
 - [The Tari Base Layer](base_layer.md)
   - [RFC-0110: Base nodes](RFC-0110_BaseNodes.md)

--- a/src/TIP-0001_tari_improvement_proposals.md
+++ b/src/TIP-0001_tari_improvement_proposals.md
@@ -168,11 +168,12 @@ Council.
 
 ### Accepted (A)
 
-The Council has accepted the TIP after review and discussion.
+The Council has accepted the TIP after review and discussion. Implementation has not been completed. If the proposal
+does not require implementation or is already implemented, it goes straight to the Implemented status instead.
 
 ### Implemented (I)
 
-Implementation (if the proposal requires a specific implementation) has been completed.
+Implementation has been completed or the TIP is otherwise in effect.
 
 ### Rejected (R)
 

--- a/src/TIP-0002_tari_community_charter.md
+++ b/src/TIP-0002_tari_community_charter.md
@@ -1,6 +1,6 @@
-# A-TIP-PROC-2: The Tari Community Charter
+# I-TIP-PROC-2: The Tari Community Charter
 
-| TIP           | [A-TIP-PROC-2](#a-tip-proc-2-the-tari-community-charter) |
+| TIP           | [I-TIP-PROC-2](#i-tip-proc-2-the-tari-community-charter) |
 |---------------|----------------------------------------------------------|
 | Title         | The Tari Community Charter                               |
 | Last Modified | 2026-05-22                                               |


### PR DESCRIPTION
## Description

This PR tweaks the definition of the 'Impelemented' and 'Accepted' statuses to indicate that TIPs without specific implementation which are in effect should use Implemented rather than Accepted.

## Motivation and Context

The original definitions meant that a TIP might be in effect when in Accepted status, since TIPs without a specific implementation might be in Accepted status. This could cause confusion because in other cases, a TIP would not be in effect until it reached the Implemented status, as it was waiting on implementation.

## How Has This Been Tested?

Locally.