### PR TITLE
docs: fix CryptoNote whitepaper link

### DIFF
--- a/src/RFC-0203_StealthAddresses.md
+++ b/src/RFC-0203_StealthAddresses.md
@@ -139,7 +139,7 @@ one-time private key \\( c + a \\).
 [one-sided payment]: ./RFC-0201_TariScript.md#one-sided-payment
 [utxo]: ./Glossary.md#unspent-transaction-outputs
 [bytecoin]: https://bitcointalk.org/index.php?topic=5965.0
-[Cryptonote]: https://cryptonote.org/whitepaper.pdf
+[Cryptonote]: https://web.archive.org/web/20200926050427/https://cryptonote.org/whitepaper.pdf
 [Peter Todd]: https://www.mail-archive.com/bitcoin-development@lists.sourceforge.net/msg03613.html
 [BIP-32]: https://en.bitcoin.it/wiki/BIP_0032
 


### PR DESCRIPTION
## Summary

- replace the unavailable CryptoNote whitepaper URL in RFC-0203 with a timestamped Internet Archive capture of the original URL
- preserve the existing citation text and surrounding RFC content unchanged

## Verification

- confirmed the original `cryptonote.org` URL times out under a bounded request
- confirmed the replacement returns HTTP 200 with `application/pdf` and a valid PDF file signature
- confirmed the Wayback response identifies `https://cryptonote.org/whitepaper.pdf` as the original source
- built the RFC book with the repository-pinned mdBook 0.5.2 and mdbook-mermaid 0.17.0 ARM64 release binaries
- ran `mdbook test`
- verified the rendered RFC-0203 HTML contains the replacement hyperlink
- ran `git diff --check`

## Environment note

The canonical `scripts/build.sh` downloads x86_64 tools and therefore cannot execute on the ARM64 review host. The same pinned tool versions were used via their official ARM64 release binaries; both `mdbook build` and `mdbook test` passed. CI will run the canonical script on x86_64.

Closes #150
