### PR TITLE
fix: keep anchored headings below sticky menu

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -29,6 +29,14 @@ code {
 h2, h3 { margin-top: 2.5em; }
 h4, h5 { margin-top: 2em; }
 
+/* Content headings double as permalink/Glossary anchor targets (mdBook gives
+   every heading an id and a `.header` self-link). #menu-bar (chrome.css) is
+   sticky and covers the top of the viewport, so without this the browser's
+   native fragment scroll lands the target right under it. */
+h1, h2, h3, h4, h5, h6 {
+    scroll-margin-top: 90px;
+}
+
 .header + .header h3,
 .header + .header h4,
 .header + .header h5 {


### PR DESCRIPTION
## Description

Adds fragment-scroll clearance for content headings so Glossary terms and other heading anchors remain visible below the site's sticky menu.

The change is limited to the custom theme CSS and applies consistently to `h1` through `h6`; no RFC text, heading IDs, JavaScript, or build configuration is changed.

## Motivation and Context

When an RFC link navigates to a term in the Glossary, the browser previously placed the target heading at the top of the viewport, directly underneath the sticky menu. This forced users to scroll upward manually to see the intended term.

The menu is 87px tall in the rendered book at the tested desktop and mobile viewports. A 90px `scroll-margin-top` keeps anchored headings visible with a small clearance while leaving normal document layout unchanged.

Closes #152.

## How Has This Been Tested?

- `git diff --check`
- `mdbook build` with mdBook 0.5.2 and mdbook-mermaid 0.17.0
- `mdbook test`
- Playwright/Chromium checks covering:
  - direct navigation and reload for three representative Glossary anchors;
  - a real cross-page Glossary link click;
  - desktop `1280x800` and mobile `390x844` viewports;
  - heading self-links, sidebar toggling, and an unrelated footnote anchor

The geometry assertion failed in all 14 baseline scenarios and passed in all 14 scenarios after the change. Additional direct-anchor checks passed at viewport widths from 280px through 1440px.

## Environment Note

The canonical `scripts/build.sh` downloads x86_64 binaries and cannot run on the ARM64 verification host. The same pinned versions were used via their official ARM64 musl release archives; `mdbook build` and `mdbook test` both passed. CI will run the canonical script on x86_64.
