### PR TITLE
docs: fix broken links in RFC pages

### DIFF
--- a/src/RFC-0001_overview.md
+++ b/src/RFC-0001_overview.md
@@ -107,7 +107,7 @@ the DAN to continue.
 
 ### Base Layer
 
-[The Tari base layer](RFC-0100_BaseLayer.md) has the following primary features:
+[The Tari base layer](base_layer.md) has the following primary features:
 
 - PoW-based blockchain using Nakamoto consensus
 - Transactions and blocks based on the [Mimblewimble] protocol

--- a/src/RFC-0123_One_sided_replay_attacks.md
+++ b/src/RFC-0123_One_sided_replay_attacks.md
@@ -61,7 +61,7 @@ The aim of this Request for Comment (RFC) is to describe ways we can block repla
 
 ## Related Requests for Comment
 
-* [RFC-0120: Base Layer Consensus](RFC-0120_consensus.md)
+* [RFC-0120: Base Layer Consensus](RFC-0120_Consensus.md)
 * [RFC-0201: TariScript](RFC-0201_TariScript.md)
 
 ## Replay attack

--- a/src/RFC-0170_NetworkCommunicationProtocol.md
+++ b/src/RFC-0170_NetworkCommunicationProtocol.md
@@ -62,7 +62,7 @@ This document will introduce the Tari communication network and the communicatio
 ## Related RFCs
 
 * [RFC-0111: Base Node Architecture](./RFC-0111_BaseNodeArchitecture.md)
-* [RFC-0303: DAN Overview](RFCD-0303_DanOverview.md)
+* [RFC-0303: DAN Overview](RFC-0303_DanOverview.md)
 
 ## Description
 

--- a/src/RFC-0172_PeerToPeerMessagingProtocol.md
+++ b/src/RFC-0172_PeerToPeerMessagingProtocol.md
@@ -62,7 +62,7 @@ and [communication client]s on the Tari network.
 
 ## Related Requests for Comment
 
-- [RFC-0170: NetworkCommunicationProtocol](rfc-0170_NetworkCommunicationProtocol.md)
+- [RFC-0170: NetworkCommunicationProtocol](RFC-0170_NetworkCommunicationProtocol.md)
 - [RFC-0171: MessageSerialization](RFC-0171_MessageSerialisation.md)
 
 ## Description

--- a/src/RFC-0205_HardwareTransactions.md
+++ b/src/RFC-0205_HardwareTransactions.md
@@ -64,7 +64,7 @@ This Request for Comment (RFC) presents a design for a hardware wallet with Mimb
 ## Related Requests for Comment
 
 - [RFC-0201: TariScript](RFC-0201_TariScript.md)
-- [RFC-0203: Stealth Address](RFC-0203_StealthAddress.md)
+- [RFC-0203: Stealth Address](RFC-0203_StealthAddresses.md)
 
 ## Introduction
 

--- a/src/RFC-0313_VNRegistration.md
+++ b/src/RFC-0313_VNRegistration.md
@@ -318,7 +318,7 @@ to re-sync their state and spend time not participating in the network, losing o
 [VNC]: RFC-0314_VNCSelection.md#Intro
 [Schnorr signature]: https://tlu.tarilabs.com/cryptography/introduction-schnorr-signatures
 [utxo]: Glossary.md#unspent-transaction-outputs
-[shard space]: RFC-0304-DanGlossarymd#Consensus-level
+[shard space]: #shard-key-and-shuffling
 [Blake256]: https://github.com/tari-project/tari-crypto/blob/fa042e498be144d8d2af7b96efe805c5af0b2d4f/src/hash/blake2.rs
 [Ristretto]: https://ristretto.group/
 [Block header]: Glossary.md#block-header

--- a/src/RFC-0323_TariThrottle.md
+++ b/src/RFC-0323_TariThrottle.md
@@ -92,7 +92,7 @@ goals:
 * Secondarily, to maintain the total circulating supply at a target value (satisfying an implicit assumption in 
   cryptocurrencies that token supplies are finite).
 
-A proof-of-concept controller has been implemented and tested in a simulation environment ([repository]). As the 
+A proof-of-concept controller has been implemented and tested in a simulation environment. As the
 results below attest, the controller logic is sufficient to achieve these goals, even under highly volatile layer 
 two fee conditions. 
 
@@ -135,7 +135,7 @@ The PID controller has three components:
 
 ## Tari throttle
 
-The `burn-sim` [repository] was used to generate the results in this exploratory study.
+The `burn-sim` repository was used to generate the results in this exploratory study.
 
 The primary module in the repository is the `TariThrottle` struct.
 
@@ -224,7 +224,7 @@ operations, since the IEEE leaves some aspects of floating-point math
 [unspecified](https://randomascii.wordpress.com/2013/07/16/floating-point-determinism/).
 
 This is not permissible in Tari, and therefore an integer-based approach to control is implemented in the `tari-sim` 
-[repository].
+repository.
 
 Simply put, this involves scaling the error values by a constant to convert them to integers of roughly the same 
 order of magnitude, (via `error_i_scale`). The control parameters are also integers, expressed as "parts per million" 
@@ -717,5 +717,4 @@ A controller model that incorporates these target conditions will be the subject
 
 
 
-[repository]: https://github.com/tari-project/burn-sim "TariThrottle simulation repository"
 [turbine model]: /RFC-0320_TurbineModel.html "Turbine model"

--- a/src/RFC-0325_DanTimeManagement.md
+++ b/src/RFC-0325_DanTimeManagement.md
@@ -173,16 +173,16 @@ The epoch must also be short enough that we can effectively remove inactive [VN]
 
 [VNC]: RFC-0314_VNCSelection.md#Intro
 
-[VN]: RFC-0XXX.md
+[VN]: Glossary.md#validator-node
 
 [base node]: Glossary.md#base-node
 
 [Minotari]: Glossary.md#base-layer
 
-[shard space]: RFC-0304-DanGlossarymd#Consensus-level
+[shard space]: RFC-0313_VNRegistration.md#shard-key-and-shuffling
 
-[shard key]: RFC-0304-DanGlossarymd#Consensus-level
+[shard key]: RFC-0313_VNRegistration.md#shard-key-and-shuffling
 
 [FTL]: RFC-0120_Consensus.md#FTL
 
-[VN registration]: RFC-0XXX.md
+[VN registration]: RFC-0313_VNRegistration.md#validator-registration

--- a/src/RFC-8001_MultiPartyTransactions.md
+++ b/src/RFC-8001_MultiPartyTransactions.md
@@ -56,7 +56,7 @@ technological merits of the potential system outlined herein.
 
 ## Goals
 
-This document describes a few extensions to [MimbleWimble](MimbleWimble) to allow multi-party [UTXOs](utxo).
+This document describes a few extensions to [MimbleWimble] to allow multi-party [UTXOs][UTXO].
 
 ## Related RFCs
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -18,6 +18,7 @@
       - [MT-0110: Base nodes](RFC-0110_BaseNodes.md)
       - [MT-0111: Base node architecture](RFC-0111_BaseNodeArchitecture.md)
       - [MT-0120: Consensus rules](RFC-0120_Consensus.md)
+      - [MT-0122: Burning](RFC-0122_Burning.md)
       - [MT-0131: Mining](RFC-0131_Mining.md)
       - [MT-0132: Merge Mining Monero](RFC-0132_Merge_Mining_Monero.md)
       - [MT-0140: Synchronizing the Blockchain: Archival and Pruned modes](RFC-0140_Syncing_and_seeding.md)


### PR DESCRIPTION
Description
---

Repairs the broken links reported in #149 across the RFC book:

- updates stale filenames and case-sensitive paths;
- replaces placeholder and malformed references with existing rendered definitions;
- adds the existing burning RFC to `SUMMARY.md` so mdBook renders it;
- reuses existing Glossary references for Mimblewimble and UTXO terms; and
- removes the dead `burn-sim` hyperlink while preserving the historical text, since no authoritative replacement repository is publicly available.

No protocol requirements or technical parameters are changed.

Motivation and Context
---

Several RFC links returned 404s because their targets had been renamed, omitted from the mdBook summary, used incorrect filename casing, or no longer existed. This change resolves all remaining cases in #149 without inventing replacement content or changing RFC meaning.

Closes #149.

How Has This Been Tested?
---

- `git diff --check`
- `mdbook build` with mdBook 0.5.2 and mdbook-mermaid 0.17.0
- `mdbook test` with rustdoc 1.98.0
- deterministic checks that each repaired rendered page and anchor exists
- external check that the already-updated merge-mining-proxy link returns HTTP 200
- verification that the removed `burn-sim` URL no longer appears in source or rendered HTML
